### PR TITLE
CORE-8375 Fixes for apps listing endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "2.8.1"]
                  [org.cyverse/kameleon "2.8.3-SNAPSHOT"]
-                 [org.cyverse/mescal "2.8.1-SNAPSHOT"]
+                 [org.cyverse/mescal "2.8.1"]
                  [org.cyverse/metadata-client "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/common-cfg "2.8.0"]

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/common-cfg "2.8.0"]
-                 [org.cyverse/common-swagger-api "2.8.1"]
+                 [org.cyverse/common-swagger-api "2.8.2"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]
                  [org.cyverse/event-messages "0.0.1"]

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -52,7 +52,7 @@
 
 (defroutes admin-apps
   (GET "/" []
-       :query [params AppSearchParams]
+       :query [params AdminAppSearchParams]
        :middleware [wrap-metadata-base-url]
        :summary "List Apps"
        :return AdminAppListing

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -54,7 +54,7 @@
   (GET "/" []
        :query [params AppSearchParams]
        :middleware [wrap-metadata-base-url]
-       :summary "Filter Apps"
+       :summary "List Apps"
        :return AdminAppListing
        :description
        (str

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -17,7 +17,7 @@
   (GET "/" []
     :query [params AppSearchParams]
     :middleware [wrap-metadata-base-url]
-    :summary "Filter Apps"
+    :summary "List Apps"
     :return AppListing
     :description
     (str "This service allows users to get a paged listing of all Apps accessible to the user.

--- a/src/apps/routes/apps/categories.clj
+++ b/src/apps/routes/apps/categories.clj
@@ -4,7 +4,8 @@
         [common-swagger-api.schema.ontologies]
         [apps.routes.middleware :only [wrap-metadata-base-url]]
         [apps.routes.params]
-        [apps.routes.schemas.app :only [AppListing]]
+        [apps.routes.schemas.app :only [AppListing
+                                        AppListingPagingParams]]
         [apps.routes.schemas.app.category]
         [apps.user :only [current-user]]
         [apps.util.coercions :only [coerce!]]

--- a/src/apps/routes/params.clj
+++ b/src/apps/routes/params.clj
@@ -55,12 +55,6 @@
 (s/defschema SecuredPagingParams
   (merge SecuredQueryParams PagingParams))
 
-(s/defschema AppSearchParams
-  (merge SecuredPagingParams
-         {(s/optional-key :search)
-          (describe String
-            "The pattern to match in an App's Name, Description, Integrator Name, or Tool Name.")}))
-
 (s/defschema SecuredIncludeHiddenParams
   (merge SecuredQueryParams IncludeHiddenParams))
 

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -1,6 +1,6 @@
 (ns apps.routes.schemas.app
   (:use [common-swagger-api.schema :only [->optional-param
-                                          ->required-key
+                                          optional-key->keyword
                                           describe
                                           PagingParams
                                           SortFieldDocs
@@ -422,7 +422,7 @@
          {:apps (describe [AdminAppListingDetail] "A listing of App details")}))
 
 (def AppListingValidSortFields
-  (-> (map ->required-key (keys AppListingDetail))
+  (-> (map optional-key->keyword (keys AppListingDetail))
       (conj :average_rating :user_rating)
       set
       (sets/difference #{:app_type
@@ -432,7 +432,10 @@
                          :pipeline_eligibility
                          :rating})))
 
-(def AdminAppListingJobStatsKeys (set (map ->required-key (keys AdminAppListingJobStats))))
+(def AdminAppListingJobStatsKeys (->> AdminAppListingJobStats
+                                      keys
+                                      (map optional-key->keyword)
+                                      set))
 
 (def AdminAppListingValidSortFields
   (sets/union AppListingValidSortFields AdminAppListingJobStatsKeys))

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -1,9 +1,15 @@
 (ns apps.routes.schemas.app
-  (:use [common-swagger-api.schema :only [->optional-param describe]]
+  (:use [common-swagger-api.schema :only [->optional-param
+                                          ->required-key
+                                          describe
+                                          PagingParams
+                                          SortFieldDocs
+                                          SortFieldOptionalKey]]
         [apps.routes.params]
         [apps.routes.schemas.app.rating]
         [apps.routes.schemas.tool :only [Tool]]
-        [schema.core :only [Any defschema optional-key recursive]])
+        [schema.core :only [Any defschema enum optional-key recursive]])
+  (:require [clojure.set :as sets])
   (:import [java.util UUID Date]))
 
 (def AppIdParam (describe UUID "A UUID that is used to identify the App"))
@@ -414,6 +420,50 @@
 (defschema AdminAppListing
   (merge AppListing
          {:apps (describe [AdminAppListingDetail] "A listing of App details")}))
+
+(def AppListingValidSortFields
+  (-> (map ->required-key (keys AppListingDetail))
+      (conj :average_rating :user_rating)
+      set
+      (sets/difference #{:app_type
+                         :can_favor
+                         :can_rate
+                         :can_run
+                         :pipeline_eligibility
+                         :rating})))
+
+(def AdminAppListingJobStatsKeys (set (map ->required-key (keys AdminAppListingJobStats))))
+
+(def AdminAppListingValidSortFields
+  (sets/union AppListingValidSortFields AdminAppListingJobStatsKeys))
+
+(defschema AppListingPagingParams
+  (merge SecuredQueryParamsEmailRequired
+         PagingParams
+         {SortFieldOptionalKey
+          (describe (apply enum AppListingValidSortFields) SortFieldDocs)}))
+
+(def AppSearchValidSortFields
+  (-> AppListingValidSortFields
+      (sets/difference #{:average_rating :user_rating})
+      (conj :average :total)))
+
+(def AdminAppSearchValidSortFields
+  (sets/union AppSearchValidSortFields AdminAppListingJobStatsKeys))
+
+(defschema AppSearchParams
+  (merge SecuredPagingParams
+         {(optional-key :search)
+          (describe String
+            "The pattern to match in an App's Name, Description, Integrator Name, or Tool Name.")
+
+          SortFieldOptionalKey
+          (describe (apply enum AppSearchValidSortFields) SortFieldDocs)}))
+
+(defschema AdminAppSearchParams
+  (merge AppSearchParams
+         {SortFieldOptionalKey
+          (describe (apply enum AdminAppSearchValidSortFields) SortFieldDocs)}))
 
 (defschema AdminAppDetails
   (merge AppDetails

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -409,8 +409,8 @@
      (describe String "The user's access level for the app.")}))
 
 (defschema AppListing
-  {:app_count (describe Long "The total number of Apps in the listing")
-   :apps      (describe [AppListingDetail] "A listing of App details")})
+  {:total (describe Long "The total number of Apps in the listing")
+   :apps  (describe [AppListingDetail] "A listing of App details")})
 
 (defschema AdminAppListingDetail
   (merge AppListingDetail

--- a/src/apps/routes/schemas/app/category.clj
+++ b/src/apps/routes/schemas/app/category.clj
@@ -1,6 +1,5 @@
 (ns apps.routes.schemas.app.category
   (:use [common-swagger-api.schema :only [->optional-param
-                                          ->required-key
                                           describe
                                           NonBlankString
                                           PagingParams

--- a/src/apps/routes/schemas/app/category.clj
+++ b/src/apps/routes/schemas/app/category.clj
@@ -8,9 +8,10 @@
                                           SortFieldOptionalKey]]
         [common-swagger-api.schema.ontologies]
         [apps.routes.params]
-        [apps.routes.schemas.app]
+        [apps.routes.schemas.app :only [AdminAppListingValidSortFields
+                                        AppListingDetail
+                                        AppListingPagingParams]]
         [schema.core :only [defschema optional-key recursive enum]])
-  (:require [clojure.set :as sets])
   (:import [java.util Date UUID]))
 
 (def AppCategoryNameParam (describe String "The App Category's name"))
@@ -23,27 +24,6 @@
         public in the database are returned. If set to 'false', then only app categories that
         are in the user's workspace are returned. If not set, then both public and the user's
         private categories are returned.")}))
-
-(def AppListingValidSortFields
-  (-> (map ->required-key (keys AppListingDetail))
-      (conj :average_rating :user_rating)
-      set
-      (sets/difference #{:app_type
-                         :can_favor
-                         :can_rate
-                         :can_run
-                         :pipeline_eligibility
-                         :rating})))
-
-(def AdminAppListingValidSortFields
-  (-> (map ->required-key (keys AdminAppListingJobStats))
-      (concat AppListingValidSortFields)))
-
-(defschema AppListingPagingParams
-  (merge SecuredQueryParamsEmailRequired
-    (assoc PagingParams
-      SortFieldOptionalKey
-      (describe (apply enum AppListingValidSortFields) SortFieldDocs))))
 
 (defschema AppCategory
   {:id

--- a/src/apps/routes/schemas/app/category.clj
+++ b/src/apps/routes/schemas/app/category.clj
@@ -32,7 +32,7 @@
    :name
    AppCategoryNameParam
 
-   :app_count
+   :total
    (describe Long "The number of Apps under this Category and all of its children")
 
    :is_public

--- a/src/apps/service/apps/agave/listings.clj
+++ b/src/apps/service/apps/agave/listings.clj
@@ -44,7 +44,7 @@
 (defn list-apps-with-ontology
   [agave term params admin?]
   (try+
-    (-> (select-keys (.listAppsWithOntology agave term) [:app_count :apps])
+    (-> (select-keys (.listAppsWithOntology agave term) [:total :apps])
         (add-app-listing-job-stats admin?)
         (sort-apps params {:default-sort-field "name"})
         (apply-offset params)

--- a/src/apps/service/apps/combined/util.clj
+++ b/src/apps/service/apps/combined/util.clj
@@ -11,11 +11,11 @@
     :sort-dir   (or (:sort-dir params) "ASC")))
 
 (defn combine-app-listings
-  "Expects results to be a list of maps in a format like {:app_count int, :apps []}"
+  "Expects results to be a list of maps in a format like {:total int, :apps []}"
   [params results]
   (let [params (apply-default-search-params params)]
-    (-> {:app_count (apply + (map :app_count results))
-         :apps      (mapcat :apps results)}
+    (-> {:total (apply + (map :total results))
+         :apps  (mapcat :apps results)}
         (sort-apps params)
         (apply-offset params)
         (apply-limit params))))

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -57,10 +57,10 @@
     (listings/list-apps-under-hierarchy user ontology-version root-iri attr params true))
 
   (searchApps [_ _ params]
-    (listings/filter-apps user params false))
+    (listings/list-apps user params false))
 
   (adminSearchApps [_ _ params]
-    (listings/filter-apps user params true))
+    (listings/list-apps user params true))
 
   (canEditApps [_]
     true)

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -67,12 +67,13 @@
       params)))
 
 (defn- add-subgroups
-  [group groups]
+  [{:keys [app_count] :as group} groups]
   (let [subgroups (filter #(= (:id group) (:parent_id %)) groups)
         subgroups (map #(add-subgroups % groups) subgroups)
-        result    (if (empty? subgroups) group (assoc group :categories subgroups))
-        result    (dissoc result :parent_id :workspace_id :description)]
-    result))
+        result    (if (empty? subgroups) group (assoc group :categories subgroups))]
+    (-> result
+        (assoc :total app_count)
+        (dissoc :app_count :parent_id :workspace_id :description))))
 
 (defn format-trash-category
   "Formats the virtual group for the admin's deleted and orphaned apps category."
@@ -80,7 +81,7 @@
   {:id         trash-category-id
    :name       "Trash"
    :is_public  true
-   :app_count  (count-deleted-and-orphaned-apps params)})
+   :total      (count-deleted-and-orphaned-apps params)})
 
 (defn list-trashed-apps
   "Lists the public, deleted apps and orphaned apps."
@@ -93,7 +94,7 @@
   {:id        my-public-apps-id
    :name      "My public apps"
    :is_public false
-   :app_count (count-public-apps-by-user username params)})
+   :total     (count-public-apps-by-user username params)})
 
 (defn list-my-public-apps
   "Lists the public apps belonging to the user with the given workspace."
@@ -110,7 +111,7 @@
   {:id        shared-with-me-id
    :name      "Shared with me"
    :is_public false
-   :app_count (count-shared-apps workspace (workspace-favorites-app-category-index) params)})
+   :total     (count-shared-apps workspace (workspace-favorites-app-category-index) params)})
 
 (defn list-apps-shared-with-me
   [_ workspace params]
@@ -141,7 +142,7 @@
                         params)]
     (-> group
         (update-in [:categories] concat virtual-groups)
-        (assoc :app_count actual-count))))
+        (assoc :total actual-count))))
 
 (defn- format-app-group-hierarchy
   "Formats the app group hierarchy rooted at the app group with the given
@@ -297,8 +298,8 @@
         public-app-ids  (perms-client/get-public-app-ids)
         app-listing-fn  (if admin? admin-list-apps-by-id list-apps-by-id)
         app-listing     (app-listing-fn workspace faves-index app-listing-ids (fix-sort-params params))]
-    {:app_count (count app-listing-ids)
-     :apps      (map (partial format-app-listing admin? perms beta-ids-set public-app-ids) app-listing)}))
+    {:total (count app-listing-ids)
+     :apps  (map (partial format-app-listing admin? perms beta-ids-set public-app-ids) app-listing)}))
 
 (defn list-apps-under-hierarchy
   ([user root-iri attr params]
@@ -349,8 +350,8 @@
         beta-ids-set   (app-ids->beta-ids-set shortUsername (map :id apps_in_group))
         apps_in_group  (map (partial format-app-listing false perms beta-ids-set public-app-ids) apps_in_group)]
     (assoc app_group
-      :app_count total
-      :apps apps_in_group)))
+      :total total
+      :apps  apps_in_group)))
 
 (defn list-apps-in-group
   "This service lists all of the apps in an app group and all of its
@@ -386,8 +387,8 @@
         beta-ids-set   (app-ids->beta-ids-set shortUsername (map :id apps))
         public-app-ids (:public-app-ids params)
         apps           (map (partial format-app-listing admin? perms beta-ids-set public-app-ids) apps)]
-    {:app_count total
-     :apps      apps}))
+    {:total total
+     :apps  apps}))
 
 (defn- load-app-details
   "Retrieves the details for a single app."

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -368,7 +368,7 @@
   (or (virtual-group-ids category-id)
       (seq (select :app_categories (where {:id category-id})))))
 
-(defn filter-apps
+(defn list-apps
   "This service fetches a paged list of apps in the user's workspace and all public app groups,
    further filtering results by a search term if the `search` parameter is present."
   [{:keys [username shortUsername]} params admin?]

--- a/test/apps/service/apps/combined_test.clj
+++ b/test/apps/service/apps/combined_test.clj
@@ -1,10 +1,12 @@
 (ns apps.service.apps.combined-test
   (:use [clojure.test]
+        [kameleon.uuids :only [uuid]]
         [apps.service.apps.combined]))
 
-(def client1-apps-listing {:total 5, :apps [{:id 1} {:id 2} {:id 3} {:id 4} {:id 5}]})
-(def client2-apps-listing {:total 3, :apps [{:id "a"} {:id "b"} {:id "c"}]})
-(def combined-app-set #{{:id 1} {:id 2} {:id 3} {:id 4} {:id 5} {:id "a"} {:id "b"} {:id "c"}})
+(def client1-apps-listing {:total 5, :apps [{:id (uuid)} {:id (uuid)} {:id (uuid)} {:id (uuid)} {:id (uuid)}]})
+(def client2-apps-listing nil)
+(def client3-apps-listing {:total 3, :apps [{:id "a"} {:id "b"} {:id "c"}]})
+(def combined-app-set (set (concat (:apps client1-apps-listing) (:apps client3-apps-listing))))
 
 (deftype TestClient1 []
   apps.protocols.Apps
@@ -28,8 +30,19 @@
     [_ ontology-version root-iri attr params]
     client2-apps-listing))
 
+(deftype TestClient3 []
+  apps.protocols.Apps
+
+  (listAppsUnderHierarchy
+    [_ root-iri attr params]
+    client3-apps-listing)
+
+  (adminListAppsUnderHierarchy
+    [_ ontology-version root-iri attr params]
+    client3-apps-listing))
+
 (def combined-client (apps.service.apps.combined.CombinedApps.
-                       [(TestClient1.) (TestClient2.)]
+                       [(TestClient1.) (TestClient2.) (TestClient3.)]
                        "someuser"))
 
 (deftest CombinedApps-listAppsUnderHierarchy-test

--- a/test/apps/service/apps/combined_test.clj
+++ b/test/apps/service/apps/combined_test.clj
@@ -2,8 +2,8 @@
   (:use [clojure.test]
         [apps.service.apps.combined]))
 
-(def client1-apps-listing {:app_count 5, :apps [{:id 1} {:id 2} {:id 3} {:id 4} {:id 5}]})
-(def client2-apps-listing {:app_count 3, :apps [{:id "a"} {:id "b"} {:id "c"}]})
+(def client1-apps-listing {:total 5, :apps [{:id 1} {:id 2} {:id 3} {:id 4} {:id 5}]})
+(def client2-apps-listing {:total 3, :apps [{:id "a"} {:id "b"} {:id "c"}]})
 (def combined-app-set #{{:id 1} {:id 2} {:id 3} {:id 4} {:id 5} {:id "a"} {:id "b"} {:id "c"}})
 
 (deftype TestClient1 []
@@ -33,20 +33,20 @@
                        "someuser"))
 
 (deftest CombinedApps-listAppsUnderHierarchy-test
-  (let [{:keys [app_count apps]} (.listAppsUnderHierarchy combined-client
+  (let [{:keys [total apps]} (.listAppsUnderHierarchy combined-client
                                                           "root-iri"
                                                           "attr"
                                                           {:sort-field "id"})]
     (testing "Test CombinedApps.listAppsWithMetadata app count and apps list."
-      (is (= app_count 8))
+      (is (= total 8))
       (is (= (set apps) combined-app-set)))))
 
 (deftest CombinedApps-adminListAppsUnderHierarchy-test
-  (let [{:keys [app_count apps]} (.adminListAppsUnderHierarchy combined-client
+  (let [{:keys [total apps]} (.adminListAppsUnderHierarchy combined-client
                                                                "ontology-version"
                                                                "root-iri"
                                                                "attr"
                                                                {:sort-field "id"})]
     (testing "Test CombinedApps.adminListAppsUnderHierarchy app count and apps list."
-      (is (= app_count 8))
+      (is (= total 8))
       (is (= (set apps) combined-app-set)))))

--- a/test/apps/service/apps/permissions_test.clj
+++ b/test/apps/service/apps/permissions_test.clj
@@ -22,13 +22,13 @@
 ;; FIXME: tmp disabled failing test
 #_(deftest test-app-search
   (let [{username :shortUsername :as user} (get-user :testde1)]
-    (is (= 1 (:app_count (apps/search-apps user {:search (:name test-app)}))))
+    (is (= 1 (:total (apps/search-apps user {:search (:name test-app)}))))
     (is (= 1 (count (:apps (apps/search-apps user {:search (:name test-app)})))))
     (perms-client/unshare-app (:id test-app) "user" username)
-    (is (= 0 (:app_count (apps/search-apps user {:search (:name test-app)}))))
+    (is (= 0 (:total (apps/search-apps user {:search (:name test-app)}))))
     (is (= 0 (count (:apps (apps/search-apps user {:search (:name test-app)})))))
     (pc/grant-permission (config/permissions-client) "app" (:id test-app) "user" username "own")
-    (is (= 1 (:app_count (apps/search-apps user {:search (:name test-app)}))))
+    (is (= 1 (:total (apps/search-apps user {:search (:name test-app)}))))
     (is (= 1 (count (:apps (apps/search-apps user {:search (:name test-app)})))))))
 
 ;; FIXME: tmp disabled failing test
@@ -37,39 +37,40 @@
         dev-category-id                    (:id (get-dev-category user))
         beta-category-id                   (:id (get-beta-category user))
         group-id                           (ipg/grouper-user-group-id)]
-    (is (= 1 (:app_count (apps/list-apps-in-category user dev-category-id {}))))
-    (is (= (count beta-apps) (:app_count (apps/list-apps-in-category user beta-category-id {}))))
+    (is (= 1 (:total (apps/list-apps-in-category user dev-category-id {}))))
+    (is (= (count beta-apps) (:total (apps/list-apps-in-category user beta-category-id {}))))
     (perms-client/unshare-app (:id test-app) "user" username)
-    (is (= 0 (:app_count (apps/list-apps-in-category user dev-category-id {}))))
+    (is (= 0 (:total (apps/list-apps-in-category user dev-category-id {}))))
     (pc/grant-permission (config/permissions-client) "app" (:id test-app) "user" username "own")
-    (is (= 1 (:app_count (apps/list-apps-in-category user dev-category-id {}))))
-    (is (= (count beta-apps) (:app_count (apps/list-apps-in-category user beta-category-id {}))))
+    (is (= 1 (:total (apps/list-apps-in-category user dev-category-id {}))))
+    (is (= (count beta-apps) (:total (apps/list-apps-in-category user beta-category-id {}))))
     (pc/revoke-permission (config/permissions-client) "app" (:id (first beta-apps)) "group" group-id)
-    (is (= 1 (:app_count (apps/list-apps-in-category user dev-category-id {}))))
-    (is (= (dec (count beta-apps)) (:app_count (apps/list-apps-in-category user beta-category-id {}))))))
+    (is (= 1 (:total (apps/list-apps-in-category user dev-category-id {}))))
+    (is (= (dec (count beta-apps)) (:total (apps/list-apps-in-category user beta-category-id {}))))))
 
 ;; FIXME: tmp disabled failing test
 #_(deftest test-app-hierarchy-counts
   (let [{username :shortUsername :as user} (get-user :testde1)
         group-id                           (ipg/grouper-user-group-id)]
-    (is (= 1 (:app_count (get-dev-category user))))
-    (is (= (count beta-apps) (:app_count (get-beta-category user))))
+    (is (= 1 (:total (get-dev-category user))))
+    (is (= (count beta-apps) (:total (get-beta-category user))))
     (perms-client/unshare-app (:id test-app) "user" username)
-    (is (= 0 (:app_count (get-dev-category user))))
-    (is (= (count beta-apps) (:app_count (get-beta-category user))))
+    (is (= 0 (:total (get-dev-category user))))
+    (is (= (count beta-apps) (:total (get-beta-category user))))
     (pc/grant-permission (config/permissions-client) "app" (:id test-app) "user" username "own")
-    (is (= 1 (:app_count (get-dev-category user))))
-    (is (= (count beta-apps) (:app_count (get-beta-category user))))
+    (is (= 1 (:total (get-dev-category user))))
+    (is (= (count beta-apps) (:total (get-beta-category user))))
     (pc/revoke-permission (config/permissions-client) "app" (:id (first beta-apps)) "group" group-id)
-    (is (= 1 (:app_count (get-dev-category user))))
-    (is (= (dec (count beta-apps)) (:app_count (get-beta-category user))))))
+    (is (= 1 (:total (get-dev-category user))))
+    (is (= (dec (count beta-apps)) (:total (get-beta-category user))))))
 
+;; FIXME the Beta category is obsolete
 (deftest test-admin-app-hierarchy-counts
   (let [{username :shortUsername :as user} (get-user :testde1)
         group-id                           (ipg/grouper-user-group-id)]
-    (is (= (count beta-apps) (:app_count (get-admin-beta-category user))))
+    (is (= (count beta-apps) (:total (get-admin-beta-category user))))
     (pc/revoke-permission (config/permissions-client) "app" (:id (first beta-apps)) "group" group-id)
-    (is (= (dec (count beta-apps)) (:app_count (get-admin-beta-category user))))))
+    (is (= (dec (count beta-apps)) (:total (get-admin-beta-category user))))))
 
 (defn find-app [listing app-id]
   (first (filter (comp (partial = app-id) :id) (:apps listing))))
@@ -443,6 +444,6 @@
     (is (not (contains-app? (:id app) (:apps old-listing))))
     (pc/grant-permission (config/permissions-client) "app" (:id app) "user" (:shortUsername testde2) "read")
     (let [new-listing (shared-apps testde2)]
-      (is (= (inc (:app_count old-listing)) (:app_count new-listing)))
+      (is (= (inc (:total old-listing)) (:total new-listing)))
       (is (contains-app? (:id app) (:apps new-listing))))
     (permanently-delete-app testde1 de-system-id (:id app))))

--- a/test/apps/service/apps/test_fixtures.clj
+++ b/test/apps/service/apps/test_fixtures.clj
@@ -129,6 +129,7 @@
                  (sql/join [:app_categories :c] {:aca.app_category_id :c.id})
                  (sql/fields :aca.app_id)))
 
+;; FIXME the Beta category is obsolete
 (defn load-beta-apps
   "For the purposes of integration tests, any app that is integrated by either 'Default DE Tools' or 'Internal
    DE Tools' is considered to be public by default."


### PR DESCRIPTION
This PR introduces 2 major changes for app listing responses:

1.  Allows sorting results under the `job_stats` and `rating` fields and fixes combined app sorting for fields with number values (such as job counts).
2. Renames the `app_count` field to `total` since this is what the UI expects for paging results.

The swagger docs of the `GET /admin/apps` and `GET /apps` endpoints were also updated to enumerate their valid sort fields.

This PR also requires changes from cyverse-de/mescal#2.