### PR TITLE
CORE-8540 Allow jobs without outputs to be (un)shared.

### DIFF
--- a/src/apps/routes/schemas/permission.clj
+++ b/src/apps/routes/schemas/permission.clj
@@ -82,9 +82,10 @@
 
 (defschema AnalysisSharingResponseElement
   (assoc AnalysisSharingRequestElement
-    :analysis_name        (describe NonBlankString "The analysis name")
-    :success              (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
-    (optional-key :error) (describe ErrorResponse "Information about any error that may have occurred")))
+    :analysis_name                (describe NonBlankString "The analysis name")
+    :success                      (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
+    (optional-key :outputs_error) (describe NonBlankString "A brief reason for the result folder sharing error")
+    (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")))
 
 (defschema UserAnalysisSharingRequestElement
   {:user     (describe NonBlankString "The user ID")
@@ -100,15 +101,12 @@
 (defschema AnalysisSharingResponse
   {:sharing (describe [UserAnalysisSharingResponseElement] "The list of sharing responses for individual users")})
 
-(defschema AnalysisUnsharingRequestElement
-  {:analysis_id (describe UUID "The analysis ID")
-   :permission  (describe AnalysisPermissionEnum "The requested permission level")})
-
 (defschema AnalysisUnsharingResponseElement
-  {:analysis_id          (describe UUID "The analysis ID")
-   :analysis_name        (describe NonBlankString "The analysis name")
-   :success              (describe Boolean "A Boolean flag indicating whether the unsharing request succeeded")
-   (optional-key :error) (describe ErrorResponse "Information about any error that may have occurred")})
+  {:analysis_id                  (describe UUID "The analysis ID")
+   :analysis_name                (describe NonBlankString "The analysis name")
+   :success                      (describe Boolean "A Boolean flag indicating whether the unsharing request succeeded")
+   (optional-key :outputs_error) (describe NonBlankString "A brief reason for the result folder unsharing error")
+   (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")})
 
 (defschema UserAnalysisUnsharingRequestElement
   {:user     (describe NonBlankString "The user ID")


### PR DESCRIPTION
The `POST /analyses/sharing` and `POST /analyses/unsharing` endpoints have been updated so that they no longer return an error when the results folder can't be (un)shared. Instead, the response will return success, but will now include an `outputs_error` field with an error message for the results (un)share error.

For example:
```json
{
  "unsharing": [
    {
      "user": "username",
      "analyses": [
        {
          "analysis_id": "714d5da0-e1bf-11e6-bf3b-f64e9b87c109",
          "analysis_name": "Word_Count_analysis1",
          "success": true,
          "outputs_error": "unable to unshare result folder: ERR_DOES_NOT_EXIST"
        }
      ]
    }
  ]
}
```

This allows jobs to be (un)shared, even when the job has not yet completed and the output folder doesn't exist, or if the output folder has been renamed.