### PR TITLE
CORE-8691 Add a `POST /tools` endpoint that allows users to add private tools

### DIFF
--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -41,6 +41,7 @@
 
 (def register-private-app (partial register-private-resource (rt-app)))
 (def register-private-analysis (partial register-private-resource (rt-analysis)))
+(def register-private-tool (partial register-private-resource (rt-tool)))
 
 (defn- filter-perms-response
   [response filter-fn]

--- a/src/apps/metadata/element_listings.clj
+++ b/src/apps/metadata/element_listings.clj
@@ -81,11 +81,14 @@
   "Obtains a listing of tools for the metadata element listing service."
   [{:keys [user] :as params}]
   (let [perms           (perms-client/load-tool-permissions user)
-        public-tool-ids (perms-client/get-public-tool-ids)]
-    {:tools (->> (select-keys params [:include-hidden])
-                 (tool-listing-base-query)
-                 (select)
-                 (map (partial format-tool-listing perms public-tool-ids)))}))
+        tool-ids        (set (keys perms))
+        public-tool-ids (perms-client/get-public-tool-ids)
+        tools           (-> params
+                            (select-keys [:include-hidden])
+                            (assoc :tool-ids tool-ids)
+                            (tool-listing-base-query)
+                            (select))]
+    {:tools (map (partial format-tool-listing perms public-tool-ids) tools)}))
 
 (defn- list-info-types
   "Obtains a listing of information types for the metadata element listing service."

--- a/src/apps/routes/schemas/containers.clj
+++ b/src/apps/routes/schemas/containers.clj
@@ -189,13 +189,17 @@
    {:container_volumes_from [VolumesFrom]}
    "The list of VolumeFroms associated with a tool's container."))
 
+(def DevicesParamOptional     (s/optional-key :container_devices))
+(def VolumesParamOptional     (s/optional-key :container_volumes))
+(def VolumesFromParamOptional (s/optional-key :container_volumes_from))
+
 (s/defschema ToolContainerSettings
   (describe
    (merge
     Settings
-    {(s/optional-key :container_devices)      [Device]
-     (s/optional-key :container_volumes)      [Volume]
-     (s/optional-key :container_volumes_from) [VolumesFrom]})
+    {DevicesParamOptional     [Device]
+     VolumesParamOptional     [Volume]
+     VolumesFromParamOptional [VolumesFrom]})
    "Bare minimum map containing all of the container settings."))
 
 (s/defschema ToolContainer
@@ -209,8 +213,8 @@
   (describe
    (merge
     NewSettings
-    {(s/optional-key :container_devices)      [NewDevice]
-     (s/optional-key :container_volumes)      [NewVolume]
-     (s/optional-key :container_volumes_from) [NewVolumesFrom]
-     :image                                   NewImage})
+    {DevicesParamOptional     [NewDevice]
+     VolumesParamOptional     [NewVolume]
+     VolumesFromParamOptional [NewVolumesFrom]
+     :image                   NewImage})
    "The settings for adding a new full container definition to a tool."))

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -58,6 +58,18 @@
         {:implementation (describe ToolImplementation ToolImplementationDocs)
          :container      containers/NewToolContainer})))
 
+(defschema PrivateToolContainerImportRequest
+  (dissoc containers/NewToolContainer
+          containers/DevicesParamOptional
+          containers/VolumesParamOptional
+          containers/VolumesFromParamOptional))
+
+(defschema PrivateToolImportRequest
+  (-> Tool
+      (->optional-param :id)
+      (->optional-param :type)
+      (merge {:container PrivateToolContainerImportRequest})))
+
 (defschema ToolsImportRequest
   {:tools (describe [ToolImportRequest] "zero or more Tool definitions")})
 

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -8,6 +8,7 @@
         [apps.routes.schemas.integration-data :only [IntegrationData]]
         [apps.routes.schemas.tool]
         [apps.tools :only [add-tools delete-tool get-tool search-tools update-tool]]
+        [apps.tools.private :only [add-private-tool]]
         [apps.user :only [current-user]]
         [apps.util.service]
         [slingshot.slingshot :only [throw+]]
@@ -127,6 +128,14 @@
         :description "This endpoint allows users to search for a tool with a name or description that
         contains the given search term."
         (ok (search-tools params)))
+
+  (POST "/" []
+        :query [params SecuredQueryParamsRequired]
+        :body [body (describe PrivateToolImportRequest "The Tool to import.")]
+        :return ToolDetails
+        :summary "Add Private Tool"
+        :description "This service adds a new private Tool to the DE for the requesting user."
+        (ok (add-private-tool current-user body)))
 
   (GET "/:tool-id" []
         :path-params [tool-id :- ToolIdParam]

--- a/src/apps/tools/permissions.clj
+++ b/src/apps/tools/permissions.clj
@@ -1,0 +1,11 @@
+(ns apps.tools.permissions
+  (:require [apps.clients.permissions :as permissions]
+            [clojure-commons.exception-util :as exception-util]
+            [clojure.string :as string]))
+
+(defn check-tool-permissions
+  [user required-level tool-ids]
+  (let [tool-ids            (set tool-ids)
+        accessible-tool-ids (set (keys (permissions/load-tool-permissions user tool-ids required-level)))]
+    (when-let [forbidden-tools (seq (clojure.set/difference tool-ids accessible-tool-ids))]
+      (exception-util/forbidden (str "insufficient privileges for tools: " (string/join ", " forbidden-tools))))))

--- a/src/apps/tools/private.clj
+++ b/src/apps/tools/private.clj
@@ -1,0 +1,54 @@
+(ns apps.tools.private
+  (:use [apps.validation :only [verify-tool-name-location validate-tool-not-used]]
+        [korma.db :only [transaction]])
+  (:require [apps.clients.permissions :as permissions]
+            [apps.containers :as containers]
+            [apps.persistence.app-metadata :as persistence]
+            [apps.tools :as tools]
+            [apps.util.config :as cfg]))
+
+(defn- restrict-private-tool-setting
+  [setting max]
+  (if (or (< setting 1) (< max setting))
+    max
+    setting))
+
+(defn- restrict-private-tool-container
+  "Restrict the networking, CPU shares, and memory limits for the tool's container."
+  [{:keys [cpu_shares memory_limit] :or {cpu_shares   (cfg/private-tool-cpu-shares)
+                                         memory_limit (cfg/private-tool-memory-limit)}
+    :as container}]
+  (assoc container :network_mode "none"
+                   :cpu_shares   (restrict-private-tool-setting cpu_shares   (cfg/private-tool-cpu-shares))
+                   :memory_limit (restrict-private-tool-setting memory_limit (cfg/private-tool-memory-limit))))
+
+(defn- restrict-private-tool
+  "Set restricted flag, time limit, and default type."
+  [{:keys [time_limit_seconds] :or {time_limit_seconds (cfg/private-tool-time-limit-seconds)}
+    :as tool}]
+  (assoc tool :type               "executable"
+              :restricted         true
+              :time_limit_seconds (restrict-private-tool-setting
+                                    time_limit_seconds (cfg/private-tool-time-limit-seconds))))
+
+(defn- ensure-default-implementation
+  "If implementation details were not given, then some defaults are populated with info about the current user."
+  [{:keys [email first-name last-name]} implementation]
+  (or implementation
+      {:test              {:input_files [] :output_files []}
+       :implementor       (str first-name " " last-name)
+       :implementor_email email}))
+
+(defn add-private-tool
+  "Adds a private tool to the database, returning the tool details added."
+  [{:keys [shortUsername] :as user}
+   {:keys [container implementation] :as tool}]
+  (verify-tool-name-location tool)
+  (transaction
+    (let [tool-id (-> tool
+                      restrict-private-tool
+                      (assoc :implementation (ensure-default-implementation user implementation))
+                      persistence/add-tool)]
+      (containers/add-tool-container tool-id (restrict-private-tool-container container))
+      (permissions/register-private-tool shortUsername tool-id)
+      (tools/get-tool shortUsername tool-id))))

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -97,6 +97,21 @@
   [props config-valid configs]
   "apps.data-info.base-url" "http://data-info:60000")
 
+(cc/defprop-optint private-tool-time-limit-seconds
+  "The time limit to use when adding new private tools."
+  [props config-valid configs]
+  "apps.tools.private.time-limit-seconds" (* 24 60 60)) ;; 24 hours
+
+(cc/defprop-optint private-tool-cpu-shares
+  "The cpu shares limit to use when adding new private tools."
+  [props config-valid configs]
+  "apps.tools.private.cpu-shares" 4)
+
+(cc/defprop-optint private-tool-memory-limit
+  "The memory limit, in bytes, to use when adding new private tools."
+  [props config-valid configs]
+  "apps.tools.private.memory-limit" (* 16 1024 1024 1024)) ;; 16GB
+
 (cc/defprop-optstr workspace-root-app-category
   "The name of the root app category in a user's workspace."
   [props config-valid configs]


### PR DESCRIPTION
Private tools are currently not allowed to mount any devices or volumes, and have restrictions on networking (none), resources (4 CPUs / 8GB RAM), and run duration (24 hours). If implementation details are not provided in the request, then the requesting user's name and email will be used by default.

This PR also adds permission checks on tool listings and private tool details.
Admin endpoints will not currently list a private tool if the admin does not have permissions on that tool.