### PR TITLE
CORE-8162 Remove job_stats from non-admin app listing endpoint results

### DIFF
--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -396,9 +396,6 @@
      :step_count
      (describe Long "The number of Tasks this App executes")
 
-     (optional-key :job_stats)
-     (describe AppListingJobStats AppListingJobStatsDocs)
-
      (optional-key :wiki_url)
      AppDocUrlParam
 

--- a/src/apps/routes/schemas/app/category.clj
+++ b/src/apps/routes/schemas/app/category.clj
@@ -25,14 +25,13 @@
         private categories are returned.")}))
 
 (def AppListingValidSortFields
-  (-> (map ->required-key (concat (keys AppListingDetail) (keys AppListingJobStats)))
+  (-> (map ->required-key (keys AppListingDetail))
       (conj :average_rating :user_rating)
       set
       (sets/difference #{:app_type
                          :can_favor
                          :can_rate
                          :can_run
-                         :job_stats
                          :pipeline_eligibility
                          :rating})))
 

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -75,11 +75,11 @@
 
   (listAppsUnderHierarchy [_ root-iri attr params]
     (when (user-has-access-token?)
-      (listings/list-apps-with-ontology agave root-iri params)))
+      (listings/list-apps-with-ontology agave root-iri params false)))
 
   (adminListAppsUnderHierarchy [_ ontology-version root-iri attr params]
     (when (user-has-access-token?)
-      (listings/list-apps-with-ontology agave root-iri params)))
+      (listings/list-apps-with-ontology agave root-iri params true)))
 
   (searchApps [_ search-term params]
     (when (user-has-access-token?)

--- a/src/apps/service/apps/agave/listings.clj
+++ b/src/apps/service/apps/agave/listings.clj
@@ -15,11 +15,15 @@
 
 (defn- add-app-listing-job-stats
   [app-listing admin?]
-  (update app-listing :apps (partial map (comp remove-nil-vals #(add-agave-job-stats % admin?)))))
+  (if admin?
+    (update app-listing :apps (partial map (comp remove-nil-vals #(add-agave-job-stats % admin?))))
+    app-listing))
 
 (defn- format-app-listing-job-stats
   [app-listing admin?]
-  (update app-listing :apps (partial map #(format-job-stats % admin?))))
+  (if admin?
+    (update app-listing :apps (partial map #(format-job-stats % admin?)))
+    app-listing))
 
 (defn get-app-details
   [agave app-id admin?]

--- a/src/apps/service/apps/agave/listings.clj
+++ b/src/apps/service/apps/agave/listings.clj
@@ -42,14 +42,14 @@
       (format-app-listing-job-stats false)))
 
 (defn list-apps-with-ontology
-  [agave term params]
+  [agave term params admin?]
   (try+
     (-> (select-keys (.listAppsWithOntology agave term) [:app_count :apps])
-        (add-app-listing-job-stats false)
+        (add-app-listing-job-stats admin?)
         (sort-apps params {:default-sort-field "name"})
         (apply-offset params)
         (apply-limit params)
-        (format-app-listing-job-stats false))
+        (format-app-listing-job-stats admin?))
     (catch [:error_code ce/ERR_UNAVAILABLE] _
       (log/error (:throwable &throw-context) "Agave app listing timed out")
       nil)


### PR DESCRIPTION
Removes `job_stats` from non-admin app listing endpoint results, since job stat columns have been removed from the `app_listing` view by cyverse-de/de-db#2.


Admin app search and listing endpoints now use the new admin search and app listing functions added by cyverse-de/kameleon#2 so they can still include `job_stats` in their results.

Also includes a fix for adding admin `job_stats` to `apps.service.apps.agave.listings/list-apps-with-ontology` results.