### PR TITLE
CORE-8692: Add endpoints that allow users to (un)share private tools

### DIFF
--- a/src/apps/clients/notifications.clj
+++ b/src/apps/clients/notifications.clj
@@ -152,3 +152,9 @@
   (->> (tool-notifications/format-sharing-notifications sharer sharee responses)
        (map guarded-send-notification)
        dorun))
+
+(defn send-tool-unsharing-notifications
+  [sharer sharee responses]
+  (->> (tool-notifications/format-unsharing-notifications sharer sharee responses)
+       (map guarded-send-notification)
+       dorun))

--- a/src/apps/clients/notifications.clj
+++ b/src/apps/clients/notifications.clj
@@ -8,6 +8,7 @@
             [clojure.tools.logging :as log]
             [apps.clients.notifications.app-sharing :as asn]
             [apps.clients.notifications.job-sharing :as jsn]
+            [apps.clients.notifications.tool-sharing :as tool-notifications]
             [apps.persistence.jobs :as jp]
             [apps.persistence.tool-requests :as tp]
             [apps.util.config :as config]))
@@ -143,5 +144,11 @@
 (defn send-analysis-unsharing-notifications
   [sharer sharee responses]
   (->> (jsn/format-unsharing-notifications sharer sharee responses)
+       (map guarded-send-notification)
+       dorun))
+
+(defn send-tool-sharing-notifications
+  [sharer sharee responses]
+  (->> (tool-notifications/format-sharing-notifications sharer sharee responses)
        (map guarded-send-notification)
        dorun))

--- a/src/apps/clients/notifications/tool_sharing.clj
+++ b/src/apps/clients/notifications/tool_sharing.clj
@@ -43,3 +43,11 @@
             [(format-sharer-notification sharer-success-formats share-action sharer sharee (responses true))
              (format-sharee-notification sharee-success-formats share-action sharer sharee (responses true))
              (format-sharer-notification failure-formats share-action sharer sharee (responses false))])))
+
+(defn format-unsharing-notifications
+  "Formats unsharing notifications for tools."
+  [sharer sharee responses]
+  (let [responses (group-by :success responses)]
+    (remove nil?
+            [(format-sharer-notification sharer-success-formats unshare-action sharer sharee (responses true))
+             (format-sharer-notification failure-formats unshare-action sharer sharee (responses false))])))

--- a/src/apps/clients/notifications/tool_sharing.clj
+++ b/src/apps/clients/notifications/tool_sharing.clj
@@ -1,0 +1,45 @@
+(ns apps.clients.notifications.tool-sharing
+  (:use [apps.clients.notifications.common-sharing]
+        [medley.core :only [remove-vals]])
+  (:require [clojure.string :as string]))
+
+(def notification-type "tools")
+(def singular "tool")
+(def plural "tools")
+
+(defn- format-tool
+  [response]
+  (remove-vals nil? (select-keys response [:tool_id :tool_name])))
+
+(defn- format-payload
+  [action responses]
+  {:action action
+   :tools  (map format-tool responses)})
+
+(defn- format-notification
+  [recipient formats action sharer sharee responses]
+  (when (seq responses)
+    (let [response-desc  (string/join ", " (map :tool_name responses))
+          response-count (count responses)]
+      {:type    notification-type
+       :user    recipient
+       :subject (format-subject formats singular plural action sharer sharee response-desc response-count)
+       :message (format-message formats singular plural action sharer sharee response-desc response-count)
+       :payload (format-payload action responses)})))
+
+(defn- format-sharer-notification
+  [formats action sharer sharee responses]
+  (format-notification sharer formats action sharer sharee responses))
+
+(defn- format-sharee-notification
+  [formats action sharer sharee responses]
+  (format-notification sharee formats action sharer sharee responses))
+
+(defn format-sharing-notifications
+  "Formats sharing notifications for tools."
+  [sharer sharee responses]
+  (let [responses (group-by :success responses)]
+    (remove nil?
+            [(format-sharer-notification sharer-success-formats share-action sharer sharee (responses true))
+             (format-sharee-notification sharee-success-formats share-action sharer sharee (responses true))
+             (format-sharer-notification failure-formats share-action sharer sharee (responses false))])))

--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -154,6 +154,7 @@
 (def share-analysis (partial share-resource (rt-analysis)))
 (def unshare-analysis (partial unshare-resource (rt-analysis)))
 (def share-tool (partial share-resource (rt-tool)))
+(def unshare-tool (partial unshare-resource (rt-tool)))
 
 (defn- get-public-resource-ids [resource-type]
   (->> (pc/get-subject-permissions-for-resource-type (client) "group" (ipg/grouper-user-group-id) resource-type false)

--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -137,7 +137,7 @@
    (catch clj-http-error? {:keys [body]}
      (let [reason (get-failure-reason body)]
        (log/error (resource-sharing-log-msg "share" resource-type resource-name subject-type subject-id reason)))
-     "the app sharing request failed")))
+     (str "the " resource-type " sharing request failed"))))
 
 (defn- unshare-resource
   [resource-type resource-name subject-type subject-id]
@@ -147,12 +147,13 @@
    (catch clj-http-error? {:keys [body]}
      (let [reason (get-failure-reason body)]
        (log/error (resource-sharing-log-msg "unshare" resource-type resource-name subject-type subject-id reason)))
-     "the app unsharing request failed")))
+     (str "the " resource-type " unsharing request failed"))))
 
 (def share-app (partial share-resource (rt-app)))
 (def unshare-app (partial unshare-resource (rt-app)))
 (def share-analysis (partial share-resource (rt-analysis)))
 (def unshare-analysis (partial unshare-resource (rt-analysis)))
+(def share-tool (partial share-resource (rt-tool)))
 
 (defn- get-public-resource-ids [resource-type]
   (->> (pc/get-subject-permissions-for-resource-type (client) "group" (ipg/grouper-user-group-id) resource-type false)

--- a/src/apps/routes/schemas/permission.clj
+++ b/src/apps/routes/schemas/permission.clj
@@ -152,3 +152,23 @@
 
 (defschema ToolSharingResponse
   {:sharing (describe [UserToolSharingResponseElement] "The list of Tool sharing responses")})
+
+(defschema ToolUnsharingResponseElement
+  {:tool_id              (describe UUID "The Tool ID")
+   :tool_name            (describe NonBlankString "The Tool name")
+   :success              (describe Boolean "A Boolean flag indicating whether the unsharing request succeeded")
+   (optional-key :error) (describe ErrorResponse "Information about any error that may have occurred")})
+
+(defschema UserToolUnsharingRequestElement
+  {:user  (describe NonBlankString "The user ID")
+   :tools (describe [UUID] "The identifiers of the Tools to unshare")})
+
+(defschema UserToolUnsharingResponseElement
+  (assoc UserToolUnsharingRequestElement
+    :tools (describe [ToolUnsharingResponseElement] "The list of Tool unsharing responses for the user")))
+
+(defschema ToolUnsharingRequest
+  {:unsharing (describe [UserToolUnsharingRequestElement] "The list of unsharing requests for individual users")})
+
+(defschema ToolUnsharingResponse
+  {:unsharing (describe [UserToolUnsharingResponseElement] "The list of unsharing responses for individual users")})

--- a/src/apps/routes/schemas/permission.clj
+++ b/src/apps/routes/schemas/permission.clj
@@ -6,6 +6,7 @@
 
 (def AppPermissionEnum (enum "read" "write" "own" ""))
 (def AnalysisPermissionEnum (enum "read" "own" ""))
+(def ToolPermissionEnum AppPermissionEnum)
 
 (defschema QualifiedAppId
   {:system_id SystemId
@@ -127,3 +128,27 @@
 
 (defschema AnalysisUnsharingResponse
   {:unsharing (describe [UserAnalysisUnsharingResponseElement] "The list of unsharing responses for individual users")})
+
+(defschema ToolSharingRequestElement
+  {:tool_id    (describe UUID "The Tool ID")
+   :permission (describe ToolPermissionEnum "The requested permission level")})
+
+(defschema ToolSharingResponseElement
+  (assoc ToolSharingRequestElement
+    :tool_name            (describe NonBlankString "The Tool name")
+    :success              (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
+    (optional-key :error) (describe ErrorResponse "Information about any error that may have occurred")))
+
+(defschema UserToolSharingRequestElement
+  {:user  (describe NonBlankString "The user ID")
+   :tools (describe [ToolSharingRequestElement] "The list of Tool sharing requests for the user")})
+
+(defschema UserToolSharingResponseElement
+  (assoc UserToolSharingRequestElement
+    :tools (describe [ToolSharingResponseElement] "The list of Tool sharing responses for the user")))
+
+(defschema ToolSharingRequest
+  {:sharing (describe [UserToolSharingRequestElement] "The list of Tool sharing requests")})
+
+(defschema ToolSharingResponse
+  {:sharing (describe [UserToolSharingResponseElement] "The list of Tool sharing responses")})

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -162,6 +162,16 @@ otherwise the default value will be used."
         It may be worthwhile to repeat failed or timed out calls to this endpoint."
         (ok (tool-sharing/share-tools current-user sharing)))
 
+  (POST "/unsharing" []
+        :query [params SecuredQueryParams]
+        :body [{:keys [unsharing]} (describe permission/ToolUnsharingRequest "The Tool unsharing request.")]
+        :return permission/ToolUnsharingResponse
+        :summary "Revoke Tool Permissions"
+        :description "This endpoint allows the caller to revoke permission to access one or more Tools from one or more users.
+        The authenticated user must have ownership permission to every Tool in the request body for this endoint to fully succeed.
+        Note: like Tool sharing, this is a potentially slow operation."
+        (ok (tool-sharing/unshare-tools current-user unsharing)))
+
   (GET "/:tool-id" []
         :path-params [tool-id :- ToolIdParam]
         :query [{:keys [user]} SecuredQueryParams]

--- a/src/apps/tools/permissions.clj
+++ b/src/apps/tools/permissions.clj
@@ -1,4 +1,6 @@
 (ns apps.tools.permissions
+  (:use [clojure-commons.error-codes :only [clj-http-error?]]
+        [slingshot.slingshot :only [try+ throw+]])
   (:require [apps.clients.permissions :as permissions]
             [clojure-commons.exception-util :as exception-util]
             [clojure.string :as string]))
@@ -9,3 +11,11 @@
         accessible-tool-ids (set (keys (permissions/load-tool-permissions user tool-ids required-level)))]
     (when-let [forbidden-tools (seq (clojure.set/difference tool-ids accessible-tool-ids))]
       (exception-util/forbidden (str "insufficient privileges for tools: " (string/join ", " forbidden-tools))))))
+
+(defn has-tool-permission
+  [user tool-id required-level]
+  (try+
+    (seq (permissions/load-tool-permissions user [tool-id] required-level))
+    (catch clj-http-error? {:keys [body]}
+      (throw+ {:type   ::permission-load-failure
+               :reason (permissions/extract-error-message body)}))))

--- a/src/apps/tools/sharing.clj
+++ b/src/apps/tools/sharing.clj
@@ -40,6 +40,20 @@
    :error      {:error_code error-codes/ERR_BAD_REQUEST
                 :reason     reason}})
 
+(defn tool-unsharing-success
+  [tool-id tool]
+  {:tool_id   (str tool-id)
+   :tool_name (get-tool-name tool-id tool)
+   :success   true})
+
+(defn tool-unsharing-failure
+  [tool-id tool reason]
+  {:tool_id   (str tool-id)
+   :tool_name (get-tool-name tool-id tool)
+   :success   false
+   :error     {:error_code error-codes/ERR_BAD_REQUEST
+               :reason     reason}})
+
 (defn share-tool-with-user
   [{username :shortUsername} sharee tool-id level]
   (if-let [tool (first (tools/get-tools-by-id [tool-id]))]
@@ -54,6 +68,20 @@
           (share-failure (tool-sharing-msg :load-failure tool-id reason)))))
     (tool-sharing-failure tool-id nil level (tool-sharing-msg :not-found tool-id))))
 
+(defn unshare-tool-with-user
+  [{username :shortUsername} sharee tool-id]
+  (if-let [tool (first (tools/get-tools-by-id [tool-id]))]
+    (let [share-failure (partial tool-unsharing-failure tool-id tool)]
+      (try+
+        (if-not (perms/has-tool-permission username tool-id "own")
+          (share-failure (tool-sharing-msg :not-allowed tool-id))
+          (if-let [failure-reason (perms-client/unshare-tool tool-id "user" sharee)]
+            (share-failure failure-reason)
+            (tool-unsharing-success tool-id tool)))
+        (catch [:type :apps.service.apps.de.permissions/permission-load-failure] {:keys [reason]}
+          (share-failure (tool-sharing-msg :load-failure tool-id reason)))))
+    (tool-unsharing-failure tool-id nil (tool-sharing-msg :not-found tool-id))))
+
 (defn- share-tools-with-user
   [sharer {sharee :user :keys [tools]}]
   (let [responses (for [{:keys [tool_id permission]} tools] (share-tool-with-user sharer sharee tool_id permission) )]
@@ -64,3 +92,14 @@
 (defn share-tools
   [user sharing-requests]
   {:sharing (mapv (partial share-tools-with-user user) sharing-requests)})
+
+(defn- unshare-tools-with-user
+  [sharer {sharee :user :keys [tools]}]
+  (let [responses (mapv (partial unshare-tool-with-user sharer sharee) tools)]
+    (cn/send-tool-unsharing-notifications (:shortUsername sharer) sharee responses)
+    {:user  sharee
+     :tools responses}))
+
+(defn unshare-tools
+  [user unsharing-requests]
+  {:unsharing (mapv (partial unshare-tools-with-user user) unsharing-requests)})

--- a/src/apps/tools/sharing.clj
+++ b/src/apps/tools/sharing.clj
@@ -1,0 +1,66 @@
+(ns apps.tools.sharing
+  (:use [clostache.parser :only [render]]
+        [slingshot.slingshot :only [try+]])
+  (:require [apps.clients.notifications :as cn]
+            [apps.clients.permissions :as perms-client]
+            [apps.tools :as tools]
+            [apps.tools.permissions :as perms]
+            [clojure-commons.error-codes :as error-codes]))
+
+(defn- get-tool-name
+  [tool-id {tool-name :name}]
+  (or tool-name (str "tool ID " tool-id)))
+
+(def tool-sharing-formats
+  {:not-found    "tool ID {{tool-id}} does not exist"
+   :load-failure "unable to load permissions for {{tool-id}}: {{detail}}"
+   :not-allowed  "insufficient privileges for tool ID {{tool-id}}"})
+
+(defn- tool-sharing-msg
+  ([reason-code tool-id]
+   (tool-sharing-msg reason-code tool-id nil))
+  ([reason-code tool-id detail]
+   (render (tool-sharing-formats reason-code)
+           {:tool-id tool-id
+            :detail  (or detail "unexpected error")})))
+
+(defn- tool-sharing-success
+  [tool-id tool level]
+  {:tool_id    (str tool-id)
+   :tool_name  (get-tool-name tool-id tool)
+   :permission level
+   :success    true})
+
+(defn- tool-sharing-failure
+  [tool-id tool level reason]
+  {:tool_id    (str tool-id)
+   :tool_name  (get-tool-name tool-id tool)
+   :permission level
+   :success    false
+   :error      {:error_code error-codes/ERR_BAD_REQUEST
+                :reason     reason}})
+
+(defn share-tool-with-user
+  [{username :shortUsername} sharee tool-id level]
+  (if-let [tool (first (tools/get-tools-by-id [tool-id]))]
+    (let [share-failure (partial tool-sharing-failure tool-id tool level)]
+      (try+
+        (if-not (perms/has-tool-permission username tool-id "own")
+          (share-failure (tool-sharing-msg :not-allowed tool-id))
+          (if-let [failure-reason (perms-client/share-tool tool-id "user" sharee level)]
+            (share-failure failure-reason)
+            (tool-sharing-success tool-id tool level)))
+        (catch [:type :apps.service.apps.de.permissions/permission-load-failure] {:keys [reason]}
+          (share-failure (tool-sharing-msg :load-failure tool-id reason)))))
+    (tool-sharing-failure tool-id nil level (tool-sharing-msg :not-found tool-id))))
+
+(defn- share-tools-with-user
+  [sharer {sharee :user :keys [tools]}]
+  (let [responses (for [{:keys [tool_id permission]} tools] (share-tool-with-user sharer sharee tool_id permission) )]
+    (cn/send-tool-sharing-notifications (:shortUsername sharer) sharee responses)
+    {:user  sharee
+     :tools responses}))
+
+(defn share-tools
+  [user sharing-requests]
+  {:sharing (mapv (partial share-tools-with-user user) sharing-requests)})

--- a/src/apps/tools/sharing.clj
+++ b/src/apps/tools/sharing.clj
@@ -64,7 +64,7 @@
           (if-let [failure-reason (perms-client/share-tool tool-id "user" sharee level)]
             (share-failure failure-reason)
             (tool-sharing-success tool-id tool level)))
-        (catch [:type :apps.service.apps.de.permissions/permission-load-failure] {:keys [reason]}
+        (catch [:type :apps.tools.permissions/permission-load-failure] {:keys [reason]}
           (share-failure (tool-sharing-msg :load-failure tool-id reason)))))
     (tool-sharing-failure tool-id nil level (tool-sharing-msg :not-found tool-id))))
 
@@ -78,7 +78,7 @@
           (if-let [failure-reason (perms-client/unshare-tool tool-id "user" sharee)]
             (share-failure failure-reason)
             (tool-unsharing-success tool-id tool)))
-        (catch [:type :apps.service.apps.de.permissions/permission-load-failure] {:keys [reason]}
+        (catch [:type :apps.tools.permissions/permission-load-failure] {:keys [reason]}
           (share-failure (tool-sharing-msg :load-failure tool-id reason)))))
     (tool-unsharing-failure tool-id nil (tool-sharing-msg :not-found tool-id))))
 


### PR DESCRIPTION
This PR adds `POST /tools/sharing` and `POST /tools/unsharing` endpoints.
These endpoints will send tool (un)sharing notifications to the sharer and sharee as appropriate.

Also, when a user shares an app that uses private tools, those tools are also shared with `read` access.