### PR TITLE
CORE-8418: Add permissions support for public tools

### DIFF
--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -76,6 +76,7 @@
 
 (def load-app-permissions (partial load-resource-permissions (rt-app)))
 (def load-analysis-permissions (partial load-resource-permissions (rt-analysis)))
+(def load-tool-permissions (partial load-resource-permissions (rt-tool)))
 
 (defn- format-perms-listing
   [user perms]
@@ -159,6 +160,7 @@
        set))
 
 (def get-public-app-ids (partial get-public-resource-ids "app"))
+(def get-public-tool-ids (partial get-public-resource-ids "tool"))
 
 (defn- get-directly-accessible-resource-ids [resource-type user]
   (->> (pc/get-subject-permissions-for-resource-type (client) "user" user resource-type false)

--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -97,6 +97,10 @@
   [app-id]
   (pc/delete-resource (client) app-id (rt-app)))
 
+(defn delete-tool-resource
+  [tool-id]
+  (pc/delete-resource (client) tool-id (rt-tool)))
+
 (defn- revoke-app-user-permission
   "Revokes a user's permission to access an app, ignoring cases where the user didn't already have access."
   [user app-id]

--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -18,6 +18,9 @@
 (defn- rt-analysis []
   (config/analysis-resource-type))
 
+(defn- rt-tool []
+  (config/tool-resource-type))
+
 (defn- get-failure-reason
   "Extracts the failure reason from an error response body."
   [body]
@@ -105,6 +108,10 @@
   [user app-id]
   (revoke-app-user-permission user app-id)
   (pc/grant-permission (client) (rt-app) app-id "group" (ipg/grouper-user-group-id) "read"))
+
+(defn register-public-tool
+  [tool-id]
+  (pc/grant-permission (client) (rt-tool) tool-id "group" (ipg/grouper-user-group-id) "read"))
 
 (defn- resource-sharing-log-msg
   [action resource-type resource-name subject-type subject-id reason]

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -41,8 +41,13 @@
    (optional-key :restricted)         ToolRestricted
    (optional-key :time_limit_seconds) ToolTimeLimit})
 
-(defschema ToolDetails
+(defschema ToolListingItem
   (merge Tool
+    {:is_public  (describe Boolean "Whether the Tool has been published and is viewable by all users")
+     :permission (describe String "The user's access level for the Tool")}))
+
+(defschema ToolDetails
+  (merge ToolListingItem
     {:implementation (describe ToolImplementation ToolImplementationDocs)
      :container      containers/ToolContainer}))
 
@@ -65,7 +70,7 @@
       (->optional-param :container)))
 
 (defschema ToolListing
-  {:tools (describe [Tool] "Listing of App Tools")})
+  {:tools (describe [ToolListingItem] "Listing of App Tools")})
 
 (defschema NewTool
   (assoc Tool

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -130,11 +130,11 @@
 
   (GET "/:tool-id" []
         :path-params [tool-id :- ToolIdParam]
-        :query [params SecuredQueryParams]
+        :query [{:keys [user]} SecuredQueryParams]
         :return ToolDetails
         :summary "Get a Tool"
         :description "This endpoint returns the details for one tool."
-        (ok (get-tool tool-id)))
+        (ok (get-tool user tool-id)))
 
   (GET "/:tool-id/container" []
         :path-params [tool-id :- ToolIdParam]
@@ -333,7 +333,7 @@
 
   (PATCH "/:tool-id" []
           :path-params [tool-id :- ToolIdParam]
-          :query [{:keys [overwrite-public]} ToolUpdateParams]
+          :query [{:keys [user overwrite-public]} ToolUpdateParams]
           :body [body (describe ToolUpdateRequest "The Tool to update.")]
           :return ToolDetails
           :summary "Update a Tool"
@@ -349,7 +349,7 @@ included in it. Any existing settings not included in the request's `container` 
     Do not update container settings that are in use by tools in public apps unless it is certain the new
     container settings will not break reproducibility for those apps.
     If required, the `overwrite-public` flag may be used to update these settings for public tools."
-          (ok (update-tool overwrite-public (assoc body :id tool-id))))
+          (ok (update-tool user overwrite-public (assoc body :id tool-id))))
 
   (POST "/:tool-id/container/devices" []
          :path-params [tool-id :- ToolIdParam]

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -8,7 +8,8 @@
         [kameleon.queries]
         [kameleon.util.search]
         [korma.core :exclude [update]]
-        [korma.db :only [transaction]])
+        [korma.db :only [transaction]]
+        [slingshot.slingshot :only [try+]])
   (:require [apps.clients.permissions :as permissions]
             [apps.persistence.app-metadata :as persistence]
             [clojure.tools.logging :as log]))
@@ -113,4 +114,8 @@
     (validate-tool-not-used tool-id)
     (log/warn user "deleting tool" tool-id name version "@" location))
   (delete tools (where {:id tool-id}))
+  (try+
+    (permissions/delete-tool-resource tool-id)
+    (catch [:status 404] _
+      (log/warn "tool resource" tool-id "not found by permissions service")))
   nil)

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -9,7 +9,8 @@
         [kameleon.util.search]
         [korma.core :exclude [update]]
         [korma.db :only [transaction]])
-  (:require [apps.persistence.app-metadata :as persistence]
+  (:require [apps.clients.permissions :as permissions]
+            [apps.persistence.app-metadata :as persistence]
             [clojure.tools.logging :as log]))
 
 (defn- add-search-where-clauses
@@ -96,6 +97,7 @@
   [{:keys [tools]}]
   (transaction
     (let [tool-ids (doall (map add-new-tool tools))]
+      (dorun (map permissions/register-public-tool tool-ids))
       {:tool_ids tool-ids})))
 
 (defn update-tool

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -371,6 +371,12 @@
   []
   "analysis")
 
+(defn tool-resource-type
+  "The tool resource type name. This value is hard-coded for now, but placed in this namespace so that we can easily
+   convert it to a configuration setting if necessary."
+  []
+  "tool")
+
 (defn log-environment
   []
   (log/warn "ENV?: apps.data-info.base-url = " (data-info-base)))

--- a/test/apps/service/apps/test_fixtures.clj
+++ b/test/apps/service/apps/test_fixtures.clj
@@ -94,7 +94,7 @@
 
 (defn create-test-tool-app [user name]
   (sql/delete :apps (sql/where {:name name}))
-  (let [tool (tools/get-tool test-tool-id)
+  (let [tool (tools/get-tool (:shortUsername user) test-tool-id)
         app  (apps/add-app user jp/de-client-name (assoc app-definition :name name :tools [tool]))]
     (apps/owner-add-app-docs user de-system-id (:id app) {:documentation "This is a test."})
     app))

--- a/test/apps/tools_test.clj
+++ b/test/apps/tools_test.clj
@@ -1,18 +1,20 @@
 (ns apps.tools-test
   (:use [apps.persistence.entities :only [tools]]
-        [apps.test-fixtures :only [run-integration-tests with-test-db]]
+        [apps.test-fixtures :only [run-integration-tests with-test-db with-test-user]]
         [apps.tools]
+        [apps.user :only [current-user]]
         [clojure.test]
         [korma.db]
         [korma.core :exclude [update]]))
 
-(use-fixtures :each with-test-db run-integration-tests)
+(use-fixtures :each with-test-db with-test-user run-integration-tests)
 
 (deftest test-get-tool
   (let [tool-map (first (select tools (where {:name "notreal"})))]
     (testing "(get-tool) returns the right tool"
       (let [tool-id        (:id tool-map)
-            retrieved-tool (get-tool tool-id)]
+            user           (:shortUsername current-user)
+            retrieved-tool (get-tool user tool-id)]
         (is (= tool-id (:id retrieved-tool)))
         (is (contains? retrieved-tool :restricted))
         (is (contains? retrieved-tool :time_limit_seconds))
@@ -23,12 +25,13 @@
   (let [tool-map (first (select tools (where {:name "notreal"})))]
     (testing "(update-tool) actually updates the tool"
       (let [tool-id      (:id tool-map)
-            updated-tool (update-tool false (-> tool-map
-                                               (assoc :restricted true)
-                                               (assoc :time_limit_seconds 10)))]
+            user         (:shortUsername current-user)
+            updated-tool (update-tool user false (-> tool-map
+                                                     (assoc :restricted true)
+                                                     (assoc :time_limit_seconds 10)))]
         (is (= tool-id (:id updated-tool)))
         (is (contains? updated-tool :restricted))
         (is (contains? updated-tool :time_limit_seconds))
         (is (:restricted updated-tool))
         (is (= (:time_limit_seconds updated-tool) 10))
-        (update-tool false tool-map)))))
+        (update-tool user false tool-map)))))


### PR DESCRIPTION
This PR updates the following endpoints with public permissions support for tools (all tools are currently considered public):

* `POST /admin/tools`
* `DELETE /admin/tools/:id`
* `GET /tools`

A future PR will add support to allow users to add private tools, and to restrict tool listing and details based on private vs. public permissions. This PR is just to ensure that tool permissions stay in sync with any tools added or deleted by admins before any further features are implemented.