### PR TITLE
CORE-8610: use the last updated time from the Agave job status update…

### DIFF
--- a/src/apps/routes/callbacks.clj
+++ b/src/apps/routes/callbacks.clj
@@ -7,7 +7,7 @@
 
 (defroutes callbacks
   (POST "/de-job" []
-         :body [body (describe DeJobStatusUpdate "The App to add.")]
+         :body [body (describe DeJobStatusUpdate "The updated job status information.")]
          :summary "Update the status of of a DE analysis."
          :description "The jex-events service calls this endpoint when the status of a DE analysis
          changes"
@@ -15,7 +15,8 @@
 
   (POST "/agave-job/:job-id" []
          :path-params [job-id :- AnalysisIdPathParam]
-         :query [params AgaveJobStatusUpdate]
+         :body [body (describe AgaveJobStatusUpdate "The updated job status information.")]
+         :query [params AgaveJobStatusUpdateParams]
          :summary "Update the status of an Agave analysis."
          :description "The DE registers this endpoint as a callback when it submts jobs to Agave."
-         (ok (callbacks/update-agave-job-status job-id params))))
+         (ok (callbacks/update-agave-job-status job-id (:lastUpdated body) params))))

--- a/src/apps/routes/schemas/callback.clj
+++ b/src/apps/routes/schemas/callback.clj
@@ -1,6 +1,6 @@
 (ns apps.routes.schemas.callback
   (:use [common-swagger-api.schema :only [describe]]
-        [schema.core :only [defschema optional-key]]))
+        [schema.core :only [defschema optional-key Keyword Any]]))
 
 (defschema DeJobState
   {:status
@@ -15,7 +15,11 @@
 (defschema DeJobStatusUpdate
   {:state (describe DeJobState "The current state of the analysis")})
 
-(defschema AgaveJobStatusUpdate
+(defschema AgaveJobStatusUpdateParams
   {:status      (describe String "The status assigned to the job by Agave")
    :external-id (describe String "Agave's identifier for the job")
-   :end-time    (describe String "The analysis completion timestamp.")})
+   :end-time    (describe String "The analysis completion timestamp")})
+
+(defschema AgaveJobStatusUpdate
+  {:lastUpdated (describe String "The time the job status was last updated")
+   Keyword      Any})

--- a/src/apps/service/apps/agave/jobs.clj
+++ b/src/apps/service/apps/agave/jobs.clj
@@ -172,7 +172,8 @@
 
 (defn update-job-status
   [agave {:keys [external_id] :as job-step} {job-id :id :as job} status end-date]
-  (let [status (translate-job-status agave status)]
+  (let [status   (translate-job-status agave status)
+        end-date (when (jp/completed? status) end-date)]
     (when (and status (jp/status-follows? status (:status job-step)))
       (jp/update-job-step job-id external_id status end-date)
       (jp/update-job job-id status end-date))))

--- a/src/apps/service/apps/combined/jobs.clj
+++ b/src/apps/service/apps/combined/jobs.clj
@@ -212,7 +212,8 @@
 
 (defn- update-pipeline-status
   [combined-client clients max-step-number job-step {job-id :id :as job} status end-date]
-  (let [status (.translateJobStatus combined-client (:job_type job-step) status)]
+  (let [status   (.translateJobStatus combined-client (:job_type job-step) status)
+        end-date (when (jp/completed? status) end-date)]
     (when (jp/status-follows? status (:status job-step))
       (jp/update-job-step job-id (:external_id job-step) status end-date)
       (handle-pipeline-status-change job-id job-step max-step-number status end-date)

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -86,7 +86,7 @@
 
   (getAppJobView [_ system-id app-id]
     (validate-system-id system-id)
-    (job-view/get-app (uuidify app-id)))
+    (job-view/get-app user (uuidify app-id)))
 
   (deleteApp [_ system-id app-id]
     (validate-system-id system-id)

--- a/src/apps/service/apps/de/job_view.clj
+++ b/src/apps/service/apps/de/job_view.clj
@@ -1,5 +1,6 @@
 (ns apps.service.apps.de.job-view
-  (:use [apps.util.conversions :only [remove-nil-vals]]
+  (:use [apps.service.apps.de.validation :only [verify-app-permission]]
+        [apps.util.conversions :only [remove-nil-vals]]
         [korma.core :exclude [update]])
   (:require [apps.metadata.params :as mp]
             [apps.persistence.app-metadata :as amp]
@@ -84,6 +85,7 @@
 (defn get-app
   "This service obtains an app description in a format that is suitable for building the job
   submission UI."
-  [app-id]
-  (-> (amp/get-app app-id)
-      (format-app)))
+  [user app-id]
+  (let [app (amp/get-app app-id)]
+    (verify-app-permission user app "read")
+    (format-app app)))

--- a/src/apps/service/apps/de/jobs.clj
+++ b/src/apps/service/apps/de/jobs.clj
@@ -137,9 +137,10 @@
 
 (defn update-job-status
   [{:keys [external_id] :as job-step} {job-id :id :as job} status end-date]
-  (when (jp/status-follows? status (:status job-step))
-    (jp/update-job-step job-id external_id status end-date)
-    (jp/update-job job-id status end-date)))
+  (let [end-date (when (jp/completed? status) end-date)]
+    (when (jp/status-follows? status (:status job-step))
+      (jp/update-job-step job-id external_id status end-date)
+      (jp/update-job job-id status end-date))))
 
 (defn get-default-output-name
   [{output-id :output_id :as io-map} {task-id :task_id :as source-step}]

--- a/src/apps/service/callbacks.clj
+++ b/src/apps/service/callbacks.clj
@@ -1,8 +1,9 @@
 (ns apps.service.callbacks
-  (:require [clojure.tools.logging :as log]
-            [apps.persistence.jobs :as jp]
+  (:require [apps.persistence.jobs :as jp]
             [apps.service.apps :as apps]
-            [apps.util.service :as service]))
+            [apps.util.service :as service]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log]))
 
 (defn update-de-job-status
   [{{end-date :completion_date :keys [status uuid]} :state}]
@@ -13,9 +14,9 @@
     (apps/update-job-status uuid status end-date)))
 
 (defn update-agave-job-status
-  [job-id {:keys [status external-id end-time]}]
+  [job-id last-updated {:keys [status external-id end-time]}]
   (service/assert-valid job-id "no job UUID provided")
   (service/assert-valid status "no status provided")
   (service/assert-valid external-id "no external job ID provided")
   (log/info (str "received a status update for Agave job " external-id ": status = " status))
-  (apps/update-job-status job-id external-id status end-time))
+  (apps/update-job-status job-id external-id status (first (remove string/blank? [end-time last-updated]))))


### PR DESCRIPTION
These changes fix two problems.

The first problem is that Agave jobs are not updated with an end timestamp when the job moves to either the `Completed` state or the `Failed` state (CORE-8610). This was happening because the end date was not being sent to the DE in the job status updates. To fix this problem, I modified the services so that they will use the `lastUpdated` timestamp if the end time is not provided in the status update.

The second problem is that the services aren't verifying app permissions in all cases. This wasn't a problem before because app listings were checking permissions. Now that it's possible to share an analysis with a user without the corresponding app being shared, however, it is possible for users to run apps without having explicit permission to. I modified the services to check permissions on an app any time a user tries to obtain its job submission information.