### PR TITLE
CORE-3957 Update GET /admin/apps to include deleted apps.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [metosin/compojure-api "1.1.8"]
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "2.8.1"]
-                 [org.cyverse/kameleon "2.8.3-SNAPSHOT"]
+                 [org.cyverse/kameleon "2.8.3"]
                  [org.cyverse/mescal "2.8.1"]
                  [org.cyverse/metadata-client "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -378,7 +378,8 @@
         perms          (perms-client/load-app-permissions shortUsername)
         params         (fix-sort-params (augment-listing-params params shortUsername perms))
         params         (augment-search-params search_term params shortUsername admin?)
-        total          (count-apps-for-user search_term (:id workspace) params)
+        count-apps-fn  (if admin? count-apps-for-admin count-apps-for-user)
+        total          (count-apps-fn search_term (:id workspace) params)
         app-listing-fn (if admin? get-apps-for-admin get-apps-for-user)
         apps           (app-listing-fn search_term
                                        workspace

--- a/test/apps/service/apps/public_apps_test.clj
+++ b/test/apps/service/apps/public_apps_test.clj
@@ -15,6 +15,14 @@
 (use-fixtures :once tf/run-integration-tests tf/with-test-db tf/with-config atf/with-workspaces)
 (use-fixtures :each atf/with-public-apps atf/with-test-app atf/with-test-tool)
 
+(defn- list-apps
+  [user category-id]
+  (:apps (apps/list-apps-in-category user category-id {})))
+
+(defn- find-app
+  [{app-id :id} apps]
+  (filter (comp (partial = app-id) :id) apps))
+
 ;; FIXME the Beta category is obsolete
 (deftest test-marked-as-public
   (let [user        (get-user :testde1)
@@ -23,13 +31,13 @@
         _           (apps/make-app-public user app)
         ;FIXME listed      (first (:apps (apps/search-apps user {:search (:name app)})))
         beta-id     (:id (atf/get-beta-category user))
-        apps        (:apps (apps/list-apps-in-category user beta-id {}))
-        public-apps (:apps (apps/list-apps-in-category user my-public-apps-id {}))
-        listed      (first (filter (comp (partial = (:id app)) :id) public-apps))]
+        apps        (list-apps user beta-id)
+        public-apps (list-apps user my-public-apps-id)
+        listed      (first (find-app app public-apps))]
     (is (not (nil? listed)))
     (is (:is_public listed))
-    (is (empty? (filter (comp (partial = (:id app)) :id) apps)))
-    (is (seq (filter (comp (partial = (:id app)) :id) public-apps)))
+    (is (empty? (find-app app apps)))
+    (is (seq (find-app app public-apps)))
     (permanently-delete-app user de-system-id (:id app) true)))
 
 (deftest test-publishable
@@ -53,11 +61,11 @@
     (permanently-delete-app user de-system-id (:id app) true)))
 
 (deftest validate-app-trash
-  (let [user  (get-user :testde1)
-        app   (atf/create-test-app user "To be published")
-        _     (sql/delete :app_documentation (sql/where {:app_id (:id app)}))
-        _     (apps/make-app-public user app)
-        _     (apps/admin-delete-app user (:id app))
-        trash (:apps (apps/list-apps-in-category user trash-category-id {}))]
-    (is (seq (filter (comp (partial = (:id app)) :id) trash)))
+  (let [user (get-user :testde1)
+        app (atf/create-test-app user "To be published")]
+    (sql/delete :app_documentation (sql/where {:app_id (:id app)}))
+    (apps/make-app-public user app)
+    (is (empty? (find-app app (list-apps user trash-category-id))))
+    (apps/admin-delete-app user (:id app))
+    (is (seq (find-app app (list-apps user trash-category-id))))
     (permanently-delete-app user de-system-id (:id app) true)))


### PR DESCRIPTION
Updated `apps.service.apps.de.listings/list-apps` to use the new `kameleon.app-listing/count-apps-for-admin` function added by cyverse-de/kameleon#5.

This new function, along with the updated `kameleon.app-listing/get-apps-for-admin` function, allows deleted apps to be returned in the results for admins.