### PR TITLE
CORE-8162 Add job stats fields to app listings and details endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [metosin/compojure-api "1.1.8"]
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "2.8.1"]
-                 [org.cyverse/kameleon "2.8.0"]
+                 [org.cyverse/kameleon "2.8.2-SNAPSHOT"]
                  [org.cyverse/mescal "2.8.1-SNAPSHOT"]
                  [org.cyverse/metadata-client "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -594,13 +594,17 @@
 
 (defn get-job-stats
   [^String app-id]
-  (-> (get-job-stats-base-query app-id)
-      get-job-stats-fields
-      select
-      first))
+  (merge {:job_count 0
+          :job_count_failed 0
+          :job_count_completed 0}
+         (-> (get-job-stats-base-query app-id)
+             get-job-stats-fields
+             select
+             first)))
 
 (defn get-public-job-stats
   [^String app-id]
-  (-> (get-job-stats-base-query app-id)
-      select
-      first))
+  (merge {:job_count_completed 0}
+         (-> (get-job-stats-base-query app-id)
+             select
+             first)))

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -554,3 +554,53 @@
   (select (job-base-query)
           (where {:j.id       [in (map uuidify job-ids)]
                   :j.username [not= username]})))
+
+(defn- get-job-stats-fields
+  "Adds query fields with subselects similar to the app_listing view's job_count, job_count_failed,
+   and last_used columns."
+  [query]
+  (fields query
+          [(subselect :jobs
+                      (aggregate (count :id) :job_count)
+                      (where {:app_id :j.app_id}))
+           :job_count]
+          [(subselect :jobs
+                      (aggregate (count :id) :job_count_failed)
+                      (where {:app_id :j.app_id
+                              :status failed-status}))
+           :job_count_failed]
+          [(subselect :jobs
+                      (aggregate (max :start_date) :last_used)
+                      (where {:app_id :j.app_id}))
+           :last_used]))
+
+(defn- get-job-stats-base-query
+  "Fetches job stats for the given app ID, with fields via subselects similar to the app_listing view's
+   job_count_completed and job_last_completed columns."
+  [^String app-id]
+  (-> (select* [:jobs :j])
+      (fields [(subselect :jobs
+                          (aggregate (count :id) :job_count_completed)
+                          (where {:app_id :j.app_id
+                                  :status completed-status}))
+               :job_count_completed]
+              [(subselect :jobs
+                          (aggregate (max :end_date) :job_last_completed)
+                          (where {:app_id :j.app_id
+                                  :status completed-status}))
+               :job_last_completed])
+      (where {:app_id app-id})
+      (group :app_id)))
+
+(defn get-job-stats
+  [^String app-id]
+  (-> (get-job-stats-base-query app-id)
+      get-job-stats-fields
+      select
+      first))
+
+(defn get-public-job-stats
+  [^String app-id]
+  (-> (get-job-stats-base-query app-id)
+      select
+      first))

--- a/src/apps/protocols.clj
+++ b/src/apps/protocols.clj
@@ -12,6 +12,7 @@
   (listAppsUnderHierarchy [_ root-iri attr params])
   (adminListAppsUnderHierarchy [_ ontology-version root-iri attr params])
   (searchApps [_ search-term params])
+  (adminSearchApps [_ search-term params])
   (canEditApps [_])
   (addApp [_ app] [_ system-id app])
   (previewCommandLine [_ app] [_ system-id app])

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -51,6 +51,24 @@
          (ok (update-tool-request request-id (config/uid-domain) current-user body))))
 
 (defroutes admin-apps
+  (GET "/" []
+       :query [params AppSearchParams]
+       :middleware [wrap-metadata-base-url]
+       :summary "Search Apps"
+       :return AdminAppListing
+       :description
+       (str
+"This service allows admins to search for Apps based on a part of the App name, description, integrator's
+ name, tool name, or category name the app is under."
+(get-endpoint-delegate-block
+  "metadata"
+  "POST /avus/filter-targets")
+(get-endpoint-delegate-block
+  "metadata"
+  "POST /ontologies/{ontology-version}/filter-targets"))
+       (ok (coerce! AdminAppListing
+                    (apps/admin-search-apps current-user params))))
+
   (POST "/" []
          :query [params SecuredQueryParams]
          :body [body (describe AppCategorizationRequest "An App Categorization Request.")]

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -80,7 +80,7 @@
           :path-params [app-id :- AppIdPathParam]
           :query [params SecuredQueryParams]
           :body [body (describe AdminAppPatchRequest "The App to update.")]
-          :return AppDetails
+          :return AdminAppDetails
           :middleware [wrap-metadata-base-url]
           :summary "Update App Details and Labels"
           :description (str
@@ -103,13 +103,13 @@
   "metadata"
   "POST /ontologies/{ontology-version}/filter")
 "Please see the metadata service documentation for information about the `hierarchies` response field.")
-          (ok (coerce! AppDetails
+          (ok (coerce! AdminAppDetails
                 (apps/admin-update-app current-user (assoc body :id app-id)))))
 
   (GET "/:app-id/details" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParams]
-        :return AppDetails
+        :return AdminAppDetails
         :middleware [wrap-metadata-base-url]
         :summary "Get App Details"
         :description (str
@@ -118,7 +118,7 @@
   "metadata"
   "POST /ontologies/{ontology-version}/filter")
 "Please see the metadata service documentation for information about the `hierarchies` response field.")
-        (ok (coerce! AppDetails
+        (ok (coerce! AdminAppDetails
                (apps/admin-get-app-details current-user app-id))))
 
   (PATCH "/:app-id/documentation" []
@@ -253,9 +253,9 @@
   (GET "/:ontology-version/:root-iri/apps" []
         :path-params [ontology-version :- OntologyVersionParam
                       root-iri :- OntologyClassIRIParam]
-        :query [{:keys [attr] :as params} OntologyAppListingPagingParams]
+        :query [{:keys [attr] :as params} AdminOntologyAppListingPagingParams]
         :middleware [wrap-metadata-base-url]
-        :return AppListing
+        :return AdminAppListing
         :summary "List Apps in a Category"
         :description (str
 "Lists all of the apps under an app category hierarchy, for the given `ontology-version`,
@@ -263,14 +263,14 @@
 (get-endpoint-delegate-block
   "metadata"
   "POST /ontologies/{ontology-version}/{root-iri}/filter-targets"))
-        (ok (coerce! AppListing
+        (ok (coerce! AdminAppListing
                      (apps/admin-list-apps-under-hierarchy current-user ontology-version root-iri attr params))))
 
   (GET "/:ontology-version/:root-iri/unclassified" [root-iri]
         :path-params [ontology-version :- OntologyVersionParam
                       root-iri :- OntologyClassIRIParam]
-        :query [{:keys [attr] :as params} OntologyAppListingPagingParams]
-        :return AppListing
+        :query [{:keys [attr] :as params} AdminOntologyAppListingPagingParams]
+        :return AdminAppListing
         :middleware [wrap-metadata-base-url]
         :summary "List Unclassified Apps"
         :description (str
@@ -279,8 +279,8 @@
 (get-endpoint-delegate-block
   "metadata"
   "POST /ontologies/{ontology-version}/{root-iri}/filter-unclassified"))
-        (ok (coerce! AppListing
-                     (listings/get-unclassified-app-listing current-user ontology-version root-iri attr params)))))
+        (ok (coerce! AdminAppListing
+                     (listings/get-unclassified-app-listing current-user ontology-version root-iri attr params true)))))
 
 (defroutes reference-genomes
   (POST "/" []

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -33,6 +33,7 @@
 (def TreeSelectorGroupListDocs "The TreeSelector root's groups")
 (def TreeSelectorGroupParameterListDocs "The TreeSelector Group's arguments")
 (def TreeSelectorGroupGroupListDocs "The TreeSelector Group's groups")
+(def AppListingJobStatsDocs "Some launch statistics associated with the App")
 
 (defschema AppParameterListItem
   {:id                         (describe UUID "A UUID that is used to identify the List Item")
@@ -256,6 +257,24 @@
   (assoc Tool
     :id (describe String "The tool identifier.")))
 
+(defschema AppListingJobStats
+  {:job_count_completed
+   (describe Long "The number of times this app has run to `Completed` status")
+
+   (optional-key :job_last_completed)
+   (describe Date "The last date this app has run to `Completed` status")})
+
+(defschema AdminAppListingJobStats
+  (merge AppListingJobStats
+         {:job_count
+          (describe Long "The number of times this app has run")
+
+          :job_count_failed
+          (describe Long "The number of times this app has run to `Failed` status")
+
+          (optional-key :last_used)
+          (describe Date "The start date this app was last run")}))
+
 (defschema AppDetails
   (merge AppBase
          {:id
@@ -281,6 +300,9 @@
 
           :references
           AppReferencesParam
+
+          (optional-key :job_stats)
+          (describe AppListingJobStats AppListingJobStatsDocs)
 
           (optional-key :hierarchies)
           (describe Any
@@ -374,6 +396,9 @@
      :step_count
      (describe Long "The number of Tasks this App executes")
 
+     (optional-key :job_stats)
+     (describe AppListingJobStats AppListingJobStatsDocs)
+
      (optional-key :wiki_url)
      AppDocUrlParam
 
@@ -383,6 +408,20 @@
 (defschema AppListing
   {:app_count (describe Long "The total number of Apps in the listing")
    :apps      (describe [AppListingDetail] "A listing of App details")})
+
+(defschema AdminAppListingDetail
+  (merge AppListingDetail
+         {(optional-key :job_stats)
+          (describe AdminAppListingJobStats AppListingJobStatsDocs)}))
+
+(defschema AdminAppListing
+  (merge AppListing
+         {:apps (describe [AdminAppListingDetail] "A listing of App details")}))
+
+(defschema AdminAppDetails
+  (merge AppDetails
+         {(optional-key :job_stats)
+          (describe AdminAppListingJobStats AppListingJobStatsDocs)}))
 
 (defschema QualifiedAppId
   {:system_id SystemId

--- a/src/apps/routes/schemas/app/category.clj
+++ b/src/apps/routes/schemas/app/category.clj
@@ -25,15 +25,20 @@
         private categories are returned.")}))
 
 (def AppListingValidSortFields
-  (-> (map ->required-key (keys AppListingDetail))
+  (-> (map ->required-key (concat (keys AppListingDetail) (keys AppListingJobStats)))
       (conj :average_rating :user_rating)
       set
       (sets/difference #{:app_type
                          :can_favor
                          :can_rate
                          :can_run
+                         :job_stats
                          :pipeline_eligibility
                          :rating})))
+
+(def AdminAppListingValidSortFields
+  (-> (map ->required-key (keys AdminAppListingJobStats))
+      (concat AppListingValidSortFields)))
 
 (defschema AppListingPagingParams
   (merge SecuredQueryParamsEmailRequired
@@ -107,3 +112,8 @@
 (defschema OntologyAppListingPagingParams
   (merge AppListingPagingParams
          {:attr (describe String "The metadata attribute that stores the given class IRI")}))
+
+(defschema AdminOntologyAppListingPagingParams
+  (assoc OntologyAppListingPagingParams
+    SortFieldOptionalKey
+    (describe (apply enum AdminAppListingValidSortFields) SortFieldDocs)))

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -97,6 +97,10 @@
   [user {:keys [search] :as params}]
   (.searchApps (get-apps-client user) search params))
 
+(defn admin-search-apps
+  [user {:keys [search] :as params}]
+  (.adminSearchApps (get-apps-client user) search params))
+
 (defn add-app
   ([user app]
    (.addApp (get-apps-client user) app))

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -83,7 +83,11 @@
 
   (searchApps [_ search-term params]
     (when (user-has-access-token?)
-      (listings/search-apps agave search-term params)))
+      (listings/search-apps agave search-term params false)))
+
+  (adminSearchApps [_ search-term params]
+    (when (user-has-access-token?)
+      (listings/search-apps agave search-term params true)))
 
   (canEditApps [_]
     false)
@@ -144,15 +148,13 @@
     (validate-system-id system-id)
     (reject-app-integration-request))
 
-  ;; FIXME: remove the third parameter when we can.
-  (getAppDetails [_ app-id _]
+  (getAppDetails [_ app-id admin?]
     (when-not (util/uuid? app-id)
-      (.getAppDetails agave app-id)))
+      (listings/get-app-details agave app-id admin?)))
 
-  ;; FIXME: remove the fourth parameter when we can.
-  (getAppDetails [_ system-id app-id _]
+  (getAppDetails [_ system-id app-id admin?]
     (validate-system-id system-id)
-    (.getAppDetails agave app-id))
+    (listings/get-app-details agave app-id admin?))
 
   (removeAppFavorite [_ app-id]
     (when-not (util/uuid? app-id)

--- a/src/apps/service/apps/agave/listings.clj
+++ b/src/apps/service/apps/agave/listings.clj
@@ -9,15 +9,9 @@
 
 (defn- add-agave-job-stats
   [{:keys [id] :as app} admin?]
-  (let [job-stats     (if admin?
-                        (jobs-db/get-job-stats id)
-                        (jobs-db/get-public-job-stats id))
-        default-stats (if admin?
-                        {:job_count 0
-                         :job_count_failed 0
-                         :job_count_completed 0}
-                        {:job_count_completed 0})]
-    (merge app default-stats job-stats)))
+  (merge app (if admin?
+               (jobs-db/get-job-stats id)
+               (jobs-db/get-public-job-stats id))))
 
 (defn- add-app-listing-job-stats
   [app-listing admin?]

--- a/src/apps/service/apps/agave/listings.clj
+++ b/src/apps/service/apps/agave/listings.clj
@@ -1,24 +1,57 @@
 (ns apps.service.apps.agave.listings
-  (:use [apps.service.util :only [sort-apps apply-offset apply-limit uuid?]]
+  (:use [apps.service.util :only [sort-apps apply-offset apply-limit format-job-stats uuid?]]
+        [apps.util.conversions :only [remove-nil-vals]]
         [slingshot.slingshot :only [try+]])
   (:require [clojure.tools.logging :as log]
             [clojure-commons.error-codes :as ce :refer [clj-http-error?]]
-            [apps.persistence.app-metadata :as ap]))
+            [apps.persistence.app-metadata :as ap]
+            [apps.persistence.jobs :as jobs-db]))
+
+(defn- add-agave-job-stats
+  [{:keys [id] :as app} admin?]
+  (let [job-stats     (if admin?
+                        (jobs-db/get-job-stats id)
+                        (jobs-db/get-public-job-stats id))
+        default-stats (if admin?
+                        {:job_count 0
+                         :job_count_failed 0
+                         :job_count_completed 0}
+                        {:job_count_completed 0})]
+    (merge app default-stats job-stats)))
+
+(defn- add-app-listing-job-stats
+  [app-listing admin?]
+  (update app-listing :apps (partial map (comp remove-nil-vals #(add-agave-job-stats % admin?)))))
+
+(defn- format-app-listing-job-stats
+  [app-listing admin?]
+  (update app-listing :apps (partial map #(format-job-stats % admin?))))
+
+(defn get-app-details
+  [agave app-id admin?]
+  (-> (.getAppDetails agave app-id)
+      (add-agave-job-stats admin?)
+      (format-job-stats admin?)
+      remove-nil-vals))
 
 (defn list-apps
   [agave category-id params]
   (-> (.listApps agave)
+      (add-app-listing-job-stats false)
       (sort-apps params {:default-sort-field "name"})
       (apply-offset params)
-      (apply-limit params)))
+      (apply-limit params)
+      (format-app-listing-job-stats false)))
 
 (defn list-apps-with-ontology
   [agave term params]
   (try+
     (-> (select-keys (.listAppsWithOntology agave term) [:app_count :apps])
+        (add-app-listing-job-stats false)
         (sort-apps params {:default-sort-field "name"})
         (apply-offset params)
-        (apply-limit params))
+        (apply-limit params)
+        (format-app-listing-job-stats false))
     (catch [:error_code ce/ERR_UNAVAILABLE] _
       (log/error (:throwable &throw-context) "Agave app listing timed out")
       nil)
@@ -27,12 +60,14 @@
       nil)))
 
 (defn search-apps
-  [agave search-term params]
+  [agave search-term params admin?]
   (try+
    (-> (.searchApps agave search-term)
+       (add-app-listing-job-stats admin?)
        (sort-apps params {:default-sort-field "name"})
        (apply-offset params)
-       (apply-limit params))
+       (apply-limit params)
+       (format-app-listing-job-stats false))
    (catch [:error_code ce/ERR_UNAVAILABLE] _
      (log/error (:throwable &throw-context) "Agave app search timed out")
      nil)

--- a/src/apps/service/apps/agave/listings.clj
+++ b/src/apps/service/apps/agave/listings.clj
@@ -61,7 +61,7 @@
        (sort-apps params {:default-sort-field "name"})
        (apply-offset params)
        (apply-limit params)
-       (format-app-listing-job-stats false))
+       (format-app-listing-job-stats admin?))
    (catch [:error_code ce/ERR_UNAVAILABLE] _
      (log/error (:throwable &throw-context) "Agave app search timed out")
      nil)

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -69,6 +69,11 @@
          (remove nil?)
          (util/combine-app-search-results params)))
 
+  (adminSearchApps [_ search-term params]
+    (->> (map #(.adminSearchApps % search-term (select-keys params [:search])) clients)
+         (remove nil?)
+         (util/combine-app-search-results params)))
+
   (canEditApps [_]
     (some #(.canEditApps %) clients))
 

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -54,10 +54,13 @@
     (listings/list-apps-under-hierarchy user root-iri attr params))
 
   (adminListAppsUnderHierarchy [_ ontology-version root-iri attr params]
-    (listings/list-apps-under-hierarchy user ontology-version root-iri attr params))
+    (listings/list-apps-under-hierarchy user ontology-version root-iri attr params true))
 
   (searchApps [_ _ params]
-    (listings/search-apps user params))
+    (listings/search-apps user params false))
+
+  (adminSearchApps [_ _ params]
+    (listings/search-apps user params true))
 
   (canEditApps [_]
     true)

--- a/src/apps/service/util.clj
+++ b/src/apps/service/util.clj
@@ -11,8 +11,8 @@
   (partial sort-by
            (keyword sort-field)
            (if (and sort-dir (= (string/upper-case sort-dir) "DESC"))
-             #(compare (string/lower-case %2) (string/lower-case %1))
-             #(compare (string/lower-case %1) (string/lower-case %2)))))
+             #(compare (string/lower-case (str %2)) (string/lower-case (str %1)))
+             #(compare (string/lower-case (str %1)) (string/lower-case (str %2))))))
 
 (defn sort-apps
   [res {:keys [sort-field sort-dir]} & [{:keys [default-sort-field]}]]
@@ -58,3 +58,13 @@
     :sort-dir       (keyword (:sort-dir params default-sort-dir))
     :filter         (:filter params)
     :include-hidden (:include-hidden params false)}))
+
+(defn format-job-stats [app admin?]
+  (let [job-stats-keys [:job_count
+                        :job_count_completed
+                        :job_count_failed
+                        :job_last_completed
+                        :last_used]
+        stats-to-show  (if admin? job-stats-keys [:job_count_completed :job_last_completed])
+        app            (assoc app :job_stats (remove-nil-vals (select-keys app stats-to-show)))]
+    (apply dissoc app job-stats-keys)))


### PR DESCRIPTION
This PR adds a `job_stats` JSON object with `job_count_completed` and `job_last_completed` fields to the following endpoint responses:
* `GET /apps`
* `GET /apps/{app-id}/details`
* `GET /apps/{system-id}/{app-id}/details`
* `GET /apps/categories/{category-id}`
* `GET /apps/hierarchies/{root-iri}/apps`
* `GET /apps/hierarchies/{root-iri}/unclassified`

For example:
```json
{
  "job_stats": {
    "job_count_completed": 0,
    "job_last_completed": "2016-10-12T00:38:57.037Z"
  }
}
```

Also a `job_stats` field with the same JSON object above, but also with `job_count`, `job_count_failed`, and `last_used` fields were added to the following endpoint responses:
* `PATCH /admin/apps/{app-id}`
* `GET /admin/apps/{app-id}/details`
* `GET /admin/ontologies/{ontology-version}/{root-iri}/apps`
* `GET /admin/ontologies/{ontology-version}/{root-iri}/unclassified`

For example:
```json
{
  "job_stats": {
    "job_count_completed": 0,
    "job_last_completed": "2016-10-12T00:38:57.037Z",
    "job_count": 0,
    "job_count_failed": 0,
    "last_used": "2016-10-12T00:38:57.037Z"
  }
}
```

The updated listing endpoints are also able to sort results on the fields added to their responses.