### PR TITLE
Add the execution system ID to analysis and app listing endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "2.8.0"]
                  [org.cyverse/kameleon "2.8.0"]
-                 [org.cyverse/mescal "2.8.0"]
+                 [org.cyverse/mescal "2.8.1-SNAPSHOT"]
                  [org.cyverse/metadata-client "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/common-cfg "2.8.0"]

--- a/src/apps/protocols.clj
+++ b/src/apps/protocols.clj
@@ -14,7 +14,6 @@
   (canEditApps [_])
   (addApp [_ app])
   (previewCommandLine [_ app])
-  (listAppIds [_])
   (deleteApps [_ deletion-request])
   (getAppJobView [_ app-id])
   (getAppSubmissionInfo [_ app-id])

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -51,14 +51,6 @@
          `/arg-preview` service in the JEX. Please see the JEX documentation for more information."
          (ok (apps/preview-command-line current-user body)))
 
-  (GET* "/ids" []
-        :query [params SecuredQueryParams]
-        :return AppIdList
-        :summary "List All App Identifiers"
-        :description "The export script needs to have a way to obtain the identifiers of all of the apps
-        in the Discovery Environment, deleted or not. This service provides that information."
-        (ok (apps/list-app-ids current-user)))
-
   (POST* "/shredder" []
          :query [params SecuredQueryParams]
          :body [body (describe AppDeletionRequest "List of App IDs to delete.")]

--- a/src/apps/routes/schemas/analysis.clj
+++ b/src/apps/routes/schemas/analysis.clj
@@ -1,5 +1,5 @@
 (ns apps.routes.schemas.analysis
-  (:use [common-swagger-api.schema :only [describe]]
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
         [schema.core :only [defschema optional-key Any Bool Keyword]]
         [apps.routes.schemas.containers :only [ToolContainer]])
   (:import [java.util UUID]))
@@ -38,6 +38,7 @@
 
 (defschema AnalysisParameters
   {:app_id     (describe String "The ID of the app used to perform the analysis.")
+   :system_id  (describe NonBlankString "The ID of the app execution system.")
    :parameters (describe [AnalysisParameter] "The list of parameters.")})
 
 (defschema AnalysisShredderRequest

--- a/src/apps/routes/schemas/analysis/listing.clj
+++ b/src/apps/routes/schemas/analysis/listing.clj
@@ -1,5 +1,5 @@
 (ns apps.routes.schemas.analysis.listing
-  (:use [common-swagger-api.schema :only [describe]]
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
         [apps.routes.params :only [ResultsTotalParam]]
         [schema.core :only [defschema optional-key Any Int Bool]])
   (:import [java.util UUID]))
@@ -21,6 +21,9 @@
 
    :app_id
    (describe String "The ID of the app used to perform the analysis.")
+
+   :system_id
+   (describe NonBlankString "The app's execution system ID.")
 
    (optional-key :app_name)
    (describe String "The name of the app used to perform the analysis.")

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -195,7 +195,7 @@
    :description                     (describe String "The App's description")
    (optional-key :integration_date) (describe Date "The App's Date of public submission")
    (optional-key :edited_date)      (describe Date "The App's Date of its last edit")
-   :system_id                       (describe NonBlankString "The primary execution system ID for the app.")})
+   (optional-key :system_id)        (describe NonBlankString "The primary execution system ID for the app.")})
 
 (defschema App
   (merge AppBase

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -1,5 +1,5 @@
 (ns apps.routes.schemas.app
-  (:use [common-swagger-api.schema :only [->optional-param describe]]
+  (:use [common-swagger-api.schema :only [->optional-param describe NonBlankString]]
         [apps.routes.params]
         [apps.routes.schemas.app.rating]
         [apps.routes.schemas.tool :only [Tool]]
@@ -194,7 +194,8 @@
    :name                            (describe String "The App's name")
    :description                     (describe String "The App's description")
    (optional-key :integration_date) (describe Date "The App's Date of public submission")
-   (optional-key :edited_date)      (describe Date "The App's Date of its last edit")})
+   (optional-key :edited_date)      (describe Date "The App's Date of its last edit")
+   :system_id                       (describe NonBlankString "The primary execution system ID for the app.")})
 
 (defschema App
   (merge AppBase
@@ -372,6 +373,9 @@
 
      :step_count
      (describe Long "The number of Tasks this App executes")
+
+     :system_id
+     (describe NonBlankString "The primary execution system ID for the app.")
 
      (optional-key :wiki_url)
      AppDocUrlParam

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -374,9 +374,6 @@
      :step_count
      (describe Long "The number of Tasks this App executes")
 
-     :system_id
-     (describe NonBlankString "The primary execution system ID for the app.")
-
      (optional-key :wiki_url)
      AppDocUrlParam
 

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -105,10 +105,6 @@
   [user app]
   (.previewCommandLine (get-apps-client user) app))
 
-(defn list-app-ids
-  [user]
-  (.listAppIds (get-apps-client user)))
-
 (defn delete-apps
   [user deletion-request]
   (.deleteApps (get-apps-client user) deletion-request))

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -64,9 +64,6 @@
   (canEditApps [_]
     false)
 
-  (listAppIds [_]
-    nil)
-
   (getAppJobView [_ app-id]
     (when-not (util/uuid? app-id)
       (.getApp agave app-id)))

--- a/src/apps/service/apps/agave/jobs.clj
+++ b/src/apps/service/apps/agave/jobs.clj
@@ -119,6 +119,7 @@
     :batch           false
     :description     (:description job)
     :enddate         (:enddate job)
+    :system_id       "agave"
     :id              job-id
     :name            (:name job)
     :notify          (:notify job)

--- a/src/apps/service/apps/agave/jobs.clj
+++ b/src/apps/service/apps/agave/jobs.clj
@@ -119,7 +119,7 @@
     :batch           false
     :description     (:description job)
     :enddate         (:enddate job)
-    :system_id       "agave"
+    :system_id       jp/agave-client-name
     :id              job-id
     :name            (:name job)
     :notify          (:notify job)

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -75,9 +75,6 @@
   (previewCommandLine [_ app]
     (.previewCommandLine (util/get-apps-client clients) app))
 
-  (listAppIds [_]
-    (apply merge-with concat (map #(.listAppIds %) clients)))
-
   (deleteApps [_ deletion-request]
     (.deleteApps (util/get-apps-client clients) deletion-request))
 

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -62,9 +62,6 @@
   (previewCommandLine [_ app]
     (app-metadata/preview-command-line app))
 
-  (listAppIds [_]
-    (listings/list-app-ids))
-
   (deleteApps [_ deletion-request]
     (app-metadata/delete-apps user deletion-request))
 

--- a/src/apps/service/apps/de/constants.clj
+++ b/src/apps/service/apps/de/constants.clj
@@ -1,0 +1,3 @@
+(ns apps.service.apps.de.constants)
+
+(def system-id "de")

--- a/src/apps/service/apps/de/edit.clj
+++ b/src/apps/service/apps/de/edit.clj
@@ -17,7 +17,8 @@
   (:require [clojure.set :as set]
             [apps.clients.permissions :as permissions]
             [apps.persistence.app-metadata :as persistence]
-            [apps.service.apps.de.categorization :as categorization]))
+            [apps.service.apps.de.categorization :as categorization]
+            [apps.service.apps.de.constants :as c]))
 
 (def ^:private copy-prefix "Copy of ")
 (def ^:private max-app-name-len 255)
@@ -199,7 +200,8 @@
       (-> app
           (assoc :references (map :reference_text (:app_references app))
                  :tools      (map remove-nil-vals (persistence/get-app-tools (:id app)))
-                 :groups     (map format-group (:parameter_groups task)))
+                 :groups     (map format-group (:parameter_groups task))
+                 :system_id  c/system-id)
           (dissoc :app_references
                   :tasks)))))
 
@@ -365,7 +367,9 @@
         (persistence/remove-parameter-values current-param-ids))
       (when-not (empty? references)
         (persistence/set-app-references app-id references))
-      (assoc app :groups (update-app-groups task-id groups)))))
+      (assoc app
+        :groups    (update-app-groups task-id groups)
+        :system_id c/system-id))))
 
 (defn get-user-subcategory
   [username index]

--- a/src/apps/service/apps/de/job_view.clj
+++ b/src/apps/service/apps/de/job_view.clj
@@ -4,7 +4,8 @@
         [kameleon.entities]
         [apps.util.conversions :only [remove-nil-vals]])
   (:require [apps.metadata.params :as mp]
-            [apps.persistence.app-metadata :as amp]))
+            [apps.persistence.app-metadata :as amp]
+            [apps.service.apps.de.constants :as c]))
 
 (defn- mapped-input-subselect
   [step-id]
@@ -77,9 +78,10 @@
 (defn- format-app
   [{app-id :id name :name :as app}]
   (-> (select-keys app [:id :name :description :disabled :deleted])
-      (assoc :label  name
-             :groups   (remove (comp empty? :parameters) (format-steps app-id))
-             :app_type "DE")))
+      (assoc :label     name
+             :groups    (remove (comp empty? :parameters) (format-steps app-id))
+             :app_type  "DE"
+             :system_id (c/system-id))))
 
 (defn get-app
   "This service obtains an app description in a format that is suitable for building the job

--- a/src/apps/service/apps/de/job_view.clj
+++ b/src/apps/service/apps/de/job_view.clj
@@ -81,7 +81,7 @@
       (assoc :label     name
              :groups    (remove (comp empty? :parameters) (format-steps app-id))
              :app_type  "DE"
-             :system_id (c/system-id))))
+             :system_id c/system-id)))
 
 (defn get-app
   "This service obtains an app description in a format that is suitable for building the job

--- a/src/apps/service/apps/de/jobs.clj
+++ b/src/apps/service/apps/de/jobs.clj
@@ -86,6 +86,7 @@
     :app_name        (:app_name jex-submission)
     :batch           batch?
     :description     (:description jex-submission)
+    :system_id       "de"
     :id              (str job-id)
     :name            (:name jex-submission)
     :notify          (:notify jex-submission)

--- a/src/apps/service/apps/de/pipeline_edit.clj
+++ b/src/apps/service/apps/de/pipeline_edit.clj
@@ -18,6 +18,7 @@
                                       validate-pipeline]]
         [apps.service.apps.de.edit :only [add-app-to-user-dev-category app-copy-name]])
   (:require [apps.clients.permissions :as permissions]
+            [apps.service.apps.de.constants :as c]
             [apps.service.apps.de.listings :as listings]))
 
 (defn- add-app-type
@@ -115,7 +116,8 @@
         (select-keys [:id :name :description])
         (assoc :tasks tasks
                :steps steps
-               :mappings mappings))))
+               :mappings mappings
+               :system_id c/system-id))))
 
 (defn- convert-app-to-copy
   "Adds copies of the steps and mappings fields to the app, and formats

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -50,7 +50,7 @@
     :app_name        (:app-name job)
     :description     (:description job)
     :enddate         (job-timestamp (:end-date job))
-    :system_id       (string/lower-case (:job_type job))
+    :system_id       (string/lower-case (:job-type job))
     :id              id
     :name            (:job-name job)
     :resultfolderid  (:result-folder-path job)

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -42,6 +42,8 @@
   [apps-client rep-steps {:keys [parent-id id]}]
   (and (nil? parent-id) (job-permissions/job-steps-support-job-sharing? apps-client (rep-steps id))))
 
+(def job-type-to-system-id string/lower-case)
+
 (defn format-job
   [apps-client app-tables rep-steps {:keys [parent-id id] :as job}]
   (remove-nil-vals
@@ -50,7 +52,7 @@
     :app_name        (:app-name job)
     :description     (:description job)
     :enddate         (job-timestamp (:end-date job))
-    :system_id       (string/lower-case (:job-type job))
+    :system_id       (job-type-to-system-id (:job-type job))
     :id              id
     :name            (:job-name job)
     :resultfolderid  (:result-folder-path job)

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -5,6 +5,7 @@
             [apps.persistence.jobs :as jp]
             [apps.service.apps.jobs.permissions :as job-permissions]
             [apps.service.util :as util]
+            [clojure.string :as string]
             [kameleon.db :as db]))
 
 (defn- job-timestamp
@@ -37,6 +38,10 @@
                        (into {}))
                   :total (count children)))))
 
+(defn- job-supports-sharing?
+  [apps-client rep-steps {:keys [parent-id id]}]
+  (and (nil? parent-id) (job-permissions/job-steps-support-job-sharing? apps-client (rep-steps id))))
+
 (defn format-job
   [apps-client app-tables rep-steps {:keys [parent-id id] :as job}]
   (remove-nil-vals
@@ -45,6 +50,7 @@
     :app_name        (:app-name job)
     :description     (:description job)
     :enddate         (job-timestamp (:end-date job))
+    :system_id       (string/lower-case (:job_type job))
     :id              id
     :name            (:job-name job)
     :resultfolderid  (:result-folder-path job)
@@ -58,7 +64,7 @@
     :parent_id       parent-id
     :batch           (:is-batch job)
     :batch_status    (when (:is-batch job) (format-batch-status id))
-    :can_share       (and (nil? parent-id) (job-permissions/job-steps-support-job-sharing? apps-client (rep-steps id)))}))
+    :can_share       (job-supports-sharing? apps-client rep-steps job)}))
 
 (defn- list-jobs*
   [{:keys [username]} search-params types analysis-ids]

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -144,6 +144,7 @@
   (validate-jobs-for-user user [job-id] "read")
   (let [job (jp/get-job-by-id job-id)]
     {:app_id     (:app-id job)
+     :system_id  (string/lower-case (:job-type job))
      :parameters (job-params/get-parameter-values apps-client job)}))
 
 (defn get-job-relaunch-info

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -2,7 +2,6 @@
   (:use [korma.db :only [transaction]]
         [slingshot.slingshot :only [try+]])
   (:require [clojure.tools.logging :as log]
-            [clojure.string :as string]
             [clojure-commons.error-codes :as ce]
             [clojure-commons.exception-util :as cxu]
             [kameleon.db :as db]
@@ -144,7 +143,7 @@
   (validate-jobs-for-user user [job-id] "read")
   (let [job (jp/get-job-by-id job-id)]
     {:app_id     (:app-id job)
-     :system_id  (string/lower-case (:job-type job))
+     :system_id  (listings/job-type-to-system-id (:job-type job))
      :parameters (job-params/get-parameter-values apps-client job)}))
 
 (defn get-job-relaunch-info


### PR DESCRIPTION
This adds the job execution system ID, which is different from Agave's execution system iD, to several app and analysis editing and listing endpoints.
