### PR TITLE
CORE-8455: pass docker registry auth information down to jex-adapter etc.

### DIFF
--- a/src/apps/persistence/docker_registries.clj
+++ b/src/apps/persistence/docker_registries.clj
@@ -1,0 +1,35 @@
+(ns apps.persistence.docker-registries
+  (:use [apps.persistence.entities :only [docker-registries]]
+        [korma.core :exclude [update]]
+        [korma.db :only [transaction]])
+  (:require [korma.core :as sql]))
+
+(defn get-registries
+  []
+  (select docker-registries))
+
+(defn get-registry
+  [name]
+  (first (select docker-registries
+                 (where {:name name}))))
+
+(defn add-registry
+  [name username password]
+  (insert docker-registries
+          (values {:name name
+                   :username username
+                   :password password})))
+
+(defn update-registry
+  [name username password]
+  (sql/update docker-registries (set-fields {:username username :password password}) (where {:name name})))
+
+(defn add-or-update-registry
+  [name username password]
+  (if (get-registry name)
+    (update-registry name username password)
+    (add-registry name username password)))
+
+(defn delete-registry
+  [name]
+  (delete docker-registries (where {:name name})))

--- a/src/apps/persistence/entities.clj
+++ b/src/apps/persistence/entities.clj
@@ -294,3 +294,9 @@
 
 (defentity job-status-updates
   (table :job_status_updates))
+
+;; Docker registry auth information
+(defentity docker-registries
+  (table :docker_registries)
+  (entity-fields :name :username :password [(raw "encode(concat(username, ':', password)::bytea, 'base64')") :auth])
+  (pk :name))


### PR DESCRIPTION
Since the model namespace has been updated, this gets passed the whole way to road-runner. Which, right now, doesn't actually use it. That's next, after cyverse-de/dockerops#1 can be used to do it.

Tested that everything still works properly with this (and made a few small changes to other code to ensure as much).