### PR TITLE
CORE-8337: evaluate the /apps context after evaluating all other /app…

### DIFF
--- a/src/apps/routes.clj
+++ b/src/apps/routes.clj
@@ -93,15 +93,15 @@
     (context "/apps/elements" []
       :tags ["app-element-types"]
       app-element-routes/app-elements)
-    (context "/apps" []
-      :tags ["apps"]
-      app-routes/apps)
     (context "/apps/pipelines" []
       :tags ["pipelines"]
       pipeline-routes/pipelines)
     (context "/apps/:app-id/metadata" []
       :tags ["app-metadata"]
       metadata-routes/app-metadata)
+    (context "/apps" []
+      :tags ["apps"]
+      app-routes/apps)
     (context "/analyses" []
       :tags ["analyses"]
       analysis-routes/analyses)


### PR DESCRIPTION
…s endpoints in order to avoid erroneous matches

The `POST /apps/pipelines` endpoint was being matched by the `POST /apps/:system-id` endpoint, which was preventing pipelines from being saved.
