### PR TITLE
CORE-8162 Exclude parent jobs from app details `job_stats` counts.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [metosin/compojure-api "1.1.8"]
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "2.8.1"]
-                 [org.cyverse/kameleon "2.8.2-SNAPSHOT"]
+                 [org.cyverse/kameleon "2.8.2"]
                  [org.cyverse/mescal "2.8.1-SNAPSHOT"]
                  [org.cyverse/metadata-client "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]


### PR DESCRIPTION
This PR will exclude the parent job of batch jobs in the `job_stats` counts of app details endpoint responses.