### PR TITLE
CORE-7507 Update the apps is-publishable endpoint to check for app existence first

### DIFF
--- a/src/apps/service/apps/de/admin.clj
+++ b/src/apps/service/apps/de/admin.clj
@@ -16,11 +16,6 @@
 
 (def ^:private max-app-category-name-len 255)
 
-(defn- validate-app-existence
-  "Verifies that apps exist."
-  [app-id]
-  (persistence/get-app app-id))
-
 (defn- validate-app-category-existence
   "Retrieves all app category fields from the database."
   [category-id]
@@ -100,7 +95,7 @@
    deleted or disabled in the database."
   [{username :shortUsername} {app-name :name app-id :id :as app}]
   (transaction
-   (validate-app-existence app-id)
+   (av/validate-app-existence app-id)
    (when-not (nil? app-name)
      (categorization/validate-app-name-in-current-hierarchy username app-id app-name)
      (av/validate-app-name app-name app-id))

--- a/src/apps/service/apps/de/validation.clj
+++ b/src/apps/service/apps/de/validation.clj
@@ -8,77 +8,12 @@
         [korma.core :exclude [update]]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [apps.clients.permissions :as perms-client]
-            [apps.service.apps.de.permissions :as perms]
-            [clojure.string :as string]))
+            [apps.service.apps.de.permissions :as perms]))
 
 (defn validate-app-existence
   "Verifies that apps exist."
   [app-id]
   (get-app app-id))
-
-(defn- get-tool-type-from-database
-  "Gets the tool type for the deployed component with the given identifier from
-   the database."
-  [component-id]
-  (first (select tools
-                 (fields :tool_types.id :tool_types.name)
-                 (join tool_types)
-                 (where {:id component-id}))))
-
-(defn- get-deployed-component-from-database
-  "Gets the deployed component for the deployed component with the given identifer
-   from the database."
-  [component-id]
-  (first (select tools
-                 (where {:id component-id}))))
-
-;; FIXME
-(defn- get-tool-type-from-registry
-  "Gets the tool type for the deployed component with the given identifier from
-   the given registry."
-  [registry component-id]
-  (when-not (nil? registry)
-    (let [components (throw+ "Reimplement: (.getRegisteredObjects registry DeployedComponent)")
-          component  (first (filter #(= component-id (.getId %)) components))
-          tool-type  (when-not (nil? component) (.getToolType component))]
-      (when-not (nil? tool-type)
-        {:id   (.getId tool-type)
-         :name (.getName tool-type)}))))
-
-(defn- get-tool-type
-  "Gets the tool type name for the deployed component with the given identifier."
-  [registry component-id]
-  (or (get-tool-type-from-registry registry component-id)
-      (get-tool-type-from-database component-id)))
-
-(defn- get-valid-ptype-names
-  "Gets the valid property type names for a given tool type."
-  [{tool-type-id :id}]
-  (map :name (parameter-types-for-tool-type tool-type-id)))
-
-;; FIXME
-(defn validate-template-property-types
-  "Validates the property types in a template that is being imported."
-  [template registry]
-  (when-let [tool-type (get-tool-type registry (.getComponent template))]
-    (let [valid-ptypes (into #{} (get-valid-ptype-names tool-type))
-          properties   (mapcat #(.getProperties %) (.getPropertyGroups template))]
-      (dorun (map #(throw+ {:type          ::UnsupportedPropertyTypeException
-                            :property-type %
-                            :name          (:name tool-type)})
-                  (filter #(nil? (valid-ptypes %))
-                          (map #(.getPropertyTypeName %) properties)))))))
-
-;; FIXME
-(defn validate-template-deployed-component
-  "Validates a deployed component that is associated with a template."
-  [template]
-  (let [component-id (.getComponent template)]
-   (when (string/blank? component-id)
-     (throw+ {:type        ::MissingDeployedComponentException
-              :template-id (.getId template)}))
-   (when (nil? (get-deployed-component-from-database component-id))
-     (throw+ {:type ::UnknownDeployedComponentException :component-id component-id}))))
 
 (defn- task-ids-for-app
   "Get the list of task IDs associated with an app."
@@ -114,7 +49,7 @@
    templates in the app are associated with any single-step apps that are not public. Returns
    a flag indicating whether or not the app is publishable along with the reason the app isn't
    publishable if it's not."
-  [{username :shortUsername} app-id & {:keys [permissions-checked]}]
+  [{username :shortUsername} app-id]
   (validate-app-existence app-id)
   (perms/check-app-permissions username "own" [app-id])
   (let [task-ids         (task-ids-for-app app-id)

--- a/src/apps/service/apps/de/validation.clj
+++ b/src/apps/service/apps/de/validation.clj
@@ -11,6 +11,11 @@
             [apps.service.apps.de.permissions :as perms]
             [clojure.string :as string]))
 
+(defn validate-app-existence
+  "Verifies that apps exist."
+  [app-id]
+  (get-app app-id))
+
 (defn- get-tool-type-from-database
   "Gets the tool type for the deployed component with the given identifier from
    the database."
@@ -110,9 +115,9 @@
    a flag indicating whether or not the app is publishable along with the reason the app isn't
    publishable if it's not."
   [{username :shortUsername} app-id & {:keys [permissions-checked]}]
+  (validate-app-existence app-id)
   (perms/check-app-permissions username "own" [app-id])
-  (let [app              (get-app app-id)
-        task-ids         (task-ids-for-app app-id)
+  (let [task-ids         (task-ids-for-app app-id)
         unrunnable-tasks (list-unrunnable-tasks task-ids)
         public-app-ids   (perms-client/get-public-app-ids)
         is-public?       (contains? public-app-ids app-id)


### PR DESCRIPTION
Now that this endpoint is guarded with a `system-id`, the apps service can check if a DE app exists first, and return an `ERR_NOT_FOUND` before checking the user's app permissions.

This PR also removes some obsolete code.