### PR TITLE
CORE-8555: Allow sharing of Agave apps and analyses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "2.8.2-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.1"]
-                 [org.cyverse/mescal "2.8.2-SNAPSHOT"]
+                 [org.cyverse/mescal "2.8.2"]
                  [org.cyverse/metadata-client "3.0.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/common-cfg "2.8.0"]

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -67,7 +67,7 @@
     :return perms/AppPermissionListing
     :summary "List App Permissions"
     :description "This endpoint allows the caller to list the permissions for one or more apps. The
-    authenticated user must have ownership permission on every app in the request body for this
+    authenticated user must have read permission on every app in the request body for this
     endpoint to succeed."
     (ok (apps/list-app-permissions current-user (:apps body))))
 

--- a/src/apps/routes/schemas/permission.clj
+++ b/src/apps/routes/schemas/permission.clj
@@ -14,9 +14,9 @@
    :permission (describe AppPermissionEnum "The permission level assigned to the user")})
 
 (defschema AppPermissionListElement
-  {:id          (describe NonBlankString "The app ID")
-   :name        (describe NonBlankString "The app name")
-   :permissions (describe [UserPermissionListElement] "The list of user permissions for the app")})
+  {:id                  (describe NonBlankString "The app ID")
+   (optional-key :name) (describe NonBlankString "The app name")
+   :permissions         (describe [UserPermissionListElement] "The list of user permissions for the app")})
 
 (defschema AppPermissionListing
   {:apps (describe [AppPermissionListElement] "The list of app permissions")})

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -28,10 +28,6 @@
 
 (def app-rating-rejection "Cannot rate an HPC app with this service.")
 
-(defn- reject-app-permission-request
-  []
-  (service/bad-request app-permission-rejection))
-
 (defn- reject-app-integration-request
   []
   (service/bad-request app-integration-rejection))
@@ -369,7 +365,7 @@
   (listAppPermissions [_ app-ids]
     (when (and (user-has-access-token?)
                (some (complement util/uuid?) app-ids))
-      (reject-app-permission-request)))
+      (.listAppPermissions agave app-ids)))
 
   ;; TODO: this will have to be changed when system IDs are added to the corresponding endoint.
   (shareApps [self sharing-requests]

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -400,11 +400,11 @@
   (hasAppPermission [_ username app-id required-level]
     (when (and (user-has-access-token?)
                (not (util/uuid? app-id)))
-      false))
+      (.hasAppPermission agave username app-id required-level)))
 
   (hasAppPermission [_ username system-id app-id required-level]
     (validate-system-id system-id)
-    false)
+    (.hasAppPermission agave username app-id required-level))
 
   (supportsJobSharing [_ _]
     false))

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -6,6 +6,7 @@
             [apps.service.apps.agave.listings :as listings]
             [apps.service.apps.agave.pipelines :as pipelines]
             [apps.service.apps.agave.jobs :as agave-jobs]
+            [apps.service.apps.agave.sharing :as sharing]
             [apps.service.apps.job-listings :as job-listings]
             [apps.service.apps.permissions :as app-permissions]
             [apps.service.apps.util :as apps-util]
@@ -17,10 +18,6 @@
   (service/bad-request "Cannot edit documentation for HPC apps with this service"))
 
 (def app-integration-rejection "Cannot add or modify HPC apps with this service")
-
-(def app-permission-rejection "Cannot list or modify the permissions of HPC apps with this service")
-
-(def analysis-permission-rejection "Cannot list or modify the permissions of HPC analyses with this service")
 
 (def integration-data-rejection "Cannot list or modify integration data for HPC apps with this service")
 
@@ -376,11 +373,10 @@
     (app-permissions/process-user-app-sharing-requests self app-names sharee user-app-sharing-requests))
 
   ;; TODO: this will have to be changed when system IDs are added to the corresponding endoint.
-  (shareAppWithUser [_ app-names _ app-id level]
+  (shareAppWithUser [_ app-names sharee app-id level]
     (when (and (user-has-access-token?)
                (not (util/uuid? app-id)))
-      (let [category (.hpcAppGroup agave)]
-        (app-permissions/app-sharing-failure app-names app-id level category category app-permission-rejection))))
+      (sharing/share-app-with-user agave app-names sharee app-id level)))
 
   ;; TODO: this will have to be changed when system IDs are added to the corresponding endoint.
   (unshareApps [self unsharing-requests]
@@ -391,11 +387,10 @@
     (app-permissions/process-user-app-unsharing-requests self app-names sharee app-ids))
 
   ;; TODO: this will have to be changed when system IDs are added to the corresponding endoint.
-  (unshareAppWithUser [_ app-names _ app-id]
+  (unshareAppWithUser [_ app-names sharee app-id]
     (when (and (user-has-access-token?)
                (not (util/uuid? app-id)))
-      (let [category (.hpcAppGroup agave)]
-        (app-permissions/app-unsharing-failure app-names app-id category app-permission-rejection))))
+      (sharing/unshare-app-with-user agave app-names sharee app-id)))
 
   (hasAppPermission [_ username app-id required-level]
     (when (and (user-has-access-token?)
@@ -407,4 +402,4 @@
     (.hasAppPermission agave username app-id required-level))
 
   (supportsJobSharing [_ _]
-    false))
+    true))

--- a/src/apps/service/apps/agave/sharing.clj
+++ b/src/apps/service/apps/agave/sharing.clj
@@ -1,0 +1,38 @@
+(ns apps.service.apps.agave.sharing
+  (:use [slingshot.slingshot :only [try+]])
+  (:require [apps.service.apps.permissions :as app-permissions]
+            [clojure-commons.error-codes :as ce :refer [clj-http-error?]]
+            [clojure.tools.logging :as log]))
+
+(defn- try-share-app-with-user
+  [agave sharee app-id level success-fn failure-fn]
+  (try+
+    (.shareAppWithUser agave sharee app-id level)
+    (success-fn)
+    (catch [:error_code ce/ERR_UNAVAILABLE] {:keys [reason]}
+      (log/error (:throwable &throw-context) "Agave app listing timed out")
+      (failure-fn reason))
+    (catch clj-http-error? _
+      (log/error (:throwable &throw-context) "HTTP error returned by Agave")
+      (failure-fn (.getMessage (:throwable &throw-context))))
+    (catch Object _
+      (log/error (:throwable &throw-context) "Uncaught error returned by Agave")
+      (failure-fn (.getMessage (:throwable &throw-context))))))
+
+(defn share-app-with-user
+  [agave app-names sharee app-id level]
+  (let [category-id (:id (.hpcAppGroup agave))]
+    (try-share-app-with-user
+      agave sharee app-id level
+      #(app-permissions/app-sharing-success app-names app-id level category-id category-id)
+      (partial
+        app-permissions/app-sharing-failure app-names app-id level category-id category-id))))
+
+(defn unshare-app-with-user
+  [agave app-names sharee app-id]
+  (let [category-id (:id (.hpcAppGroup agave))]
+    (try-share-app-with-user
+      agave sharee app-id nil
+      #(app-permissions/app-unsharing-success app-names app-id category-id)
+      (partial
+        app-permissions/app-unsharing-failure app-names app-id category-id))))


### PR DESCRIPTION
These changes add support for Agave app sharing using the new features added by cyverse-de/mescal#4.
Agave app sharing is the last feature required to enable job sharing for Agave apps.