### PR TITLE
CORE-5372 Remove “no tool” error in /apps/:id/details endpoint.

### DIFF
--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -426,8 +426,6 @@
     (perms/check-app-permissions username "read" [app-id]))
   (let [details (load-app-details app-id)
         tools   (get-app-tools app-id)]
-    (when (empty? tools)
-      (throw  (IllegalArgumentException. (str "no tools associated with app, " app-id))))
     (->> (format-app-details username details tools)
          (remove-nil-vals))))
 


### PR DESCRIPTION
The UI is able to display app details with an empty "Tool Information" tab for private apps that have no tools set yet.

So this error response is obsolete.