### PR TITLE
CORE-7813 Add auth_redirect to /users/login response.

### DIFF
--- a/src/apps/routes/oauth.clj
+++ b/src/apps/routes/oauth.clj
@@ -22,8 +22,8 @@
     (ok (oauth/get-token-info api-name current-user)))
 
   (GET "/redirect-uris" []
-    :query   [params SecuredQueryParams]
-    :return  (doc-only RedirectUris RedirectUrisDoc)
+    :query [params SecuredQueryParams]
+    :return RedirectUrisResponse
     :summary "Return a set of OAuth redirect URIs if the user hasn't authenticated with the remote API yet."
     (ok (oauth/get-redirect-uris current-user))))
 

--- a/src/apps/routes/schemas/oauth.clj
+++ b/src/apps/routes/schemas/oauth.clj
@@ -1,5 +1,5 @@
 (ns apps.routes.schemas.oauth
-  (:use [common-swagger-api.schema :only [describe]])
+  (:use [common-swagger-api.schema :only [describe doc-only]])
   (:require [schema.core :as s]))
 
 (s/defschema OAuthCallbackResponse
@@ -20,3 +20,5 @@
 
 (s/defschema RedirectUrisDoc
   {:api-name (describe String "The redirect URI.")})
+
+(def RedirectUrisResponse (doc-only RedirectUris RedirectUrisDoc))

--- a/src/apps/routes/schemas/user.clj
+++ b/src/apps/routes/schemas/user.clj
@@ -1,6 +1,7 @@
 (ns apps.routes.schemas.user
   (:use [common-swagger-api.schema :only [describe]]
         [apps.routes.params :only [SecuredQueryParams]]
+        [apps.routes.schemas.oauth :only [RedirectUrisResponse]]
         [schema.core :only [defschema]])
   (:import [java.util UUID]))
 
@@ -20,7 +21,8 @@
     :user-agent (describe String "The user agent obtained from the original request.")))
 
 (defschema LoginResponse
-  {:login_time (describe Long "Login time as milliseconds since the epoch.")})
+  {:login_time    (describe Long "Login time as milliseconds since the epoch.")
+   :auth_redirect RedirectUrisResponse})
 
 (defschema LogoutParams
   (assoc SecuredQueryParams

--- a/src/apps/routes/users.clj
+++ b/src/apps/routes/users.clj
@@ -25,8 +25,9 @@
   (POST "/login" []
          :query [params LoginParams]
          :return LoginResponse
-         :summary "Record a User Login"
-         :description "Terrain calls this service to record when a user logs in."
+         :summary "User Login Service"
+         :description "Terrain calls this service to record when a user logs in
+          and to fetch user session info."
          (ok (users/login current-user params)))
 
   (POST "/logout" []

--- a/src/apps/service/users.clj
+++ b/src/apps/service/users.clj
@@ -1,6 +1,7 @@
 (ns apps.service.users
   (:use [apps.util.conversions :only [remove-nil-vals]])
   (:require [kameleon.queries :as kq]
+            [apps.service.oauth :as oauth]
             [apps.persistence.users :as up]))
 
 (defn by-id
@@ -12,8 +13,9 @@
   (remove-nil-vals (up/for-username username)))
 
 (defn login
-  [{:keys [username]} {:keys [ip-address user-agent]}]
-  {:login_time (kq/record-login username ip-address user-agent)})
+  [{:keys [username] :as current-user} {:keys [ip-address user-agent]}]
+  {:login_time (kq/record-login username ip-address user-agent)
+   :auth_redirect (oauth/get-redirect-uris current-user)})
 
 (defn logout
   [{:keys [username]} {:keys [ip-address login-time]}]


### PR DESCRIPTION
This PR combines user login responses for the terrain `bootstrap` endpoint, so it only needs to make 1 call to get both pieces of user "session" info.

This info wasn't combined with the apps `GET /workspaces` endpoint response, since this kind of user info will eventually be moved into a new `user-info` service, and workspaces will likely remain apps service specific.