### PR TITLE
CORE-8609 Allow sharing of jobs from read-only apps.

### DIFF
--- a/src/apps/routes/schemas/permission.clj
+++ b/src/apps/routes/schemas/permission.clj
@@ -89,7 +89,8 @@
   (assoc AnalysisSharingRequestElement
     :analysis_name                (describe NonBlankString "The analysis name")
     :success                      (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
-    (optional-key :outputs_error) (describe NonBlankString "A brief reason for the result folder sharing error")
+    (optional-key :outputs_error) (describe NonBlankString "A brief reason for any result folder sharing errors")
+    (optional-key :app_error)     (describe NonBlankString "A brief reason for any app sharing errors")
     (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")))
 
 (defschema UserAnalysisSharingRequestElement


### PR DESCRIPTION
Attempting to share a job created by a "read-only" app, with a user that does not already have permissions on that app, will return an error like the following:
```json
{
  "error_code": "ERR_BAD_REQUEST",
  "reason": "insufficient privileges for app ID a25da189-ffe6-4f61-9a91-704711f36bd7"
}
```

This PR changes the job sharing endpoint, similar to #27, so that the app is shared after the job is successfully shared. If there is an error sharing the app, then the error message is included in a `app_error` field of the share's success response JSON:
```json
{
  "sharing": [
    {
      "user": "username",
      "analyses": [
        {
          "analysis_id": "14b27a4a-fd39-11e6-9a18-f64e9b87c109",
          "permission": "read",
          "analysis_name": "New_app_analysis1",
          "success": true,
          "app_error": "insufficient privileges for app ID a25da189-ffe6-4f61-9a91-704711f36bd7"
        }
      ]
    }
  ]
}
```