### PR TITLE
CORE-8593 Update `GET /analyses` can_share flag with permission check.

### DIFF
--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -49,7 +49,7 @@
     (when-not (= prev-status curr-status)
       (cn/send-job-status-update
        (.getUser apps-client)
-       (listings/format-job apps-client app-tables rep-steps job)))))
+       (listings/format-job apps-client nil app-tables rep-steps job)))))
 
 (defn- determine-batch-status
   [{:keys [id]}]


### PR DESCRIPTION
The `can_share` flag will now only be set to `true` if the requesting user also has `own` permission for the job.

A side effect of this change is that the return values of `apps.service.apps.job-listings/list-job` and `apps.service.apps.jobs/update-job-status` will currently always have this flag set to `false`, since they do not lookup permissions, but this `can_share` flag is currently only used in the `GET /analyses` response.