### PR TITLE
CORE-8487 Update to new protocol version of metadata-client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.cyverse/clojure-commons "2.8.1"]
                  [org.cyverse/kameleon "3.0.0"]
                  [org.cyverse/mescal "2.8.1"]
-                 [org.cyverse/metadata-client "2.8.1"]
+                 [org.cyverse/metadata-client "2.8.2-SNAPSHOT"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/common-cfg "2.8.0"]
                  [org.cyverse/common-swagger-api "2.8.2"]

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.cyverse/clojure-commons "2.8.1"]
                  [org.cyverse/kameleon "3.0.0"]
                  [org.cyverse/mescal "2.8.1"]
-                 [org.cyverse/metadata-client "2.8.2-SNAPSHOT"]
+                 [org.cyverse/metadata-client "3.0.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/common-cfg "2.8.0"]
                  [org.cyverse/common-swagger-api "2.8.2"]

--- a/src/apps/clients/metadata.clj
+++ b/src/apps/clients/metadata.clj
@@ -4,23 +4,25 @@
             [apps.util.config :as config]
             [metadata-client.core :as metadata-client]))
 
+(def app-target-type "app")
+
 (defn filter-by-avus
   [username app-ids avus]
-  (metadata-client/filter-by-avus (config/metadata-client) username ["app"] app-ids avus))
+  (metadata-client/filter-by-avus (config/metadata-client) username [app-target-type] app-ids avus))
 
 (defn list-avus
   ([username app-id]
-   (metadata-client/list-avus (config/metadata-client) username "app" app-id))
+   (metadata-client/list-avus (config/metadata-client) username app-target-type app-id))
   ([username app-id opts]
-   (metadata-client/list-avus (config/metadata-client) username "app" app-id opts)))
+   (metadata-client/list-avus (config/metadata-client) username app-target-type app-id opts)))
 
 (defn update-avus
   [username app-id body]
-  (metadata-client/update-avus (config/metadata-client) username "app" app-id body))
+  (metadata-client/update-avus (config/metadata-client) username app-target-type app-id body))
 
 (defn set-avus
   [username app-id body]
-  (metadata-client/set-avus (config/metadata-client) username "app" app-id body))
+  (metadata-client/set-avus (config/metadata-client) username app-target-type app-id body))
 
 (defn get-active-hierarchy-version
   [& {:keys [validate] :or {validate true}}]
@@ -48,7 +50,7 @@
                                       username
                                       ontology-version
                                       attrs
-                                      "app"
+                                      app-target-type
                                       app-id))
 
 (defn filter-targets-by-ontology-search
@@ -58,7 +60,7 @@
                                                      (get-active-hierarchy-version)
                                                      category-attrs
                                                      search-term
-                                                     ["app"]
+                                                     [app-target-type]
                                                      app-ids))
 
 (defn filter-hierarchy
@@ -68,7 +70,7 @@
                                     ontology-version
                                     root-iri
                                     attr
-                                    ["app"]
+                                    [app-target-type]
                                     app-ids))
 
 (defn filter-hierarchy-targets
@@ -78,7 +80,7 @@
                                             ontology-version
                                             root-iri
                                             attr
-                                            ["app"]
+                                            [app-target-type]
                                             app-ids))
 
 (defn filter-unclassified
@@ -88,5 +90,5 @@
                                        ontology-version
                                        root-iri
                                        attr
-                                       ["app"]
+                                       [app-target-type]
                                        app-ids))

--- a/src/apps/clients/metadata.clj
+++ b/src/apps/clients/metadata.clj
@@ -1,0 +1,92 @@
+(ns apps.clients.metadata
+  (:use [slingshot.slingshot :only [throw+]])
+  (:require [apps.persistence.categories :as db-categories]
+            [apps.util.config :as config]
+            [metadata-client.core :as metadata-client]))
+
+(defn filter-by-avus
+  [username app-ids avus]
+  (metadata-client/filter-by-avus (config/metadata-client) username ["app"] app-ids avus))
+
+(defn list-avus
+  ([username app-id]
+   (metadata-client/list-avus (config/metadata-client) username "app" app-id))
+  ([username app-id opts]
+   (metadata-client/list-avus (config/metadata-client) username "app" app-id opts)))
+
+(defn update-avus
+  [username app-id body]
+  (metadata-client/update-avus (config/metadata-client) username "app" app-id body))
+
+(defn set-avus
+  [username app-id body]
+  (metadata-client/set-avus (config/metadata-client) username "app" app-id body))
+
+(defn get-active-hierarchy-version
+  [& {:keys [validate] :or {validate true}}]
+  (let [version (db-categories/get-active-hierarchy-version)]
+    (when (and validate (empty? version))
+      (throw+ {:type  :clojure-commons.exception/not-found
+               :error "An app hierarchy version has not been set."}))
+    version))
+
+(defn delete-ontology
+  [username ontology-version]
+  (metadata-client/delete-ontology (config/metadata-client) username ontology-version))
+
+(defn list-ontologies
+  [username]
+  (metadata-client/list-ontologies (config/metadata-client) username))
+
+(defn list-hierarchies
+  [username]
+  (metadata-client/list-hierarchies (config/metadata-client) username (get-active-hierarchy-version)))
+
+(defn filter-hierarchies
+  [username ontology-version attrs app-id]
+  (metadata-client/filter-hierarchies (config/metadata-client)
+                                      username
+                                      ontology-version
+                                      attrs
+                                      "app"
+                                      app-id))
+
+(defn filter-targets-by-ontology-search
+  [username category-attrs search-term app-ids]
+  (metadata-client/filter-targets-by-ontology-search (config/metadata-client)
+                                                     username
+                                                     (get-active-hierarchy-version)
+                                                     category-attrs
+                                                     search-term
+                                                     ["app"]
+                                                     app-ids))
+
+(defn filter-hierarchy
+  [username ontology-version root-iri attr app-ids]
+  (metadata-client/filter-hierarchy (config/metadata-client)
+                                    username
+                                    ontology-version
+                                    root-iri
+                                    attr
+                                    ["app"]
+                                    app-ids))
+
+(defn filter-hierarchy-targets
+  [username ontology-version root-iri attr app-ids]
+  (metadata-client/filter-hierarchy-targets (config/metadata-client)
+                                            username
+                                            ontology-version
+                                            root-iri
+                                            attr
+                                            ["app"]
+                                            app-ids))
+
+(defn filter-unclassified
+  [username ontology-version root-iri attr app-ids]
+  (metadata-client/filter-unclassified (config/metadata-client)
+                                       username
+                                       ontology-version
+                                       root-iri
+                                       attr
+                                       ["app"]
+                                       app-ids))

--- a/src/apps/metadata/avus.clj
+++ b/src/apps/metadata/avus.clj
@@ -1,16 +1,16 @@
 (ns apps.metadata.avus
-  (:require [apps.persistence.app-metadata :as app-db]
+  (:require [apps.clients.metadata :as metadata-client]
+            [apps.persistence.app-metadata :as app-db]
             [apps.service.apps.de.categorization :as categorization]
             [apps.service.apps.de.validation :as validation]
             [apps.util.service :as service]
-            [cheshire.core :as json]
-            [metadata-client.core :as metadata-client]))
+            [cheshire.core :as json]))
 
 (defn list-avus
   [{username :shortUsername :as user} app-id admin?]
   (let [app (app-db/get-app app-id)]
     (validation/verify-app-permission user app "read" admin?)
-    (metadata-client/list-avus username "app" app-id)))
+    (metadata-client/list-avus username app-id)))
 
 (defn set-avus
   [{username :shortUsername :as user} app-id body admin?]
@@ -18,7 +18,7 @@
         request (service/parse-json body)]
     (validation/verify-app-permission user app "write" admin?)
     (categorization/validate-app-name-in-hierarchy-avus username app-id app-name (:avus request))
-    (metadata-client/set-avus username "app" app-id (json/encode request))))
+    (metadata-client/set-avus username app-id (json/encode request))))
 
 (defn update-avus
   [{username :shortUsername :as user} app-id body admin?]
@@ -26,4 +26,4 @@
         request (service/parse-json body)]
     (validation/verify-app-permission user app "write" admin?)
     (categorization/validate-app-name-in-hierarchy-avus username app-id app-name (:avus request))
-    (metadata-client/update-avus username "app" app-id (json/encode request))))
+    (metadata-client/update-avus username app-id (json/encode request))))

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -7,7 +7,6 @@
                                                 replace-reference-genomes
                                                 update-reference-genome]]
         [apps.metadata.tool-requests]
-        [apps.routes.middleware :only [wrap-metadata-base-url]]
         [apps.routes.params]
         [apps.routes.schemas.app]
         [apps.routes.schemas.app.category]
@@ -53,7 +52,6 @@
 (defroutes admin-apps
   (GET "/" []
        :query [params AdminAppSearchParams]
-       :middleware [wrap-metadata-base-url]
        :summary "List Apps"
        :return AdminAppListing
        :description
@@ -101,7 +99,6 @@
           :query [params SecuredQueryParams]
           :body [body (describe AdminAppPatchRequest "The App to update.")]
           :return AdminAppDetails
-          :middleware [wrap-metadata-base-url]
           :summary "Update App Details and Labels"
           :description (str
 "This service is capable of updating high-level information of an App,
@@ -130,7 +127,6 @@
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParams]
         :return AdminAppDetails
-        :middleware [wrap-metadata-base-url]
         :summary "Get App Details"
         :description (str
 "This service allows administrative users to view detailed informaiton about private apps."
@@ -223,7 +219,6 @@
   (GET "/" []
         :query [params SecuredQueryParams]
         :return ActiveOntologyDetailsList
-        :middleware [wrap-metadata-base-url]
         :summary "List Ontology Details"
         :description (str
 "Lists Ontology details saved in the metadata service."
@@ -235,7 +230,6 @@
   (DELETE "/:ontology-version" []
            :path-params [ontology-version :- OntologyVersionParam]
            :query [params SecuredQueryParams]
-           :middleware [wrap-metadata-base-url]
            :summary "Delete an Ontology"
            :description (str
 "Marks an Ontology as deleted in the metadata service.
@@ -259,7 +253,6 @@
         :path-params [ontology-version :- OntologyVersionParam
                       root-iri :- OntologyClassIRIParam]
         :query [{:keys [attr] :as params} OntologyHierarchyFilterParams]
-        :middleware [wrap-metadata-base-url]
         :summary "Get App Category Hierarchy"
         :description (str
 "Gets the list of app categories that are visible to the user for the given `ontology-version`,
@@ -274,7 +267,6 @@
         :path-params [ontology-version :- OntologyVersionParam
                       root-iri :- OntologyClassIRIParam]
         :query [{:keys [attr] :as params} AdminOntologyAppListingPagingParams]
-        :middleware [wrap-metadata-base-url]
         :return AdminAppListing
         :summary "List Apps in a Category"
         :description (str
@@ -291,7 +283,6 @@
                       root-iri :- OntologyClassIRIParam]
         :query [{:keys [attr] :as params} AdminOntologyAppListingPagingParams]
         :return AdminAppListing
-        :middleware [wrap-metadata-base-url]
         :summary "List Unclassified Apps"
         :description (str
 "Lists all of the apps that are visible to the user that are not under the given `root-iri`, or any of

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -1,7 +1,6 @@
 (ns apps.routes.apps
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
-        [apps.routes.middleware :only [wrap-metadata-base-url]]
         [apps.routes.params]
         [apps.routes.schemas.app]
         [apps.routes.schemas.app.rating]
@@ -16,7 +15,6 @@
 (defroutes apps
   (GET "/" []
     :query [params AppSearchParams]
-    :middleware [wrap-metadata-base-url]
     :summary "List Apps"
     :return AppListing
     :description
@@ -125,7 +123,6 @@
     :query [params SecuredQueryParamsEmailRequired]
     :body [body (describe App "The App to update.")]
     :return App
-    :middleware [wrap-metadata-base-url]
     :summary "Update App Labels"
     :description
     (str "This service is capable of updating just the labels within a single-step app,
@@ -151,7 +148,6 @@
     :query [params SecuredQueryParamsEmailRequired]
     :body [body (describe AppRequest "The App to update.")]
     :return App
-    :middleware [wrap-metadata-base-url]
     :summary "Update an App"
     :description
     (str "This service updates a single-step App in the database, as long as the App has not been submitted
@@ -186,7 +182,6 @@
     :path-params [app-id :- AppIdJobViewPathParam]
     :query [params SecuredQueryParams]
     :return AppDetails
-    :middleware [wrap-metadata-base-url]
     :summary "Get App Details"
     :description
     (str "This service is used by the DE to obtain high-level details about a single App."
@@ -255,7 +250,6 @@
   (POST "/:app-id/publish" []
     :path-params [app-id :- AppIdPathParam]
     :query [params SecuredQueryParamsEmailRequired]
-    :middleware [wrap-metadata-base-url]
     :body [body (describe PublishAppRequest "The user's Publish App Request.")]
     :summary "Submit an App for Public Use"
     :description "This service can be used to submit a private App for public use. The user supplies
@@ -366,7 +360,6 @@
         :query [params SecuredQueryParamsEmailRequired]
         :body [body (describe App "The App to update.")]
         :return App
-        :middleware [wrap-metadata-base-url]
         :summary "Update App Labels"
         :description
         (str "This service is capable of updating just the labels within a single-step app,
@@ -391,7 +384,6 @@
         :query [params SecuredQueryParamsEmailRequired]
         :body [body (describe AppRequest "The App to update.")]
         :return App
-        :middleware [wrap-metadata-base-url]
         :summary "Update an App"
         :description
         (str "This service updates a single-step App in the database, as long as the App has not been submitted
@@ -423,7 +415,6 @@
       (GET "/details" []
         :query [params SecuredQueryParams]
         :return AppDetails
-        :middleware [wrap-metadata-base-url]
         :summary "Get App Details"
         :description
         (str "This service is used by the DE to obtain high-level details about a single App."

--- a/src/apps/routes/apps/categories.clj
+++ b/src/apps/routes/apps/categories.clj
@@ -2,7 +2,6 @@
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
         [common-swagger-api.schema.ontologies]
-        [apps.routes.middleware :only [wrap-metadata-base-url]]
         [apps.routes.params]
         [apps.routes.schemas.app :only [AppListing
                                         AppListingPagingParams]]
@@ -27,7 +26,6 @@
   (GET "/:category-id" []
         :path-params [category-id :- AppCategoryIdPathParam]
         :query [params AppListingPagingParams]
-        :middleware [wrap-metadata-base-url]
         :return AppCategoryAppListing
         :summary "List Apps in a Category"
         :description "This service lists all of the apps within an app category or any of its
@@ -44,7 +42,6 @@
 
   (GET "/" []
         :query [params SecuredQueryParams]
-        :middleware [wrap-metadata-base-url]
         :summary "List App Hierarchies"
         :description (str
 "Lists all hierarchies saved for the active ontology version."
@@ -57,7 +54,6 @@
   (GET "/:root-iri" []
         :path-params [root-iri :- OntologyClassIRIParam]
         :query [{:keys [attr]} OntologyHierarchyFilterParams]
-        :middleware [wrap-metadata-base-url]
         :summary "List App Category Hierarchy"
         :description (str
 "Gets the list of app categories that are visible to the user for the active ontology version,
@@ -71,7 +67,6 @@
   (GET "/:root-iri/apps" []
         :path-params [root-iri :- OntologyClassIRIParam]
         :query [{:keys [attr] :as params} OntologyAppListingPagingParams]
-        :middleware [wrap-metadata-base-url]
         :return AppListing
         :summary "List Apps in a Category"
         :description (str
@@ -85,7 +80,6 @@
         :path-params [root-iri :- OntologyClassIRIParam]
         :query [{:keys [attr] :as params} OntologyAppListingPagingParams]
         :return AppListing
-        :middleware [wrap-metadata-base-url]
         :summary "List Unclassified Apps"
         :description (str
 "Lists all of the apps that are visible to the user that are not under the given app category or any of

--- a/src/apps/routes/apps/metadata.clj
+++ b/src/apps/routes/apps/metadata.clj
@@ -1,7 +1,6 @@
 (ns apps.routes.apps.metadata
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
-        [apps.routes.middleware :only [wrap-metadata-base-url]]
         [apps.routes.params]
         [apps.user :only [current-user]])
   (:require [apps.metadata.avus :as avus]
@@ -13,7 +12,6 @@
   (GET "/" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParams]
-        :middleware [wrap-metadata-base-url]
         :summary "View all Metadata AVUs"
         :description (str
 "Lists all AVUs associated with an app.
@@ -28,7 +26,6 @@ Please see the metadata service documentation for response information.")
   (POST "/" [:as {:keys [body]}]
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParams]
-         :middleware [wrap-metadata-base-url]
          :summary "Add/Update Metadata AVUs"
          :description (str
 "Adds or updates Metadata AVUs on the app.
@@ -48,7 +45,6 @@ Please see the metadata service documentation for request and response informati
   (PUT "/" [:as {:keys [body]}]
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParams]
-        :middleware [wrap-metadata-base-url]
         :summary "Set Metadata AVUs"
         :description (str
 "Sets Metadata AVUs on the app.
@@ -72,7 +68,6 @@ Please see the metadata service documentation for request and response informati
   (GET "/" []
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParams]
-        :middleware [wrap-metadata-base-url]
         :summary "View all Metadata AVUs"
         :description (str
 "Lists all AVUs associated with the app."
@@ -86,7 +81,6 @@ Please see the metadata service documentation for response information.")
   (POST "/" [:as {:keys [body]}]
          :path-params [app-id :- AppIdPathParam]
          :query [params SecuredQueryParams]
-         :middleware [wrap-metadata-base-url]
          :summary "Add/Update Metadata AVUs"
          :description (str
 "Adds or updates Metadata AVUs on the app.
@@ -105,7 +99,6 @@ Please see the metadata service documentation for request and response informati
   (PUT "/" [:as {:keys [body]}]
         :path-params [app-id :- AppIdPathParam]
         :query [params SecuredQueryParams]
-        :middleware [wrap-metadata-base-url]
         :summary "Set Metadata AVUs"
         :description (str
 "Sets Metadata AVUs on the app.

--- a/src/apps/routes/middleware.clj
+++ b/src/apps/routes/middleware.clj
@@ -1,7 +1,0 @@
-(ns apps.routes.middleware
-  (:require [apps.util.config :as config]
-            [metadata-client.middleware :as client-middleware]))
-
-(defn wrap-metadata-base-url
-  [handler]
-  (client-middleware/wrap-metadata-base-url handler config/metadata-base))

--- a/src/apps/service/apps/de/admin.clj
+++ b/src/apps/service/apps/de/admin.clj
@@ -6,13 +6,13 @@
         [slingshot.slingshot :only [throw+]])
   (:require [clojure.tools.logging :as log]
             [apps.clients.email :as email]
+            [apps.clients.metadata :as metadata-client]
             [apps.persistence.app-groups :as app-groups]
             [apps.persistence.app-metadata :as persistence]
             [apps.persistence.categories :as db-categories]
             [apps.service.apps.de.categorization :as categorization]
             [apps.service.apps.de.validation :as av]
-            [clojure-commons.exception-util :as ex-util]
-            [metadata-client.core :as metadata-client]))
+            [clojure-commons.exception-util :as ex-util]))
 
 (def ^:private max-app-category-name-len 255)
 

--- a/src/apps/service/apps/de/metadata.clj
+++ b/src/apps/service/apps/de/metadata.clj
@@ -12,15 +12,15 @@
         [kameleon.uuids :only [uuidify]]
         [korma.db :only [transaction]]
         [slingshot.slingshot :only [throw+]])
-  (:require [cheshire.core :as cheshire]
-            [clj-http.client :as client]
+  (:require [apps.clients.metadata :as metadata-client]
             [apps.clients.permissions :as perms-client]
             [apps.persistence.app-metadata :as amp]
             [apps.service.apps.de.docs :as app-docs]
             [apps.service.apps.de.permissions :as perms]
             [apps.translations.app-metadata :as atx]
             [apps.util.config :as config]
-            [metadata-client.core :as metadata-client]))
+            [cheshire.core :as cheshire]
+            [clj-http.client :as client]))
 
 (defn- validate-app-existence
   "Verifies that apps exist."
@@ -155,7 +155,7 @@
 (defn- publish-app-metadata
   [username app-id avus]
   (let [body (cheshire/encode {:avus (conj avus (beta-avu))})]
-    (metadata-client/update-avus username "app" app-id body)))
+    (metadata-client/update-avus username app-id body)))
 
 (defn- publish-app
   [{:keys [shortUsername] :as user} {app-id :id :keys [references avus] :as app}]

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -6,6 +6,7 @@
             [clojure-commons.config :as cc]
             [clojure.tools.logging :as log]
             [common-cfg.cfg :as cfg]
+            [metadata-client.core :as metadata-client]
             [permissions-client.core :as pc]))
 
 (def docs-uri "/docs")
@@ -354,6 +355,9 @@
 
 (def permissions-client
   (memoize #(pc/new-permissions-client (permissions-base))))
+
+(def metadata-client
+  (memoize #(metadata-client/new-metadata-client (metadata-base))))
 
 (defn app-resource-type
   "The app resource type name. This value is hard-coded for now, but placed in this namespace so that we can easily

--- a/test/apps/test_fixtures.clj
+++ b/test/apps/test_fixtures.clj
@@ -8,10 +8,7 @@
             [apps.util.service :as service]
             [cemerick.url :as curl]
             [clj-http.client :as http]
-            [clojure.java.io :as io]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [metadata-client.core :as metadata-client]))
+            [clojure.java.io :as io]))
 
 (def default-config-path "/etc/iplant/de/apps.properties")
 (def default-db-uri "jdbc:postgresql://dedb/de?user=de&password=notprod")
@@ -24,7 +21,7 @@
   (let [config-path (getenv "APPS_CONFIG_PATH" default-config-path)]
     (require 'apps.util.config :reload)
     (apps.util.config/load-config-from-file config-path {:log-config? false})
-    (metadata-client/with-metadata-base (config/metadata-base) (f))))
+    (f)))
 
 (defn with-test-db [f]
   (default-connection (create-db {:connection-uri (or (System/getenv "DBURI") default-db-uri)}))


### PR DESCRIPTION
Updates for the new protocol version of `metadata-client` added by cyverse-de/metadata-client#1.

Includes a new `apps.clients.metadata` namespace to facade calls to `metadata-client` with common apps service parameters.