### PR TITLE
CORE-8375 Allow `search` param to be optional in GET apps endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [metosin/compojure-api "1.1.8"]
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "2.8.1"]
-                 [org.cyverse/kameleon "2.8.2"]
+                 [org.cyverse/kameleon "2.8.3-SNAPSHOT"]
                  [org.cyverse/mescal "2.8.1-SNAPSHOT"]
                  [org.cyverse/metadata-client "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -54,12 +54,12 @@
   (GET "/" []
        :query [params AppSearchParams]
        :middleware [wrap-metadata-base-url]
-       :summary "Search Apps"
+       :summary "Filter Apps"
        :return AdminAppListing
        :description
        (str
-"This service allows admins to search for Apps based on a part of the App name, description, integrator's
- name, tool name, or category name the app is under."
+"This service allows admins to list all apps. If the `search` parameter is included, then the results are
+ filtered by the App name, description, integrator's name, tool name, or category name the app is under."
 (get-endpoint-delegate-block
   "metadata"
   "POST /avus/filter-targets")

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -17,11 +17,12 @@
   (GET "/" []
     :query [params AppSearchParams]
     :middleware [wrap-metadata-base-url]
-    :summary "Search Apps"
+    :summary "Filter Apps"
     :return AppListing
     :description
-    (str "This service allows users to search for Apps based on a part of the App name, description, integrator's
-         name, tool name, or category name the app is under."
+    (str "This service allows users to get a paged listing of all Apps accessible to the user.
+         If the `search` parameter is included, then the results are filtered by
+         the App name, description, integrator's name, tool name, or category name the app is under."
          (get-endpoint-delegate-block
           "metadata"
           "POST /avus/filter-targets")

--- a/src/apps/routes/params.clj
+++ b/src/apps/routes/params.clj
@@ -57,7 +57,9 @@
 
 (s/defschema AppSearchParams
   (merge SecuredPagingParams
-         {:search (describe String "The pattern to match in an App's Name or Description.")}))
+         {(s/optional-key :search)
+          (describe String
+            "The pattern to match in an App's Name, Description, Integrator Name, or Tool Name.")}))
 
 (s/defschema SecuredIncludeHiddenParams
   (merge SecuredQueryParams IncludeHiddenParams))

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -3,8 +3,7 @@
   or more other implementations. This implementation expects at most one the implementations that
   it interacts with to allow users to add new apps and edit existing ones. If this is not the case
   then the first app in the list that is capable of adding or editing apps wins."
-  (:use [apps.service.util :only [apply-limit apply-offset sort-apps]]
-        [apps.util.assertions :only [assert-not-nil]])
+  (:use [apps.util.assertions :only [assert-not-nil]])
   (:require [apps.persistence.jobs :as jp]
             [apps.protocols]
             [apps.service.apps.job-listings :as job-listings]
@@ -12,18 +11,6 @@
             [apps.service.apps.combined.jobs :as combined-jobs]
             [apps.service.apps.combined.util :as util]
             [apps.service.apps.permissions :as app-permissions]))
-
-(defn- apply-app-listing-params
-  [listing-map params]
-  (-> listing-map
-      (sort-apps params {:default-sort-field "name"})
-      (apply-offset params)
-      (apply-limit params)))
-
-(defn- merge-client-app-listings
-  "Expects the client listing-maps in a format like {:app_count int, :apps []}"
-  [listing-maps]
-  (apply merge-with #(if (integer? %1) (+ %1 %2) (into %1 %2)) listing-maps))
 
 (deftype CombinedApps [clients user]
   apps.protocols.Apps
@@ -54,25 +41,23 @@
 
   (listAppsUnderHierarchy [_ root-iri attr params]
     (let [unpaged-params (dissoc params :limit :offset)
-          listing-maps   (map #(.listAppsUnderHierarchy % root-iri attr unpaged-params) clients)
-          result-map     (merge-client-app-listings listing-maps)]
-      (apply-app-listing-params result-map params)))
+          listing-maps   (map #(.listAppsUnderHierarchy % root-iri attr unpaged-params) clients)]
+      (util/combine-app-listings params listing-maps)))
 
   (adminListAppsUnderHierarchy [_ ontology-version root-iri attr params]
     (let [unpaged-params (dissoc params :limit :offset)
-          listing-maps   (map #(.adminListAppsUnderHierarchy % ontology-version root-iri attr unpaged-params) clients)
-          result-map     (merge-client-app-listings listing-maps)]
-      (apply-app-listing-params result-map params)))
+          listing-maps   (map #(.adminListAppsUnderHierarchy % ontology-version root-iri attr unpaged-params) clients)]
+      (util/combine-app-listings params listing-maps)))
 
   (searchApps [_ search-term params]
     (->> (map #(.searchApps % search-term (select-keys params [:search])) clients)
          (remove nil?)
-         (util/combine-app-search-results params)))
+         (util/combine-app-listings params)))
 
   (adminSearchApps [_ search-term params]
     (->> (map #(.adminSearchApps % search-term (select-keys params [:search])) clients)
          (remove nil?)
-         (util/combine-app-search-results params)))
+         (util/combine-app-listings params)))
 
   (canEditApps [_]
     (some #(.canEditApps %) clients))

--- a/src/apps/service/apps/combined/util.clj
+++ b/src/apps/service/apps/combined/util.clj
@@ -10,7 +10,8 @@
     :sort-field (or (:sort-field params) "name")
     :sort-dir   (or (:sort-dir params) "ASC")))
 
-(defn combine-app-search-results
+(defn combine-app-listings
+  "Expects results to be a list of maps in a format like {:app_count int, :apps []}"
   [params results]
   (let [params (apply-default-search-params params)]
     (-> {:app_count (apply + (map :app_count results))

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -57,10 +57,10 @@
     (listings/list-apps-under-hierarchy user ontology-version root-iri attr params true))
 
   (searchApps [_ _ params]
-    (listings/search-apps user params false))
+    (listings/filter-apps user params false))
 
   (adminSearchApps [_ _ params]
-    (listings/search-apps user params true))
+    (listings/filter-apps user params true))
 
   (canEditApps [_]
     true)


### PR DESCRIPTION
This PR updates the `GET /admin/apps` and `GET /apps` endpoints to allow their `search` params to be optional, using the new functions added by cyverse-de/kameleon#4.

This allows these endpoints to return a paged listing of all apps accessible by the requesting user if the `search` param is not provided.

Also some redundant code in `apps.service.apps.combined` was cleaned up.