### PR TITLE
Add the system ID to all non-admin apps endpoints.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build.xml
 *.class
 GIT_COMMIT
 VERSION
+Dockerfile.local

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "2.8.2-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.0"]
-                 [org.cyverse/mescal "2.8.1"]
+                 [org.cyverse/mescal "2.8.2-SNAPSHOT"]
                  [org.cyverse/metadata-client "3.0.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/common-cfg "2.8.0"]

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [medley "0.8.2"]
                  [metosin/compojure-api "1.1.8"]
                  [org.cyverse/authy "2.8.0"]
-                 [org.cyverse/clojure-commons "2.8.1"]
+                 [org.cyverse/clojure-commons "2.8.2-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.0"]
                  [org.cyverse/mescal "2.8.1"]
                  [org.cyverse/metadata-client "3.0.0"]

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -483,9 +483,10 @@
    (dorun (map (partial add-app-reference app-id) references))))
 
 (defn- get-job-type-id-for-system [system-id]
-  (let [job-types (:id (first (select :job_types (fields :id) (where {:system_id system-id}))))]
-    (when (nil? job-types)
-      (cxu/bad-request (str "unrecognized system ID: " system-id)))))
+  (let [job-type-id (:id (first (select :job_types (fields :id) (where {:system_id system-id}))))]
+    (when (nil? job-type-id)
+      (cxu/bad-request (str "unrecognized system ID: " system-id)))
+    job-type-id))
 
 (defn add-task
   "Adds a task to the database."

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -591,7 +591,7 @@
 (defn get-app-parameter
   "Fetches an App parameter."
   ([parameter-id]
-   (get-app-parameter ))
+   (first (select parameters (where {:id parameter-id}))))
   ([parameter-id task-id]
    (first (select :task_param_listing (where {:id parameter-id, :task_id task-id})))))
 

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -16,6 +16,7 @@
             [apps.persistence.app-metadata.delete :as delete]
             [apps.persistence.app-metadata.relabel :as relabel]
             [clojure.set :as set]
+            [clojure-commons.exception-util :as cxu]
             [korma.core :as sql]))
 
 (def param-multi-input-type "MultiFileSelector")

--- a/src/apps/persistence/entities.clj
+++ b/src/apps/persistence/entities.clj
@@ -2,7 +2,7 @@
   (:use [korma.core :exclude [update]]))
 
 (declare users collaborator requestor workspace app_categories apps app_references integration_data
-         tools tool_test_data_files output_mapping input_mapping tasks inputs outputs
+         tools tool_test_data_files output_mapping input_mapping tasks job_types inputs outputs
          task_parameters info_type data_formats multiplicity parameter_groups parameters
          parameter_values parameter_types value_type validation_rules validation_rule_arguments
          rule_type rule_subtype app_category_listing app_listing tool_listing ratings collaborators
@@ -115,12 +115,17 @@
 ;; composite primary keys.  In the meantime, we'll have to deal with this table
 ;; in code.
 
+;; A job type indicates primarily where a job will be executed.
+(defentity job_types
+  (table :job_types))
+
 ;; A task defines an interface to a tool that can be called.
 (defentity tasks
   (has-many parameter_groups {:fk :task_id})
   (has-many inputs {:fk :task_id})
   (has-many outputs {:fk :task_id})
-  (has-many task_parameters {:fk :task_id}))
+  (has-many task_parameters {:fk :task_id})
+  (belongs-to job_types {:fk :job_type_id}))
 
 ;; Input and output definitions. Once again, multiple entities are associated
 ;; with the same table to allow us to define multiple relationships between

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -215,7 +215,7 @@
   [{system-id :system_id username :username :as job-info} submission]
   (-> (select-keys job-info job-fields)
       (assoc :job_type_id (job-type-id-from-system-id system-id)
-             :user-id     (get-user-id username))
+             :user_id     (get-user-id username))
       remove-nil-values
       (save-job-with-submission (cheshire/encode submission))))
 

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -296,37 +296,37 @@
   "The base query used for retrieving job information from the database."
   []
   (-> (select* [:job_listings :j])
-      (fields [:j.app_description    :app-description]
-              [:j.system_id          :system_id]
-              [:j.app_id             :app-id]
-              [:j.app_name           :app-name]
-              [:j.job_description    :description]
-              [:j.end_date           :end-date]
-              [:j.id                 :id]
-              [:j.job_name           :job-name]
-              [:j.result_folder_path :result-folder-path]
-              [:j.start_date         :start-date]
-              [:j.status             :status]
-              [:j.username           :username]
-              [:j.app_wiki_url       :app-wiki-url]
-              [:j.job_type           :job-type]
-              [:j.parent_id          :parent-id]
-              [:j.is_batch           :is-batch]
-              [:j.notify             :notify])))
+      (fields :j.app_description
+              :j.system_id
+              :j.app_id
+              :j.app_name
+              [:j.job_description :description]
+              :j.end_date
+              :j.id
+              :j.job_name
+              :j.result_folder_path
+              :j.start_date
+              :j.status
+              :j.username
+              :j.app_wiki_url
+              :j.job_type
+              :j.parent_id
+              :j.is_batch
+              :j.notify)))
 
 (defn- job-step-base-query
   "The base query used for retrieving job step information from the database."
   []
   (-> (select* [:job_steps :s])
       (join :inner [:job_types :t] {:s.job_type_id :t.id})
-      (fields [:s.job_id          :job-id]
-              [:s.step_number     :step-number]
-              [:s.external_id     :external-id]
-              [:s.start_date      :start-date]
-              [:s.end_date        :end-date]
-              [:s.status          :status]
-              [:t.name            :job-type]
-              [:s.app_step_number :app-step-number])))
+      (fields :s.job_id
+              :s.step_number
+              :s.external_id
+              :s.start_date
+              :s.end_date
+              :s.status
+              [:t.name :job_type]
+              :s.app_step_number)))
 
 (defn get-job-step
   "Retrieves a single job step from the database."
@@ -401,20 +401,20 @@
   "Retrieves a job by its internal identifier, placing a lock on the row."
   [id]
   (-> (select* [:jobs :j])
-      (fields [:j.app_description    :app-description]
-              [:j.app_id             :app-id]
-              [:j.app_name           :app-name]
-              [:j.job_description    :description]
-              [:j.end_date           :end-date]
-              [:j.id                 :id]
-              [:j.job_name           :job-name]
-              [:j.result_folder_path :result-folder-path]
-              [:j.start_date         :start-date]
-              [:j.status             :status]
-              [:j.notify             :notify]
-              [:j.app_wiki_url       :app-wiki-url]
+      (fields :j.app_description
+              :j.app_id
+              :j.app_name
+              [:j.job_description   :description]
+              :j.end_date
+              :j.id
+              :j.job_name
+              :j.result_folder_path
+              :j.start_date
+              :j.status
+              :j.notify
+              :j.app_wiki_url
               [:j.submission         :submission]
-              [:j.parent_id          :parent-id])
+              :j.parent_id)
       (where {:j.id id})
       (#(str (as-sql %) " for update"))
       (#(exec-raw [% [id]] :results))
@@ -423,9 +423,9 @@
 (defn- distinct-job-step-types
   "Obtains the list of distinct job step types associated with a job."
   [job-id]
-  (map :job-type (select [:job_steps :s]
+  (map :job_type (select [:job_steps :s]
                          (join [:job_types :t] {:s.job_type_id :t.id})
-                         (fields [:t.name :job-type])
+                         (fields [:t.name :job_type])
                          (modifier "DISTINCT")
                          (where {:s.job_id job-id}))))
 
@@ -461,7 +461,7 @@
   [id]
   (when-let [job (lock-job* id)]
     (assoc job
-      :job-type (determine-job-type id)
+      :job_type (determine-job-type id)
       :username (determine-job-username id))))
 
 (defn- lock-job-step*
@@ -469,13 +469,13 @@
    the row."
   [job-id external-id]
   (-> (select* [:job_steps :s])
-      (fields [:s.job_id          :job-id]
-              [:s.step_number     :step-number]
-              [:s.external_id     :external-id]
-              [:s.start_date      :start-date]
-              [:s.end_date        :end-date]
-              [:s.status          :status]
-              [:s.app_step_number :app-step-number])
+      (fields :s.job_id
+              :s.step_number
+              :s.external_id
+              :s.start_date
+              :s.end_date
+              :s.status
+              :s.app_step_number)
       (where (and {:s.job_id      job-id}
                   {:s.external_id external-id}))
       (#(str (as-sql %) " for update"))
@@ -485,10 +485,10 @@
 (defn- determine-job-step-type
   "Dtermines the job type associated with a job step in the database."
   [job-id external-id]
-  ((comp :job-type first)
+  ((comp :job_type first)
    (select [:job_steps :s]
            (join [:job_types :t] {:s.job_type_id :t.id})
-           (fields [:t.name :job-type])
+           (fields [:t.name :job_type])
            (where {:s.job_id      job-id
                    :s.external_id external-id}))))
 
@@ -501,32 +501,32 @@
    should be locked first."
   [job-id external-id]
   (when-let [job-step (lock-job-step* job-id external-id)]
-    (assoc job-step :job-type (determine-job-step-type job-id external-id))))
+    (assoc job-step :job_type (determine-job-step-type job-id external-id))))
 
 (defn update-job
   "Updates an existing job in the database."
-  ([id {:keys [status end-date deleted name description]}]
-     (when (or status end-date deleted name description)
+  ([id {:keys [status end_date deleted name description]}]
+     (when (or status end_date deleted name description)
        (sql/update :jobs
          (set-fields (remove-nil-values {:status          status
-                                         :end_date        end-date
+                                         :end_date        end_date
                                          :deleted         deleted
                                          :job_name        name
                                          :job_description description}))
          (where {:id id}))))
   ([id status end-date]
      (update-job id {:status   status
-                     :end-date end-date})))
+                     :end_date end-date})))
 
 (defn update-job-step-number
   "Updates an existing job step in the database using the job ID and the step number as keys."
-  [job-id step-number {:keys [external-id status end-date start-date]}]
-  (when (or external-id status end-date start-date)
+  [job-id step-number {:keys [external_id status end_date start_date]}]
+  (when (or external_id status end_date start_date)
     (sql/update :job_steps
-      (set-fields (remove-nil-values {:external_id external-id
+      (set-fields (remove-nil-values {:external_id external_id
                                       :status      status
-                                      :end_date    end-date
-                                      :start_date  start-date}))
+                                      :end_date    end_date
+                                      :start_date  start_date}))
       (where {:job_id      job-id
               :step_number step-number}))))
 
@@ -594,7 +594,7 @@
   [job-ids]
   (select (job-step-base-query)
           (join :inner [:jobs :j] {:s.job_id :j.id})
-          (fields [:j.parent_id :parent-id])
+          (fields :j.parent_id)
           (where (or {:job_id [in job-ids]}
                      {:job_id [in (child-job-subselect job-ids)]}))))
 

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -121,7 +121,7 @@
         (apply-ownership-filter username (filter ownership-filter? query-filter)))))
 
 (defn- job-type-id-from-system-id [system-id]
-  (or ((comp :id first) (select :job_types (wheere {:system_id system-id})))
+  (or ((comp :id first) (select :job_types (where {:system_id system-id})))
       (cxu/bad-request (str "unrecognized system ID: " system-id))))
 
 (defn- get-job-type-id
@@ -235,7 +235,7 @@
   (-> (select-keys job-step-info job-step-fields)
       (assoc :job_type_id (get-job-type-id job-type))
       remove-nil-values
-      (#(insert :job_steps (values %1))))
+      (#(insert :job_steps (values %1)))))
 
 (defn save-multistep-job
   [job-info job-steps submission]

--- a/src/apps/protocols.clj
+++ b/src/apps/protocols.clj
@@ -42,7 +42,7 @@
   (editPipeline [_ app-id])
   (listJobs [_ params])
   (loadAppTables [_ app-ids])
-  (submitJob [_ submission] [_ system-id submission])
+  (submitJob [_ submission])
   (submitJobStep [_ job-id submission])
   (translateJobStatus [_ job-type status])
   (updateJobStatus [_ job-step job status end-date])

--- a/src/apps/protocols.clj
+++ b/src/apps/protocols.clj
@@ -35,7 +35,7 @@
   (getAppToolListing [_ app-id] [_ system-id app-id])
   (getAppUi [_ app-id] [_ system-id app-id])
   (getAppInputIds [_ app-id] [_ system-id app-id])
-  (addPipeline [_ pipeline] [_ system-id pipeline])
+  (addPipeline [_ pipeline])
   (formatPipelineTasks [_ pipeline])
   (updatePipeline [_ pipeline])
   (copyPipeline [_ app-id])

--- a/src/apps/routes.clj
+++ b/src/apps/routes.clj
@@ -102,9 +102,6 @@
     (context "/apps/:app-id/metadata" []
       :tags ["app-metadata"]
       metadata-routes/app-metadata)
-    (context "/apps" []
-      :tags ["apps"]
-      app-routes/apps)
     (context "/analyses" []
       :tags ["analyses"]
       analysis-routes/analyses)

--- a/src/apps/routes.clj
+++ b/src/apps/routes.clj
@@ -96,6 +96,9 @@
     (context "/apps/pipelines" []
       :tags ["pipelines"]
       pipeline-routes/pipelines)
+    (context "/apps" []
+      :tags ["apps"]
+      app-routes/apps)
     (context "/apps/:app-id/metadata" []
       :tags ["app-metadata"]
       metadata-routes/app-metadata)

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -485,4 +485,14 @@
         the means to store the App rating. This service accepts a rating level between one and
         five, inclusive, and a comment identifier that refers to a comment in iPlant's Confluence
         wiki. The rating is stored in the database and associated with the authenticated user."
-        (ok (apps/rate-app current-user system-id app-id body))))))
+        (ok (apps/rate-app current-user system-id app-id body)))
+
+      (GET "/tasks" []
+        :query [params SecuredQueryParams]
+        :return AppTaskListing
+        :summary "List Tasks with File Parameters in an App"
+        :description "When a pipeline is being created, the UI needs to know what types of files are
+        consumed by and what types of files are produced by each App's task in the pipeline. This
+        service provides that information."
+        (ok (coerce! AppTaskListing
+                     (apps/get-app-task-listing current-user system-id app-id)))))))

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -504,4 +504,13 @@
         :description "This service lists information for all of the tools that are associated with an App.
         This information used to be included in the results of the App listing service."
         (ok (coerce! NewToolListing
-                     (apps/get-app-tool-listing current-user system-id app-id)))))))
+                     (apps/get-app-tool-listing current-user system-id app-id))))
+
+      (GET "/ui" []
+        :query [params SecuredQueryParamsEmailRequired]
+        :return App
+        :summary "Make an App Available for Editing"
+        :description "The app integration utility in the DE uses this service to obtain the App
+        description JSON so that it can be edited. The App must have been integrated by the
+        requesting user."
+        (ok (apps/get-app-ui current-user system-id app-id))))))

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -466,4 +466,23 @@
         information and suggested location then places the App in the Beta category. A Tito
         administrator can subsequently move the App to the suggested location at a later time if it
         proves to be useful."
-        (ok (apps/make-app-public current-user system-id (assoc body :id app-id)))))))
+        (ok (apps/make-app-public current-user system-id (assoc body :id app-id))))
+
+      (DELETE "/rating" []
+        :query [params SecuredQueryParams]
+        :return RatingResponse
+        :summary "Delete an App Rating"
+        :description "The DE uses this service to remove a rating that a user has previously made. This
+        service deletes the authenticated user's rating for the corresponding app-id."
+        (ok (apps/delete-app-rating current-user system-id app-id)))
+
+      (POST "/rating" []
+        :query [params SecuredQueryParams]
+        :body [body (describe RatingRequest "The user's new rating for this App.")]
+        :return RatingResponse
+        :summary "Rate an App"
+        :description "Users have the ability to rate an App for its usefulness, and this service provides
+        the means to store the App rating. This service accepts a rating level between one and
+        five, inclusive, and a comment identifier that refers to a comment in iPlant's Confluence
+        wiki. The rating is stored in the database and associated with the authenticated user."
+        (ok (apps/rate-app current-user system-id app-id body))))))

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -458,7 +458,6 @@
 
       (POST "/publish" []
         :query [params SecuredQueryParamsEmailRequired]
-        :middleware [wrap-metadata-base-url]
         :body [body (describe PublishAppRequest "The user's Publish App Request.")]
         :summary "Submit an App for Public Use"
         :description "This service can be used to submit a private App for public use. The user supplies

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -495,4 +495,13 @@
         consumed by and what types of files are produced by each App's task in the pipeline. This
         service provides that information."
         (ok (coerce! AppTaskListing
-                     (apps/get-app-task-listing current-user system-id app-id)))))))
+                     (apps/get-app-task-listing current-user system-id app-id))))
+
+      (GET "/tools" []
+        :query [params SecuredQueryParams]
+        :return NewToolListing
+        :summary "List Tools used by an App"
+        :description "This service lists information for all of the tools that are associated with an App.
+        This information used to be included in the results of the App listing service."
+        (ok (coerce! NewToolListing
+                     (apps/get-app-tool-listing current-user system-id app-id)))))))

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -454,4 +454,16 @@
         :description "A multi-step App can't be made public if any of the Tasks that are included in it
         are not public. This endpoint returns a true flag if the App is a single-step App or it's a
         multistep App in which all of the Tasks included in the pipeline are public."
-        (ok (apps/app-publishable? current-user system-id app-id))))))
+        (ok (apps/app-publishable? current-user system-id app-id)))
+
+      (POST "/publish" []
+        :query [params SecuredQueryParamsEmailRequired]
+        :middleware [wrap-metadata-base-url]
+        :body [body (describe PublishAppRequest "The user's Publish App Request.")]
+        :summary "Submit an App for Public Use"
+        :description "This service can be used to submit a private App for public use. The user supplies
+        basic information about the App and a suggested location for it. The service records the
+        information and suggested location then places the App in the Beta category. A Tito
+        administrator can subsequently move the App to the suggested location at a later time if it
+        proves to be useful."
+        (ok (apps/make-app-public current-user system-id (assoc body :id app-id)))))))

--- a/src/apps/routes/schemas/analysis.clj
+++ b/src/apps/routes/schemas/analysis.clj
@@ -57,7 +57,10 @@
   {(describe Keyword "The step-ID_param-ID") (describe Any "The param-value")})
 
 (defschema AnalysisSubmission
-  {:app_id
+  {:system_id
+   SystemId
+
+   :app_id
    (describe String "The ID of the app used to perform the analysis.")
 
    (optional-key :job_id)

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -219,7 +219,8 @@
    :required    (describe Boolean "Whether or not a value is required for this Parameter")})
 
 (defschema AppTask
-  {:id          (describe String "The Task's ID")
+  {:system_id   (describe String "The Task's System ID")
+   :id          (describe String "The Task's ID")
    :name        (describe String "The Task's name")
    :description (describe String "The Task's description")
    :inputs      (describe [AppFileParameterDetails] "The Task's input parameters")

--- a/src/apps/routes/schemas/pipeline.clj
+++ b/src/apps/routes/schemas/pipeline.clj
@@ -20,6 +20,9 @@
    :description
    (describe String "The Step's description")
 
+   :system_id
+   (describe String "The ID of the execution system.")
+
    (optional-key :task_id)
    (describe String "A String referring to either an internal task or an external app. If the
                      string refers to an internal task then this must be a string representation

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -181,7 +181,7 @@
   ([user app-id]
    (.deleteAppRating (get-apps-client user) app-id))
   ([user system-id app-id]
-   (.deleteAppRating (get-apps-client user) app-id)))
+   (.deleteAppRating (get-apps-client user) system-id app-id)))
 
 (defn rate-app
   ([user app-id rating]

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -202,8 +202,10 @@
    (.getAppToolListing (get-apps-client user) system-id app-id)))
 
 (defn get-app-ui
-  [user app-id]
-  (.getAppUi (get-apps-client user) app-id))
+  ([user app-id]
+   (.getAppUi (get-apps-client user) app-id))
+  ([user system-id app-id]
+   (.getAppUi (get-apps-client user) system-id app-id)))
 
 (defn add-pipeline
   [user pipeline]

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -240,21 +240,15 @@
     (cn/send-job-status-update username email job-info)
     (format-job-submission-response job-info)))
 
-(defn check-next-step-submission
-  [job-id external-id]
-  (let [job-step (jobs/lock-job-step job-id external-id)
-        job      (jobs/lock-job job-id)]
-    (.buildNextStepSubmission (get-apps-client-for-username (:username job)) job-step job)))
-
 (defn update-job-status
   ([external-id status end-date]
-     (let [{:keys [job-id]} (jobs/get-unique-job-step external-id)]
+     (let [{job-id :job_id} (jobs/get-unique-job-step external-id)]
        (update-job-status job-id external-id status end-date)))
   ([job-id external-id status end-date]
      (transaction
       (let [job-step (jobs/lock-job-step job-id external-id)
             job      (jobs/lock-job job-id)
-            batch    (when-let [parent-id (:parent-id job)] (jobs/lock-job parent-id))]
+            batch    (when-let [parent-id (:parent_id job)] (jobs/lock-job parent-id))]
         (-> (get-apps-client-for-username (:username job))
             (jobs/update-job-status job-step job batch status end-date))))))
 

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -178,12 +178,16 @@
    (.makeAppPublic (get-apps-client user) system-id app)))
 
 (defn delete-app-rating
-  [user app-id]
-  (.deleteAppRating (get-apps-client user) app-id))
+  ([user app-id]
+   (.deleteAppRating (get-apps-client user) app-id))
+  ([user system-id app-id]
+   (.deleteAppRating (get-apps-client user) app-id)))
 
 (defn rate-app
-  [user app-id rating]
-  (.rateApp (get-apps-client user) app-id rating))
+  ([user app-id rating]
+   (.rateApp (get-apps-client user) app-id rating))
+  ([user system-id app-id rating]
+   (.rateApp (get-apps-client user) system-id app-id rating)))
 
 (defn get-app-task-listing
   [user app-id]

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -196,8 +196,10 @@
    (.getAppTaskListing (get-apps-client user) system-id app-id)))
 
 (defn get-app-tool-listing
-  [user app-id]
-  (.getAppToolListing (get-apps-client user) app-id))
+  ([user app-id]
+   (.getAppToolListing (get-apps-client user) app-id))
+  ([user system-id app-id]
+   (.getAppToolListing (get-apps-client user) system-id app-id)))
 
 (defn get-app-ui
   [user app-id]

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -190,8 +190,10 @@
    (.rateApp (get-apps-client user) system-id app-id rating)))
 
 (defn get-app-task-listing
-  [user app-id]
-  (.getAppTaskListing (get-apps-client user) app-id))
+  ([user app-id]
+   (.getAppTaskListing (get-apps-client user) app-id))
+  ([user system-id app-id]
+   (.getAppTaskListing (get-apps-client user) system-id app-id)))
 
 (defn get-app-tool-listing
   [user app-id]

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -172,8 +172,10 @@
    {:publishable (.isAppPublishable (get-apps-client user) system-id app-id)}))
 
 (defn make-app-public
-  [user app]
-  (.makeAppPublic (get-apps-client user) app))
+  ([user app]
+   (.makeAppPublic (get-apps-client user) app))
+  ([user system-id app]
+   (.makeAppPublic (get-apps-client user) system-id app)))
 
 (defn delete-app-rating
   [user app-id]

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -258,11 +258,7 @@
         [])))
 
   (submitJob [this submission]
-    (when-not (util/uuid? (:app_id submission))
-      (agave-jobs/submit agave user submission)))
-
-  (submitJob [this system-id submission]
-    (validate-system-id system-id)
+    (validate-system-id (:system_id submission))
     (agave-jobs/submit agave user submission))
 
   (submitJobStep [_ job-id submission]

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -180,6 +180,14 @@
     (validate-system-id system-id)
     false)
 
+  (makeAppPublic [_ app]
+    (when-not (util/uuid? (:id app))
+      (reject-app-integration-request)))
+
+  (makeAppPublic [_ system-id app]
+    (validate-system-id system-id)
+    (reject-app-integration-request))
+
   (getAppTaskListing [_ app-id]
     (when-not (util/uuid? app-id)
       (.listAppTasks agave app-id)))

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -269,7 +269,7 @@
       (or (.translateJobStatus agave status) status)))
 
   (updateJobStatus [self job-step job status end-date]
-    (when (apps-util/supports-job-type? self (:job-type job-step))
+    (when (apps-util/supports-job-type? self (:job_type job-step))
       (agave-jobs/update-job-status agave job-step job status end-date)))
 
   (getDefaultOutputName [_ io-map source-step]
@@ -288,10 +288,10 @@
     (validate-system-id system-id)
     (listings/get-param-definitions agave app-id))
 
-  (stopJobStep [self {:keys [job-type external-id]}]
-    (when (and (apps-util/supports-job-type? self job-type)
-               (not (string/blank? external-id)))
-      (.stopJob agave external-id)))
+  (stopJobStep [self {:keys [job_type external_id]}]
+    (when (and (apps-util/supports-job-type? self job_type)
+               (not (string/blank? external_id)))
+      (.stopJob agave external_id)))
 
   (getAppDocs [_ app-id]
     (when-not (util/uuid? app-id)

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -26,6 +26,8 @@
 
 (def app-favorite-rejection "Cannot mark an HPC app as a favorite with this service.")
 
+(def app-rating-rejection "Cannot rate an HPC app with this service.")
+
 (defn- reject-app-permission-request
   []
   (service/bad-request app-permission-rejection))
@@ -37,6 +39,10 @@
 (defn- reject-app-favorite-request
   []
   (service/bad-request app-favorite-rejection))
+
+(defn- reject-app-rating-request
+  []
+  (service/bad-request app-rating-rejection))
 
 (def ^:private supported-system-ids #{jp/agave-client-name})
 (def ^:private validate-system-id (partial apps-util/validate-system-id supported-system-ids))
@@ -187,6 +193,22 @@
   (makeAppPublic [_ system-id app]
     (validate-system-id system-id)
     (reject-app-integration-request))
+
+  (deleteAppRating [_ app-id]
+    (when-not (util/uuid? app-id)
+      (reject-app-rating-request)))
+
+  (deleteAppRating [_ system-id app-id]
+    (validate-system-id system-id)
+    (reject-app-rating-request))
+
+  (rateApp [_ app-id rating]
+    (when-not (util/uuid? app-id)
+      (reject-app-rating-request)))
+
+  (rateApp [_ system-id app-id rating]
+    (validate-system-id system-id)
+    (reject-app-rating-request))
 
   (getAppTaskListing [_ app-id]
     (when-not (util/uuid? app-id)

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -226,6 +226,14 @@
     (validate-system-id system-id)
     (.getAppToolListing agave app-id))
 
+  (getAppUi [_ app-id]
+    (when-not (util/uuid? app-id)
+      (reject-app-integration-request)))
+
+  (getAppUi [_ system-id app-id]
+    (validate-system-id system-id)
+    (reject-app-integration-request))
+
   (getAppInputIds [_ app-id]
     (when-not (util/uuid? app-id)
       (.getAppInputIds agave app-id)))

--- a/src/apps/service/apps/agave/jobs.clj
+++ b/src/apps/service/apps/agave/jobs.clj
@@ -171,10 +171,10 @@
     status))
 
 (defn update-job-status
-  [agave {:keys [external-id] :as job-step} {job-id :id :as job} status end-date]
+  [agave {:keys [external_id] :as job-step} {job-id :id :as job} status end-date]
   (let [status (translate-job-status agave status)]
     (when (and status (jp/status-follows? status (:status job-step)))
-      (jp/update-job-step job-id external-id status end-date)
+      (jp/update-job-step job-id external_id status end-date)
       (jp/update-job job-id status end-date))))
 
 (defn get-default-output-name
@@ -182,9 +182,9 @@
   (.getDefaultOutputName agave external-app-id external-output-id))
 
 (defn get-job-step-status
-  [agave {:keys [external-id]}]
+  [agave {:keys [external_id]}]
   (try+
-   (select-keys (.listJob agave external-id) [:status :enddate])
+   (select-keys (.listJob agave external_id) [:status :enddate])
    (catch [:status 404] _ nil)))
 
 (defn prepare-step-submission

--- a/src/apps/service/apps/agave/jobs.clj
+++ b/src/apps/service/apps/agave/jobs.clj
@@ -85,29 +85,30 @@
 (defn- store-agave-job
   [job-id job submission]
   (jp/save-job {:id                 job-id
-                :job-name           (:name job)
-                :description        (:description submission)
-                :app-id             (:app_id job)
-                :app-name           (:app_name job)
-                :app-description    (:app_details job)
-                :app-wiki-url       (:wiki_url job)
-                :result-folder-path (:resultfolderid job)
-                :start-date         (:startdate job)
+                :job_name           (:name job)
+                :job_description    (:description submission)
+                :system_id          (:system_id submission)
+                :app_id             (:app_id job)
+                :app_name           (:app_name job)
+                :app_description    (:app_details job)
+                :app_wiki_url       (:wiki_url job)
+                :result_folder_path (:resultfolderid job)
+                :start_date         (:startdate job)
                 :username           (:username job)
                 :status             (:status job)
                 :notify             (:notify job)
-                :parent-id          (:parent_id submission)}
+                :parent_id          (:parent_id submission)}
                submission))
 
 (defn- store-job-step
   [job-id job]
-  (jp/save-job-step {:job-id          job-id
-                     :step-number     1
-                     :external-id     (:id job)
-                     :start-date      (:startdate job)
+  (jp/save-job-step {:job_id          job-id
+                     :step_number     1
+                     :external_id     (:id job)
+                     :start_date      (:startdate job)
                      :status          (:status job)
-                     :job-type        jp/agave-job-type
-                     :app-step-number 1}))
+                     :job_type        jp/agave-job-type
+                     :app_step_number 1}))
 
 (defn- format-job-submission-response
   [job-id submission job]

--- a/src/apps/service/apps/agave/jobs.clj
+++ b/src/apps/service/apps/agave/jobs.clj
@@ -83,7 +83,7 @@
        (throw+)))))
 
 (defn- store-agave-job
-  [job-id job submission]
+  [user job-id job submission]
   (jp/save-job {:id                 job-id
                 :job_name           (:name job)
                 :job_description    (:description submission)
@@ -94,7 +94,7 @@
                 :app_wiki_url       (:wiki_url job)
                 :result_folder_path (:resultfolderid job)
                 :start_date         (:startdate job)
-                :username           (:username job)
+                :username           (:username user)
                 :status             (:status job)
                 :notify             (:notify job)
                 :parent_id          (:parent_id submission)}
@@ -132,23 +132,23 @@
     :parent_id       (:parent_id submission)}))
 
 (defn- handle-successful-submission
-  [job-id job submission]
-  (store-agave-job job-id job submission)
+  [user job-id job submission]
+  (store-agave-job user job-id job submission)
   (store-job-step job-id job)
   (format-job-submission-response job-id submission job))
 
 (defn- handle-failed-submission
-  [job-id job submission]
+  [user job-id job submission]
   (let [job (assoc job :status jp/failed-status)]
-    (store-agave-job job-id job submission)
+    (store-agave-job user job-id job submission)
     (store-job-step job-id job)
     (format-job-submission-response job-id submission job)))
 
 (defn- send-submission
   [agave user job-id submission job]
   (if-let [submitted-job (send-submission* agave user submission job)]
-    (handle-successful-submission job-id submitted-job submission)
-    (handle-failed-submission job-id job submission)))
+    (handle-successful-submission user job-id submitted-job submission)
+    (handle-failed-submission user job-id job submission)))
 
 (defn submit
   [agave user submission]

--- a/src/apps/service/apps/agave/pipelines.clj
+++ b/src/apps/service/apps/agave/pipelines.clj
@@ -9,7 +9,8 @@
 (defn- format-task
   [agave external-app-ids {:keys [id] :as task}]
   (if-let [external-app-id (external-app-ids id)]
-    (merge task (select-keys (get-agave-task agave external-app-id) [:inputs :outputs]))
+    (assoc (merge task (select-keys (get-agave-task agave external-app-id) [:inputs :outputs]))
+           :id external-app-id)
     task))
 
 (defn format-pipeline-tasks

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -79,7 +79,7 @@
   (validateDeletionRequest [_ req]
     (let [requests-for-system (group-by :system_id (:app_ids req))]
       (doseq [[system-id qualified-app-ids] requests-for-system]
-        (.validateDeletionRequest (util/get-apps-client clients system-id) (assoc req :app-ids qualified-app-ids)))))
+        (.validateDeletionRequest (util/get-apps-client clients system-id) (assoc req :app_ids qualified-app-ids)))))
 
   (deleteApps [this req]
     (.validateDeletionRequest this req)

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -181,6 +181,9 @@
          (remove nil?)
          (first)))
 
+  (getAppToolListing [_ system-id app-id]
+    (.getAppToolListing (util/get-apps-client clients system-id) system-id app-id))
+
   (getAppUi [_ app-id]
     (.getAppUi (util/get-apps-client clients) app-id))
 

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -159,8 +159,14 @@
   (deleteAppRating [_ app-id]
     (.deleteAppRating (util/get-apps-client clients) app-id))
 
+  (deleteAppRating [_ system-id app-id]
+    (.deleteAppRating (util/get-apps-client clients system-id) system-id app-id))
+
   (rateApp [_ app-id rating]
     (.rateApp (util/get-apps-client clients) app-id rating))
+
+  (rateApp [_ system-id app-id rating]
+    (.rateApp (util/get-apps-client clients system-id) system-id app-id rating))
 
   (getAppTaskListing [_ app-id]
     (->> (map #(.getAppTaskListing % app-id) clients)

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -187,6 +187,9 @@
   (getAppUi [_ app-id]
     (.getAppUi (util/get-apps-client clients) app-id))
 
+  (getAppUi [_ system-id app-id]
+    (.getAppUi (util/get-apps-client clients system-id) system-id app-id))
+
   (getAppInputIds [_ app-id]
     (->> (map #(.getAppInputIds % app-id) clients)
          (remove nil?)

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -153,6 +153,9 @@
   (makeAppPublic [_ app]
     (.makeAppPublic (util/get-apps-client clients) app))
 
+  (makeAppPublic [_ system-id app]
+    (.makeAppPublic (util/get-apps-client clients system-id) system-id app))
+
   (deleteAppRating [_ app-id]
     (.deleteAppRating (util/get-apps-client clients) app-id))
 

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -173,6 +173,9 @@
          (remove nil?)
          (first)))
 
+  (getAppTaskListing [_ system-id app-id]
+    (.getAppTaskListing (util/get-apps-client clients system-id) system-id app-id))
+
   (getAppToolListing [_ app-id]
     (->> (map #(.getAppToolListing % app-id) clients)
          (remove nil?)

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -9,6 +9,7 @@
             [apps.service.apps.job-listings :as job-listings]
             [apps.service.apps.combined.job-view :as job-view]
             [apps.service.apps.combined.jobs :as combined-jobs]
+            [apps.service.apps.combined.pipelines :as pipelines]
             [apps.service.apps.combined.util :as util]
             [apps.service.apps.permissions :as app-permissions]))
 
@@ -196,19 +197,19 @@
          (first)))
 
   (addPipeline [self pipeline]
-    (.formatPipelineTasks self (.addPipeline (util/get-apps-client clients) pipeline)))
+    (pipelines/format-pipeline self (.addPipeline (util/get-apps-client clients) pipeline)))
 
   (formatPipelineTasks [_ pipeline]
     (reduce (fn [acc client] (.formatPipelineTasks client acc)) pipeline clients))
 
   (updatePipeline [self pipeline]
-    (.formatPipelineTasks self (.updatePipeline (util/get-apps-client clients) pipeline)))
+    (pipelines/format-pipeline self (.updatePipeline (util/get-apps-client clients) pipeline)))
 
   (copyPipeline [self app-id]
-    (.formatPipelineTasks self (.copyPipeline (util/get-apps-client clients) app-id)))
+    (pipelines/format-pipeline self (.copyPipeline (util/get-apps-client clients) app-id)))
 
   (editPipeline [self app-id]
-    (.formatPipelineTasks self (.editPipeline (util/get-apps-client clients) app-id)))
+    (pipelines/format-pipeline self (.editPipeline (util/get-apps-client clients) app-id)))
 
   (listJobs [self params]
     (job-listings/list-jobs self user params))

--- a/src/apps/service/apps/combined/jobs.clj
+++ b/src/apps/service/apps/combined/jobs.clj
@@ -46,26 +46,26 @@
 (defn- build-job-save-info
   [user result-folder-path job-id app-info submission]
   {:id                 job-id
-   :job-name           (:name submission)
-   :description        (:description submission)
-   :app-id             (:id app-info)
-   :app-name           (:name app-info)
-   :app-description    (:description app-info)
-   :app-wiki-url       (:wiki_url app-info)
-   :result-folder-path result-folder-path
-   :start-date         (db/now)
+   :job_name           (:name submission)
+   :job_description    (:description submission)
+   :app_id             (:id app-info)
+   :app_name           (:name app-info)
+   :app_description    (:description app-info)
+   :app_wiki_url       (:wiki_url app-info)
+   :result_folder_path result-folder-path
+   :start_date         (db/now)
    :status             "Submitted"
    :username           (:username user)
    :notify             (:notify submission false)
-   :parent-id          (:parent_id submission)})
+   :parent_id          (:parent_id submission)})
 
 (defn- build-job-step-save-info
   [job-id job-step]
-  {:job-id          job-id
-   :step-number     (:step_number job-step)
+  {:job_id          job-id
+   :step_number     (:step_number job-step)
    :status          jp/pending-status
-   :job-type        (:job_type job-step)
-   :app-step-number (:app_step_number job-step)})
+   :job_type        (:job_type job-step)
+   :app_step-number (:app_step_number job-step)})
 
 (defn- build-job-step-list
   [job-id app-id]

--- a/src/apps/service/apps/combined/pipelines.clj
+++ b/src/apps/service/apps/combined/pipelines.clj
@@ -1,0 +1,6 @@
+(ns apps.service.apps.combined.pipelines)
+
+(defn format-pipeline [apps-client pipeline]
+  (let [fix-task-id  (fn [step] (assoc step :task_id (or (:external_app_id step) (:task_id step))))
+        fix-task-ids (fn [steps] (mapv fix-task-id steps))]
+    (update-in (.formatPipelineTasks apps-client pipeline) [:steps] fix-task-ids)))

--- a/src/apps/service/apps/combined/util.clj
+++ b/src/apps/service/apps/combined/util.clj
@@ -22,9 +22,9 @@
 
 (defn get-apps-client
   ([clients]
-     (or (first (filter #(.canEditApps %) clients))
-         (throw+ {:type  :clojure-commons.exception/bad-request-field
-                  :error "apps are not editable at this time."})))
+   (or (first (filter #(.supportsSystemId % jp/de-client-name) clients))
+       (throw+ {:type  :clojure-commons.exception/internal-system-error
+                :error "default system ID not found"})))
   ([clients system-id]
      (or (first (filter #(.supportsSystemId % system-id) clients))
          (throw+ {:type  :clojure-commons.exception/bad-request-field

--- a/src/apps/service/apps/combined/util.clj
+++ b/src/apps/service/apps/combined/util.clj
@@ -31,10 +31,8 @@
                   :error (str "unrecognized system ID " system-id)}))))
 
 (defn apps-client-for-job
-  [{app-id :app_id :as submission} clients]
-  (cond (not (uuid? app-id))                     (get-apps-client clients jp/agave-client-name)
-        (zero? (ap/count-external-steps app-id)) (get-apps-client clients jp/de-client-name)
-        :else                                    nil))
+  [{system-id :system_id} clients]
+  (get-apps-client clients system-id))
 
 (defn apps-client-for-app-step
   [clients job-step]

--- a/src/apps/service/apps/combined/util.clj
+++ b/src/apps/service/apps/combined/util.clj
@@ -43,7 +43,7 @@
 
 (defn is-de-job-step?
   [job-step]
-  (= (:job-type job-step) jp/de-job-type))
+  (= (:job_type job-step) jp/de-job-type))
 
 (defn apps-client-for-job-step
   [clients job-step]

--- a/src/apps/service/apps/combined/util.clj
+++ b/src/apps/service/apps/combined/util.clj
@@ -31,8 +31,9 @@
                   :error (str "unrecognized system ID " system-id)}))))
 
 (defn apps-client-for-job
-  [{system-id :system_id} clients]
-  (get-apps-client clients system-id))
+  [{app-id :app_id system-id :system_id} clients]
+  (when (or (not= system-id jp/de-client-name) (zero? (ap/count-external-steps app-id)))
+    (get-apps-client clients system-id)))
 
 (defn apps-client-for-app-step
   [clients job-step]

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -172,19 +172,19 @@
 
   (deleteAppRating [_ app-id]
     (when (util/uuid? app-id)
-      (app-metadata/delete-app-rating user app-id)))
+      (app-metadata/delete-app-rating user (uuidify app-id))))
 
   (deleteAppRating [_ system-id app-id]
     (validate-system-id system-id)
-    (app-metadata/delete-app-rating user app-id))
+    (app-metadata/delete-app-rating user (uuidify app-id)))
 
   (rateApp [_ app-id rating]
     (when (util/uuid? app-id)
-      (app-metadata/rate-app user app-id rating)))
+      (app-metadata/rate-app user (uuidify app-id) rating)))
 
   (rateApp [_ system-id app-id rating]
     (validate-system-id system-id)
-    (app-metadata/rate-app user app-id rating))
+    (app-metadata/rate-app user (uuidify app-id) rating))
 
   (getAppTaskListing [_ app-id]
     (when (util/uuid? app-id)

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -258,7 +258,7 @@
       status))
 
   (updateJobStatus [self job-step job status end-date]
-    (when (apps-util/supports-job-type? self (:job-type job-step))
+    (when (apps-util/supports-job-type? self (:job_type job-step))
       (de-jobs/update-job-status job-step job status end-date)))
 
   (getDefaultOutputName [_ io-map source-step]
@@ -278,10 +278,10 @@
     (validate-system-id system-id)
     (app-metadata/get-param-definitions app-id))
 
-  (stopJobStep [self {:keys [job-type external-id]}]
-    (when (and (apps-util/supports-job-type? self job-type)
-               (not (string/blank? external-id)))
-      (jex/stop-job external-id)))
+  (stopJobStep [self {:keys [job_type external_id]}]
+    (when (and (apps-util/supports-job-type? self job_type)
+               (not (string/blank? external_id)))
+      (jex/stop-job external_id)))
 
   ;; TODO: this will have to be changed when system IDs are added to the corresponding endoint.
   (categorizeApps [_ body]

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -221,10 +221,6 @@
   (addPipeline [_ pipeline]
     (pipeline-edit/add-pipeline user pipeline))
 
-  (addPipeline [_ system-id pipeline]
-    (validate-system-id system-id)
-    (pipeline-edit/add-pipeline user pipeline))
-
   (formatPipelineTasks [_ pipeline]
     pipeline)
 

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -164,11 +164,11 @@
 
   (makeAppPublic [_ app]
     (when (util/uuid? (:id app))
-      (app-metadata/make-app-public user app)))
+      (app-metadata/make-app-public user (update app :id uuidify))))
 
   (makeAppPublic [_ system-id app]
     (validate-system-id system-id)
-    (app-metadata/make-app-public user app))
+    (app-metadata/make-app-public user (update app :id uuidify)))
 
   (deleteAppRating [_ app-id]
     (when (util/uuid? app-id)

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -204,11 +204,11 @@
 
   (getAppUi [_ app-id]
     (when (util/uuid? app-id)
-      (edit/get-app-ui user app-id)))
+      (edit/get-app-ui user (uuidify app-id))))
 
   (getAppUi [_ system-id app-id]
     (validate-system-id system-id)
-    (edit/get-app-ui user app-id))
+    (edit/get-app-ui user (uuidify app-id)))
 
   (getAppInputIds [_ app-id]
     (when (util/uuid? app-id)

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -224,15 +224,12 @@
   (formatPipelineTasks [_ pipeline]
     pipeline)
 
-  ;; TODO: this will have to be changed when system IDs are added to the corresponding endoint.
   (updatePipeline [_ pipeline]
     (pipeline-edit/update-pipeline user pipeline))
 
-  ;; TODO: this will have to be changed when system IDs are added to the corresponding endoint.
   (copyPipeline [_ app-id]
     (pipeline-edit/copy-pipeline user app-id))
 
-  ;; TODO: this will have to be changed when system IDs are added to the corresponding endoint.
   (editPipeline [_ app-id]
     (pipeline-edit/edit-pipeline user app-id))
 
@@ -250,11 +247,7 @@
          (vector)))
 
   (submitJob [this submission]
-    (when (util/uuid? (:app_id submission))
-      (de-jobs/submit user (update-in submission [:app_id] uuidify))))
-
-  (submitJob [this system-id submission]
-    (validate-system-id system-id)
+    (validate-system-id (:system_id submission))
     (de-jobs/submit user (update-in submission [:app_id] uuidify)))
 
   (submitJobStep [_ _ submission]

--- a/src/apps/service/apps/de/edit.clj
+++ b/src/apps/service/apps/de/edit.clj
@@ -15,6 +15,7 @@
         [slingshot.slingshot :only [throw+]])
   (:require [apps.clients.permissions :as permissions]
             [apps.persistence.app-metadata :as persistence]
+            [apps.persistence.jobs :as jp]
             [apps.service.apps.de.categorization :as categorization]
             [apps.service.apps.de.constants :as c]
             [clojure.set :as set]))
@@ -360,7 +361,7 @@
           task-id (:id app-task)
           current-param-ids (map :id (mapcat :parameters (:parameter_groups app-task)))]
       ;; Copy the App's current name, description, and tool ID to its task
-      (persistence/update-task (assoc app :id task-id :tool_id tool-id))
+      (persistence/update-task jp/de-client-name (assoc app :id task-id :tool_id tool-id))
       ;; CORE-6266 prevent duplicate key errors from reused param value IDs
       (when-not (empty? current-param-ids)
         (persistence/remove-parameter-values current-param-ids))
@@ -384,7 +385,7 @@
 (defn- add-single-step-task
   "Adds a task as a single step to the given app, using the app's name, description, and label."
   [{app-id :id :as app}]
-  (let [task (persistence/add-task app)]
+  (let [task (persistence/add-task jp/de-client-name app)]
     (persistence/add-step app-id 0 {:task_id (:id task)})
     task))
 

--- a/src/apps/service/apps/de/jobs.clj
+++ b/src/apps/service/apps/de/jobs.clj
@@ -137,9 +137,9 @@
     (:uuid job-step)))
 
 (defn update-job-status
-  [{:keys [external-id] :as job-step} {job-id :id :as job} status end-date]
+  [{:keys [external_id] :as job-step} {job-id :id :as job} status end-date]
   (when (jp/status-follows? status (:status job-step))
-    (jp/update-job-step job-id external-id status end-date)
+    (jp/update-job-step job-id external_id status end-date)
     (jp/update-job job-id status end-date)))
 
 (defn get-default-output-name
@@ -147,8 +147,8 @@
   (ap/get-default-output-name task-id output-id))
 
 (defn get-job-step-status
-  [{:keys [external-id]}]
-  (when-let [step (jp/get-job-state external-id)]
+  [{:keys [external_id]}]
+  (when-let [step (jp/get-job-state external_id)]
     {:status  (:status step)
      :enddate (:completion_date step)}))
 

--- a/src/apps/service/apps/de/jobs.clj
+++ b/src/apps/service/apps/de/jobs.clj
@@ -15,10 +15,6 @@
             [apps.service.apps.de.jobs.base :as jb]
             [apps.util.json :as json-util]))
 
-(defn- secured-params
-  [user]
-  {:user (:shortUsername user)})
-
 (defn- pre-process-jex-step
   "Removes the input array of a fAPI step's config."
   [{{step-type :type} :component :as step}]
@@ -46,11 +42,11 @@
   (-> (select-keys job [:app_id :app_name :app_description :notify])
       (assoc :job_name           (:name job)
              :job_description    (:description job)
-             :system_id          (:system_id job)
+             :system_id          (:system_id submission)
              :app_wiki_url       (:wiki_url job)
              :result_folder_path (:output_dir job)
              :start_date         (sqlfn now)
-             :user_id            (get-user-id (:username user))
+             :username           (:username user)
              :status             status
              :parent_id          (:parent_id submission))
       (jp/save-job (cheshire/encode submission))))

--- a/src/apps/service/apps/de/jobs.clj
+++ b/src/apps/service/apps/de/jobs.clj
@@ -64,7 +64,7 @@
 
 (defn- save-job-submission
   "Saves a DE job and its job-step in the database."
-  ([user  job submission]
+  ([user job submission]
      (save-job-submission user job submission "Submitted"))
   ([user job submission status]
      (transaction
@@ -99,8 +99,8 @@
         (catch Object _
           (save-job-submission user job submission "Failed")))
        (format-job-submission-response user job true)))
-(defn- submit-standalone-job
 
+(defn- submit-standalone-job
   [user submission job]
   (do-jex-submission job)
   (->> (save-job-submission user job submission)

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -465,10 +465,12 @@
 (defn- get-tasks
   "Fetches a list of tasks for the given IDs with their inputs and outputs."
   [task-ids]
-  (select tasks
-    (fields :id
-            :name
-            :description)
+  (select [:tasks :t]
+    (join [:job_types :j] {:t.job_type_id :j.id})
+    (fields [:j.name        :system_id]
+            [:t.id          :id]
+            [:t.name        :name]
+            [:t.description :description])
     (with-task-params inputs)
     (with-task-params outputs)
     (where (in :id task-ids))))

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -465,15 +465,15 @@
 (defn- get-tasks
   "Fetches a list of tasks for the given IDs with their inputs and outputs."
   [task-ids]
-  (select [:tasks :t]
-    (join [:job_types :j] {:t.job_type_id :j.id})
-    (fields [:j.name        :system_id]
-            [:t.id          :id]
-            [:t.name        :name]
-            [:t.description :description])
+  (select tasks
+    (join job_types)
+    (fields [:job_types.system_id :system_id]
+            [:tasks.id            :id]
+            [:tasks.name          :name]
+            [:tasks.description   :description])
     (with-task-params inputs)
     (with-task-params outputs)
-    (where (in :id task-ids))))
+    (where (in :tasks.id task-ids))))
 
 (defn- format-task-file-param
   [file-parameter]

--- a/src/apps/service/apps/de/pipeline_edit.clj
+++ b/src/apps/service/apps/de/pipeline_edit.clj
@@ -41,12 +41,15 @@
                  :target_step))
     (join [:tasks :t]
           {:task_id :t.id})
+    (join [:job_types :jt]
+          {:t.job_type_id :jt.id})
     (join [:apps :app]
           {:app_id :app.id})
     (fields :app_steps.id
             :step
             :t.name
             :t.description
+            :jt.system_id
             :task_id
             :t.external_app_id)
     (where {:app.id app-id})

--- a/src/apps/service/apps/de/pipeline_edit.clj
+++ b/src/apps/service/apps/de/pipeline_edit.clj
@@ -150,6 +150,7 @@
   {:name            (:name step)
    :description     (:description step)
    :label           (:name step)
+   :system_id       (:system_id step)
    :external_app_id (:external_app_id step)})
 
 (defn- add-external-app-task

--- a/src/apps/service/apps/de/pipeline_edit.clj
+++ b/src/apps/service/apps/de/pipeline_edit.clj
@@ -24,11 +24,6 @@
   [step]
   (assoc step :app_type (if (:external_app_id step) "External" "DE")))
 
-(defn- fix-task-id
-  [step]
-  (assoc step
-    :task_id (first (remove nil? ((juxt :task_id :external_app_id) step)))))
-
 (defn- get-steps
   "Fetches the steps for the given app ID, including their task ID and
    source/target mapping IDs and step names."
@@ -60,7 +55,6 @@
   [step]
   (-> step
       add-app-type
-      fix-task-id
       (dissoc :id :step :input_mapping)
       remove-nil-vals))
 

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -39,33 +39,33 @@
                   :total (count children)))))
 
 (defn- job-supports-sharing?
-  [apps-client rep-steps {:keys [parent-id id]}]
-  (and (nil? parent-id) (job-permissions/job-steps-support-job-sharing? apps-client (rep-steps id))))
+  [apps-client rep-steps {:keys [parent_id id]}]
+  (and (nil? parent_id) (job-permissions/job-steps-support-job-sharing? apps-client (rep-steps id))))
 
 (def job-type-to-system-id string/lower-case)
 
 (defn format-job
-  [apps-client app-tables rep-steps {:keys [parent-id id] :as job}]
+  [apps-client app-tables rep-steps {:keys [parent_id id] :as job}]
   (remove-nil-vals
-   {:app_description (:app-description job)
-    :app_id          (:app-id job)
-    :app_name        (:app-name job)
+   {:app_description (:app_description job)
+    :app_id          (:app_id job)
+    :app_name        (:app_name job)
     :description     (:description job)
-    :enddate         (job-timestamp (:end-date job))
-    :system_id       (job-type-to-system-id (:job-type job))
+    :enddate         (job-timestamp (:end_date job))
+    :system_id       (job-type-to-system-id (:job_type job))
     :id              id
-    :name            (:job-name job)
-    :resultfolderid  (:result-folder-path job)
-    :startdate       (job-timestamp (:start-date job))
+    :name            (:job_name job)
+    :resultfolderid  (:result_folder_path job)
+    :startdate       (job-timestamp (:start_date job))
     :status          (:status job)
     :username        (:username job)
     :deleted         (:deleted job)
     :notify          (:notify job false)
-    :wiki_url        (:app-wiki-url job)
-    :app_disabled    (app-disabled? app-tables (:app-id job))
-    :parent_id       parent-id
-    :batch           (:is-batch job)
-    :batch_status    (when (:is-batch job) (format-batch-status id))
+    :wiki_url        (:app_wiki_url job)
+    :app_disabled    (app-disabled? app-tables (:app_id job))
+    :parent_id       parent_id
+    :batch           (:is_batch job)
+    :batch_status    (when (:is_batch job) (format-batch-status id))
     :can_share       (job-supports-sharing? apps-client rep-steps job)}))
 
 (defn- list-jobs*
@@ -83,8 +83,8 @@
         search-params    (util/default-search-params params :startdate default-sort-dir)
         types            (.getJobTypes apps-client)
         jobs             (list-jobs* user search-params types analysis-ids)
-        rep-steps        (group-by (some-fn :parent-id :job-id) (jp/list-representative-job-steps (mapv :id jobs)))
-        app-tables       (.loadAppTables apps-client (map :app-id jobs))]
+        rep-steps        (group-by (some-fn :parent_id :job_id) (jp/list-representative-job-steps (mapv :id jobs)))
+        app-tables       (.loadAppTables apps-client (map :app_id jobs))]
     {:analyses  (mapv (partial format-job apps-client app-tables rep-steps) jobs)
      :timestamp (str (System/currentTimeMillis))
      :total     (count-jobs user params types analysis-ids)}))
@@ -92,20 +92,20 @@
 (defn list-job
   [apps-client job-id]
   (let [job-info   (jp/get-job-by-id job-id)
-        app-tables (.loadAppTables apps-client [(:app-id job-info)])
-        rep-steps  (group-by :job-id (jp/list-representative-job-steps [job-id]))]
+        app-tables (.loadAppTables apps-client [(:app_id job-info)])
+        rep-steps  (group-by :job_id (jp/list-representative-job-steps [job-id]))]
     (format-job apps-client app-tables rep-steps job-info)))
 
 (defn- format-job-step
   [step]
   (remove-nil-vals
-   {:step_number     (:step-number step)
-    :external_id     (:external-id step)
-    :startdate       (job-timestamp (:start-date step))
-    :enddate         (job-timestamp (:end-date step))
+   {:step_number     (:step_number step)
+    :external_id     (:external_id step)
+    :startdate       (job-timestamp (:start_date step))
+    :enddate         (job-timestamp (:end_date step))
     :status          (:status step)
-    :app_step_number (:app-step-number step)
-    :step_type       (:job-type step)}))
+    :app_step_number (:app_step_number step)
+    :step_type       (:job_type step)}))
 
 (defn list-job-steps
   [job-id]

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -66,9 +66,11 @@
       (jp/update-job-steps (:id batch) new-status end-date))))
 
 (defn update-job-status
-  [apps-client job-step {:keys [id] :as job} batch status end-date]
+  [apps-client {external-id :external_id :as job-step} {:keys [id] :as job} batch status end-date]
   (when (jp/completed? (:status job))
     (service/bad-request (str "received a job status update for completed or canceled job, " id)))
+  (when (jp/completed? (:status job-step))
+    (service/bad-request (str "received a job status update for completed or canceled step, " external-id "/" id)))
   (let [end-date (db/timestamp-from-str end-date)]
     (.updateJobStatus apps-client job-step job status end-date)
     (when batch (update-batch-status batch end-date))

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -41,11 +41,11 @@
   (service/assert-found (jp/lock-job job-id) "job" job-id))
 
 (defn- send-job-status-update
-  [apps-client {job-id :id prev-status :status app-id :app-id}]
+  [apps-client {job-id :id prev-status :status app-id :app_id}]
   (let [{curr-status :status :as job} (jp/get-job-by-id job-id)
         app-tables                    (.loadAppTables apps-client [app-id])
         rep-steps                     (jp/list-representative-job-steps [job-id])
-        rep-steps                     (group-by (some-fn :parent-id :job-id) rep-steps)]
+        rep-steps                     (group-by (some-fn :parent_id :job_id) rep-steps)]
     (when-not (= prev-status curr-status)
       (cn/send-job-status-update
        (.getUser apps-client)
@@ -62,7 +62,7 @@
   [batch end-date]
   (let [new-status (determine-batch-status batch)]
     (when-not (= (:status batch) new-status)
-      (jp/update-job (:id batch) {:status new-status :end-date end-date})
+      (jp/update-job (:id batch) {:status new-status :end_date end-date})
       (jp/update-job-steps (:id batch) new-status end-date))))
 
 (defn update-job-status
@@ -81,15 +81,15 @@
 (defn- sync-incomplete-job-status
   [apps-client {:keys [id] :as job} step]
   (if-let [step-status (.getJobStepStatus apps-client step)]
-    (let [step     (lock-job-step id (:external-id step))
+    (let [step     (lock-job-step id (:external_id step))
           job      (lock-job id)
-          batch    (when-let [parent-id (:parent-id job)] (lock-job parent-id))
+          batch    (when-let [parent-id (:parent_id job)] (lock-job parent-id))
           status   (:status step-status)
           end-date (:enddate step-status)]
       (update-job-status apps-client step job batch status end-date))
-    (let [step  (lock-job-step id (:external-id step))
+    (let [step  (lock-job-step id (:external_id step))
           job   (lock-job id)
-          batch (when-let [parent-id (:parent-id job)] (lock-job parent-id))]
+          batch (when-let [parent-id (:parent_id job)] (lock-job parent-id))]
       (update-job-status apps-client step job batch jp/failed-status (db/now-str)))))
 
 (defn- determine-job-status
@@ -107,7 +107,7 @@
   [{:keys [id]}]
   (let [{:keys [status]} (jp/lock-job id)]
     (when-not (jp/completed? status)
-      (jp/update-job id {:status (determine-job-status id) :end-date (db/now)}))))
+      (jp/update-job id {:status (determine-job-status id) :end_date (db/now)}))))
 
 (defn sync-job-status
   [apps-client {:keys [id] :as job}]
@@ -125,7 +125,7 @@
   (validate-jobs-for-user user [job-id] "write")
   (jp/update-job job-id body)
   (->> (jp/get-job-by-id job-id)
-       ((juxt :id :job-name :description))
+       ((juxt :id :job_name :description))
        (zipmap [:id :name :description])))
 
 (defn delete-job
@@ -142,8 +142,8 @@
   [apps-client user job-id]
   (validate-jobs-for-user user [job-id] "read")
   (let [job (jp/get-job-by-id job-id)]
-    {:app_id     (:app-id job)
-     :system_id  (listings/job-type-to-system-id (:job-type job))
+    {:app_id     (:app_id job)
+     :system_id  (listings/job-type-to-system-id (:job_type job))
      :parameters (job-params/get-parameter-values apps-client job)}))
 
 (defn get-job-relaunch-info
@@ -155,7 +155,7 @@
   "Stops an individual step in a job."
   [apps-client {:keys [id] :as job} steps]
   (.stopJobStep apps-client (first steps))
-  (jp/cancel-job-step-numbers id (mapv :step-number steps))
+  (jp/cancel-job-step-numbers id (mapv :step_number steps))
   (send-job-status-update apps-client job))
 
 (defn stop-job

--- a/src/apps/service/apps/jobs/params.clj
+++ b/src/apps/service/apps/jobs/params.clj
@@ -128,7 +128,7 @@
 (defn get-job-relaunch-info
   [apps-client job]
   (let [submission (get-job-submission job)]
-    (update-in (assoc (.getAppJobView apps-client (:app-id job)) :debug (:debug submission false))
+    (update-in (assoc (.getAppJobView apps-client (:app_id job)) :debug (:debug submission false))
                [:groups]
                (partial update-app-groups (:config submission)))))
 

--- a/src/apps/service/apps/jobs/permissions.clj
+++ b/src/apps/service/apps/jobs/permissions.clj
@@ -23,7 +23,7 @@
 
 (defn- verify-not-subjobs
   [jobs]
-  (when-let [subjob-ids (seq (map :id (filter :parent-id jobs)))]
+  (when-let [subjob-ids (seq (map :id (filter :parent_id jobs)))]
     (cxu/bad-request (str "analysis sharing not supported for members of a batch job") :jobs subjob-ids)))
 
 (defn validate-job-permissions
@@ -33,9 +33,9 @@
       (cxu/forbidden (str "insufficient privileges for analyses: " (string/join ", " forbidden-ids))))))
 
 (defn- format-job-permissions
-  [short-username perms {:keys [id job-name]}]
+  [short-username perms {:keys [id job_name]}]
   {:id          id
-   :name        job-name
+   :name        job_name
    :permissions (perms id)})
 
 (defn list-job-permissions

--- a/src/apps/service/apps/jobs/sharing.clj
+++ b/src/apps/service/apps/jobs/sharing.clj
@@ -71,8 +71,8 @@
     (job-sharing-msg :not-allowed job-id)))
 
 (defn- verify-not-subjob
-  [{:keys [id parent-id]}]
-  (when parent-id
+  [{:keys [id parent_id]}]
+  (when parent_id
     (job-sharing-msg :is-subjob id)))
 
 (defn- verify-support
@@ -88,9 +88,9 @@
         (get-in response [:error :reason] "unable to share app")))))
 
 (defn- share-output-folder
-  [sharer sharee {:keys [result-folder-path]}]
+  [sharer sharee {:keys [result_folder_path]}]
   (try+
-   (data-info/share-path sharer result-folder-path sharee "read")
+   (data-info/share-path sharer result_folder_path sharee "read")
    nil
    (catch ce/clj-http-error? {:keys [body]}
      (str "unable to share result folder: " (:error_code (service/parse-json body))))))
@@ -109,7 +109,7 @@
 
 (defn- list-job-inputs
   [apps-client job]
-  (->> (mapv keyword (.getAppInputIds apps-client (:app-id job)))
+  (->> (mapv keyword (.getAppInputIds apps-client (:app_id job)))
        (select-keys (job-params/get-job-config job))
        vals
        (remove string/blank?)))
@@ -157,9 +157,9 @@
   (mapv (partial share-jobs-with-user apps-client user) sharing-requests))
 
 (defn- unshare-output-folder
-  [sharer sharee {:keys [result-folder-path]}]
+  [sharer sharee {:keys [result_folder_path]}]
   (try+
-   (data-info/unshare-path sharer result-folder-path sharee)
+   (data-info/unshare-path sharer result_folder_path sharee)
    nil
    (catch ce/clj-http-error? {:keys [body]}
      (str "unable to unshare result folder: " (:error_code (service/parse-json body))))))

--- a/src/apps/service/apps/jobs/submissions.clj
+++ b/src/apps/service/apps/jobs/submissions.clj
@@ -155,13 +155,14 @@
 
 (defn- save-batch*
   [user app submission output-dir]
-  (:id (jp/save-job {:job-name           (:name submission)
-                     :description        (:description submission)
-                     :app-id             (:app_id submission)
-                     :app-name           (:name app)
-                     :app-description    (:description app)
-                     :result-folder-path output-dir
-                     :start-date         (db/now)
+  (:id (jp/save-job {:job_name           (:name submission)
+                     :job_description    (:description submission)
+                     :system_id          (:system_id submission)
+                     :app_id             (:app_id submission)
+                     :app_name           (:name app)
+                     :app_description    (:description app)
+                     :result_folder_path output-dir
+                     :start_date         (db/now)
                      :status             jp/submitted-status
                      :username           (:username user)
                      :notify             (:notify submission)}
@@ -169,11 +170,11 @@
 
 (defn- save-batch-step
   [batch-id job-type]
-  (jp/save-job-step {:job-id          batch-id
-                     :step-number     1
+  (jp/save-job-step {:job_id          batch-id
+                     :step_number     1
                      :status          jp/submitted-status
-                     :app-step-number 1
-                     :job-type        job-type}))
+                     :app_step_number 1
+                     :job_type        job-type}))
 
 (defn- save-batch
   [user job-types app submission output-dir]

--- a/test/apps/service/apps/apps_test.clj
+++ b/test/apps/service/apps/apps_test.clj
@@ -172,3 +172,9 @@
 
 (deftest de-app-task-listing-with-invalid-app-id
   (test-non-uuid #(apps/get-app-task-listing (get-user :testde1) de-system-id fake-app-id)))
+
+(deftest app-tool-listing-with-invalid-system-id
+  (test-unrecognized-system-id #(apps/get-app-tool-listing (get-user :testde1) fake-system-id fake-app-id)))
+
+(deftest de-app-tool-listing-with-invalid-app-id
+  (test-non-uuid #(apps/get-app-tool-listing (get-user :testde1) de-system-id fake-app-id)))

--- a/test/apps/service/apps/apps_test.clj
+++ b/test/apps/service/apps/apps_test.clj
@@ -11,6 +11,8 @@
 
 (use-fixtures :once tf/run-integration-tests tf/with-test-db tf/with-config atf/with-workspaces)
 
+(use-fixtures :each atf/with-test-app)
+
 (def ^:private fake-app-id "fakeid")
 
 (def ^:private fake-rating {:rating 5 :comment_id 27})
@@ -193,3 +195,7 @@
   (let [update-fn    #(assoc % :system_id fake-system-id :app_type "External" :task_id fake-app-id)
         pipeline-def (update-in atf/default-pipeline-definition [:steps 0] update-fn)]
     (test-unrecognized-system-id #(atf/create-pipeline (get-user :testde1) pipeline-def))))
+
+(deftest app-task-listing-should-contain-system-id
+  (let [task-listing (apps/get-app-task-listing (get-user :testde1) (:system_id atf/test-app) (:id atf/test-app))]
+    (is (= (:system_id atf/test-app) (:system_id (first (:tasks task-listing)))))))

--- a/test/apps/service/apps/apps_test.clj
+++ b/test/apps/service/apps/apps_test.clj
@@ -166,3 +166,9 @@
 
 (deftest rate-de-app-with-invalid-app-id
   (test-non-uuid #(apps/rate-app (get-user :testde1) de-system-id fake-app-id fake-rating)))
+
+(deftest app-task-listing-with-invalid-system-id
+  (test-unrecognized-system-id #(apps/get-app-task-listing (get-user :testde1) fake-system-id fake-app-id)))
+
+(deftest de-app-task-listing-with-invalid-app-id
+  (test-non-uuid #(apps/get-app-task-listing (get-user :testde1) de-system-id fake-app-id)))

--- a/test/apps/service/apps/apps_test.clj
+++ b/test/apps/service/apps/apps_test.clj
@@ -12,6 +12,8 @@
 
 (def ^:private fake-app-id "fakeid")
 
+(def ^:private fake-rating {:rating 5 :comment_id 27})
+
 (defn- test-unrecognized-system-id [f]
   (is (thrown-with-msg? ExceptionInfo #"unrecognized system ID" (f))))
 
@@ -26,6 +28,9 @@
 
 (defn- test-hpc-app-favorite [f]
   (is (thrown-with-msg? ExceptionInfo #"Cannot mark an HPC app as a favorite with this service" (f))))
+
+(defn- test-hpc-app-rating [f]
+  (is (thrown-with-msg? ExceptionInfo #"Cannot rate an HPC app with this service" (f))))
 
 (deftest test-app-addition-with-invalid-system-id
   (test-unrecognized-system-id #(apps/add-app (get-user :testde1) fake-system-id atf/app-definition)))
@@ -143,3 +148,21 @@
 
 (deftest publish-de-app-with-invalid-app-id
   (test-non-uuid #(apps/make-app-public (get-user :testde1) de-system-id {:id fake-app-id})))
+
+(deftest delete-app-rating-with-invalid-system-id
+  (test-unrecognized-system-id #(apps/delete-app-rating (get-user :testde1) fake-system-id fake-app-id)))
+
+(deftest delete-app-rating-with-hpc-system-id
+  (test-hpc-app-rating #(apps/delete-app-rating (get-user :testde1) hpc-system-id fake-app-id)))
+
+(deftest delete-de-app-rating-with-invalid-app-id
+  (test-non-uuid #(apps/delete-app-rating (get-user :testde1) de-system-id fake-app-id)))
+
+(deftest rate-app-with-invalid-system-id
+  (test-unrecognized-system-id #(apps/rate-app (get-user :testde1) fake-system-id fake-app-id fake-rating)))
+
+(deftest rate-app-with-hpc-system-id
+  (test-hpc-app-rating #(apps/rate-app (get-user :testde1) hpc-system-id fake-app-id fake-rating)))
+
+(deftest rate-de-app-with-invalid-app-id
+  (test-non-uuid #(apps/rate-app (get-user :testde1) de-system-id fake-app-id fake-rating)))

--- a/test/apps/service/apps/apps_test.clj
+++ b/test/apps/service/apps/apps_test.clj
@@ -178,3 +178,12 @@
 
 (deftest de-app-tool-listing-with-invalid-app-id
   (test-non-uuid #(apps/get-app-tool-listing (get-user :testde1) de-system-id fake-app-id)))
+
+(deftest get-app-ui-with-invalid-system-id
+  (test-unrecognized-system-id #(apps/get-app-ui (get-user :testde1) fake-system-id fake-app-id)))
+
+(deftest get-app-ui-with-hpc-system-id
+  (test-hpc-app-modification #(apps/get-app-ui (get-user :testde1) hpc-system-id fake-app-id)))
+
+(deftest get-de-app-ui-with-invalid-app-id
+  (test-non-uuid #(apps/get-app-ui (get-user :testde1) de-system-id fake-app-id)))

--- a/test/apps/service/apps/apps_test.clj
+++ b/test/apps/service/apps/apps_test.clj
@@ -1,7 +1,8 @@
 (ns apps.service.apps.apps-test
   (:use [apps.service.apps.test-utils :only [get-user delete-app permanently-delete-app
                                              de-system-id fake-system-id hpc-system-id]]
-        [clojure.test])
+        [clojure.test]
+        [kameleon.uuids :only [uuid]])
   (:require [apps.persistence.jobs :as jp]
             [apps.service.apps :as apps]
             [apps.service.apps.test-fixtures :as atf]
@@ -187,3 +188,8 @@
 
 (deftest get-de-app-ui-with-invalid-app-id
   (test-non-uuid #(apps/get-app-ui (get-user :testde1) de-system-id fake-app-id)))
+
+(deftest create-pipeline-with-invalid-system-id
+  (let [update-fn    #(assoc % :system_id fake-system-id :app_type "External" :task_id fake-app-id)
+        pipeline-def (update-in atf/default-pipeline-definition [:steps 0] update-fn)]
+    (test-unrecognized-system-id #(atf/create-pipeline (get-user :testde1) pipeline-def))))

--- a/test/apps/service/apps/apps_test.clj
+++ b/test/apps/service/apps/apps_test.clj
@@ -134,3 +134,12 @@
 
 (deftest test-app-publishable-with-invalid-system-id
   (test-unrecognized-system-id #(apps/app-publishable? (get-user :testde1) fake-system-id fake-app-id)))
+
+(deftest publish-app-with-invalid-system-id
+  (test-unrecognized-system-id #(apps/make-app-public (get-user :testde1) fake-system-id {:id fake-app-id})))
+
+(deftest publish-app-with-hpc-system-id
+  (test-hpc-app-modification #(apps/make-app-public (get-user :testde1) hpc-system-id {:id fake-app-id})))
+
+(deftest publish-de-app-with-invalid-app-id
+  (test-non-uuid #(apps/make-app-public (get-user :testde1) de-system-id {:id fake-app-id})))

--- a/test/apps/service/apps/permissions_test.clj
+++ b/test/apps/service/apps/permissions_test.clj
@@ -143,11 +143,11 @@
   true)
 
 (defn check-rating [user]
-  (apps/rate-app user (:id test-app) {:rating 5 :comment_id 27})
+  (apps/rate-app user (:id test-app) de-system-id {:rating 5 :comment_id 27})
   true)
 
 (defn check-unrating [user]
-  (apps/delete-app-rating user (:id test-app))
+  (apps/delete-app-rating user de-system-id (:id test-app))
   true)
 
 (defn check-tasks [user]

--- a/test/apps/service/apps/permissions_test.clj
+++ b/test/apps/service/apps/permissions_test.clj
@@ -155,7 +155,7 @@
   true)
 
 (defn check-tools [user]
-  (apps/get-app-tool-listing user (:id test-app))
+  (apps/get-app-tool-listing user de-system-id (:id test-app))
   true)
 
 (deftest test-permission-restrictions-none

--- a/test/apps/service/apps/permissions_test.clj
+++ b/test/apps/service/apps/permissions_test.clj
@@ -110,7 +110,7 @@
   true)
 
 (defn check-app-ui [user]
-  (apps/get-app-ui user (:id test-app))
+  (apps/get-app-ui user de-system-id (:id test-app))
   true)
 
 (defn check-copy-app [user]

--- a/test/apps/service/apps/permissions_test.clj
+++ b/test/apps/service/apps/permissions_test.clj
@@ -246,7 +246,7 @@
     (sql/delete :app_documentation (sql/where {:app_id (:id test-app)}))
     (is (thrown-with-msg? ExceptionInfo #"private app" (check-rating user)))
     (is (thrown-with-msg? ExceptionInfo #"private app" (check-unrating user)))
-    (apps/make-app-public user test-app)
+    (apps/make-app-public user de-system-id test-app)
     (is (check-rating user))
     (is (check-unrating user))))
 
@@ -259,7 +259,7 @@
     (sql/delete :app_documentation (sql/where {:app_id (:id test-app)}))
     (is (has-permission? "app" (:id test-app) "user" username "own"))
     (is (not (has-permission? "app" (:id test-app) "group" (ipg/grouper-user-group-id) "read")))
-    (apps/make-app-public user test-app)
+    (apps/make-app-public user de-system-id test-app)
     (is (not (has-permission? "app" (:id test-app) "user" username "own")))
     (is (has-permission? "app" (:id test-app) "group" (ipg/grouper-user-group-id) "read"))))
 
@@ -422,7 +422,7 @@
 (deftest test-public-app-labels-update
   (let [{username :shortUsername :as user} (get-user :testde1)]
     (sql/delete :app_documentation (sql/where {:app_id (:id test-app)}))
-    (apps/make-app-public user test-app)
+    (apps/make-app-public user de-system-id test-app)
     (is (check-edit-app-docs user))))
 
 (deftest test-create-pipeline

--- a/test/apps/service/apps/permissions_test.clj
+++ b/test/apps/service/apps/permissions_test.clj
@@ -151,7 +151,7 @@
   true)
 
 (defn check-tasks [user]
-  (apps/get-app-task-listing user (:id test-app))
+  (apps/get-app-task-listing user de-system-id (:id test-app))
   true)
 
 (defn check-tools [user]

--- a/test/apps/service/apps/permissions_test.clj
+++ b/test/apps/service/apps/permissions_test.clj
@@ -143,7 +143,7 @@
   true)
 
 (defn check-rating [user]
-  (apps/rate-app user (:id test-app) de-system-id {:rating 5 :comment_id 27})
+  (apps/rate-app user de-system-id (:id test-app) {:rating 5 :comment_id 27})
   true)
 
 (defn check-unrating [user]

--- a/test/apps/service/apps/public_apps_test.clj
+++ b/test/apps/service/apps/public_apps_test.clj
@@ -44,7 +44,7 @@
   (let [user (get-user :testde1)
         app  (atf/create-test-app user "To be published")]
     (sql/delete :app_documentation (sql/where {:app_id (:id app)}))
-    (apps/make-app-public user app)
+    (apps/make-app-public user de-system-id app)
     (pc/grant-permission (config/permissions-client) "app" (:id app) "user" (:shortUsername user) "own")
     (let [publishable? (:publishable (apps/app-publishable? user de-system-id (:id app)))]
       (is (not (nil? publishable?)))
@@ -56,7 +56,7 @@
         app  (atf/create-test-tool-app user "To be published")]
     (is (nil? (v/validate-tool-not-public atf/test-tool-id)))
     (sql/delete :app_documentation (sql/where {:app_id (:id app)}))
-    (apps/make-app-public user app)
+    (apps/make-app-public user de-system-id app)
     (is (thrown-with-msg? ExceptionInfo #"in use by public apps" (v/validate-tool-not-public atf/test-tool-id)))
     (permanently-delete-app user de-system-id (:id app) true)))
 
@@ -64,7 +64,7 @@
   (let [user (get-user :testde1)
         app (atf/create-test-app user "To be published")]
     (sql/delete :app_documentation (sql/where {:app_id (:id app)}))
-    (apps/make-app-public user app)
+    (apps/make-app-public user de-system-id app)
     (is (empty? (find-app app (list-apps user trash-category-id))))
     (apps/admin-delete-app user (:id app))
     (is (seq (find-app app (list-apps user trash-category-id))))

--- a/test/apps/service/apps/test_fixtures.clj
+++ b/test/apps/service/apps/test_fixtures.clj
@@ -50,7 +50,7 @@
             :type        "executable"
             :version     "0.0.1"}]})
 
-(def pipeline-definition
+(def default-pipeline-definition
   {:mappings    [{:map         {(uuidify "13914010-89cd-406d-99c3-9c4ff8b023c3")
                                 (uuidify "13914010-89cd-406d-99c3-9c4ff8b023c3")}
                   :source_step 0
@@ -99,9 +99,11 @@
     app))
 
 (defn create-pipeline
-  [user]
-  (sql/delete :apps (sql/where {:name (:name pipeline-definition)}))
-  (apps/add-pipeline user pipeline-definition))
+  ([user pipeline-def]
+   (sql/delete :apps (sql/where {:name (:name pipeline-def)}))
+   (apps/add-pipeline user pipeline-def))
+  ([user]
+   (create-pipeline user default-pipeline-definition)))
 
 (defn with-test-app [f]
   (binding [test-app-user (get-user :testde1)

--- a/test/apps/service/apps/test_fixtures.clj
+++ b/test/apps/service/apps/test_fixtures.clj
@@ -58,10 +58,12 @@
    :steps       [{:name        "DE Word Count"
                   :description "Counts the number of words in a file."
                   :app_type    "DE"
+                  :system_id   "de"
                   :task_id     (uuidify "1ac31629-231a-4090-b3b4-63ee078a0c37")}
                  {:name        "DE Word Count"
                   :description "Counts the number of words in a file."
                   :app_type    "DE"
+                  :system_id   "de"
                   :task_id     (uuidify "1ac31629-231a-4090-b3b4-63ee078a0c37")}]
    :name        "Word Count Inception"
    :description "Counts the number of words in a word count."})


### PR DESCRIPTION
The location of the system ID depends on the nature of the endpoint. For many of the endpoints, it appears in the URI path. For endpoints where that doesn't make sense (for example, bulk update endpoints and pipeline endpoints), the system ID will appear in the request body. This is a significant change, and I wouldn't be surprised if there are issues. A thorough review would be appreciated.
