### PR TITLE
CORE-8722 Add POST /tools/permission-lister

### DIFF
--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -94,6 +94,7 @@
 
 (def list-app-permissions (partial list-resource-permissions (rt-app)))
 (def list-analysis-permissions (partial list-resource-permissions (rt-analysis)))
+(def list-tool-permissions (partial list-resource-permissions (rt-tool)))
 
 (defn delete-app-resource
   [app-id]

--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -1,7 +1,6 @@
 (ns apps.containers
   (:use [apps.persistence.app-metadata :only [get-public-tools-by-image-id
-                                              get-tools-by-image-id
-                                              update-tool]]
+                                              get-tools-by-image-id]]
         [apps.persistence.entities :only [tools
                                           container-images
                                           container-settings
@@ -10,6 +9,7 @@
                                           container-volumes-from
                                           data-containers]]
         [apps.persistence.docker-registries :only [get-registry]]
+        [apps.persistence.tools :only [update-tool]]
         [apps.util.assertions :only [assert-not-nil]]
         [apps.util.conversions :only [remove-nil-vals remove-empty-vals]]
         [apps.validation :only [validate-image-not-public

--- a/src/apps/metadata/element_listings.clj
+++ b/src/apps/metadata/element_listings.clj
@@ -1,11 +1,12 @@
 (ns apps.metadata.element-listings
   (:use [apps.persistence.app-metadata :only [parameter-types-for-tool-type]]
         [apps.persistence.entities]
-        [apps.tools :only [format-tool-listing tool-listing-base-query]]
+        [apps.tools :only [format-tool-listing]]
         [apps.util.conversions :only [remove-nil-vals]]
         [korma.core :exclude [update]]
         [slingshot.slingshot :only [throw+]])
-  (:require [apps.clients.permissions :as perms-client]))
+  (:require [apps.clients.permissions :as perms-client]
+            [apps.persistence.tools :as tools-db]))
 
 (defn get-tool-type-by-name
   "Searches for the tool type with the given name."
@@ -86,8 +87,7 @@
         tools           (-> params
                             (select-keys [:include-hidden])
                             (assoc :tool-ids tool-ids)
-                            (tool-listing-base-query)
-                            (select))]
+                            (tools-db/get-tool-listing))]
     {:tools (map (partial format-tool-listing perms public-tool-ids) tools)}))
 
 (defn- list-info-types

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -33,21 +33,6 @@
 
 (def param-reference-genome-types #{"ReferenceGenome" "ReferenceSequence" "ReferenceAnnotation"})
 
-(defn- filter-valid-tool-values
-  "Filters valid keys from the given Tool for inserting or updating in the database."
-  [tool]
-  (select-keys tool [:id
-                     :container_images_id
-                     :name
-                     :description
-                     :attribution
-                     :location
-                     :version
-                     :integration_data_id
-                     :restricted
-                     :time_limit_seconds
-                     :tool_type_id]))
-
 (defn- filter-valid-task-values
   "Filters valid keys from the given Task for inserting or updating in the database."
   [task]
@@ -258,7 +243,7 @@
       (where {:id integration-data-id})
       delete))
 
-(defn get-tool-listing-base-query
+(defn- get-tool-listing-base-query
   "Common select query for tool listings."
   []
   (-> (select* tool_listing)
@@ -269,18 +254,6 @@
               :type
               :version
               :attribution)))
-
-(defn get-tool
-  "Loads information about a single tool."
-  [tool-id]
-  (assert-not-nil
-   [:tool-id tool-id]
-   (-> (select* [:tools :t])
-       (join [:tool_types :tt] {:t.tool_type_id :tt.id})
-       (fields :t.id :t.name :t.description :t.location [:tt.name :type] :t.version :t.attribution)
-       (where {:t.id tool-id})
-       select
-       first)))
 
 (defn get-app-tools
   "Loads information about the tools associated with an app."
@@ -317,11 +290,6 @@
                        :app_id  [in (perms-client/get-public-app-ids)]}))
        (map (comp get-app :app_id))))
 
-(defn get-tool-type-id
-  "Gets the ID of the given tool type name."
-  [tool-type]
-  (:id (first (select tool_types (fields :id) (where {:name tool-type})))))
-
 (defn parameter-types-for-tool-type
   "Lists the valid parameter types for the tool type with the given identifier."
   ([tool-type-id]
@@ -332,69 +300,6 @@
                  {:tool_type_parameter_type.parameter_type_id
                   :parameter_types.id})
            (where {:tool_type_parameter_type.tool_type_id tool-type-id}))))
-
-(defn- get-tool-data-files
-  "Fetches a tool's test data files."
-  [tool-id]
-  (let [data-files (select tool_test_data_files
-                           (fields :input_file :filename)
-                           (where {:tool_id tool-id}))
-        [input-files output-files] ((juxt filter remove) :input_file data-files)]
-    {:input_files  (map :filename input-files)
-     :output_files (map :filename output-files)}))
-
-(defn get-tool-implementation-details
-  "Fetches a tool's implementation details."
-  [tool-id]
-  (let [{:keys [integrator_name integrator_email]} (get-integration-data-by-tool-id tool-id)
-        tool-data-files (get-tool-data-files tool-id)]
-    {:implementor_email integrator_email
-     :implementor       integrator_name
-     :test              tool-data-files}))
-
-(defn add-tool-data-file
-  "Adds a tool's test data files to the database"
-  [tool-id input-file filename]
-  (insert tool_test_data_files (values {:tool_id tool-id
-                                        :input_file input-file
-                                        :filename filename})))
-
-(defn add-tool
-  "Adds a new tool and its test data files to the database"
-  [{type :type {:keys [implementor_email implementor test]} :implementation :as tool}]
-  (transaction
-   (let [integration-data-id (:id (get-integration-data implementor_email implementor))
-         tool (-> tool
-                  (assoc :integration_data_id integration-data-id
-                         :tool_type_id (get-tool-type-id type))
-                  (filter-valid-tool-values))
-         tool-id (:id (insert tools (values tool)))]
-     (dorun (map (partial add-tool-data-file tool-id true) (:input_files test)))
-     (dorun (map (partial add-tool-data-file tool-id false) (:output_files test)))
-     tool-id)))
-
-(defn update-tool
-  "Updates a tool and its test data files in the database"
-  [{tool-id :id
-    type :type
-    {:keys [implementor_email implementor test] :as implementation} :implementation
-    :as tool}]
-  (transaction
-   (let [integration-data-id (when implementation
-                               (:id (get-integration-data implementor_email implementor)))
-         type-id (when type (get-tool-type-id type))
-         tool (-> tool
-                  (assoc :integration_data_id integration-data-id
-                         :tool_type_id        type-id)
-                  (dissoc :id)
-                  filter-valid-tool-values
-                  remove-nil-vals)]
-     (when-not (empty? tool)
-       (sql/update tools (set-fields tool) (where {:id tool-id})))
-     (when-not (empty? test)
-       (delete tool_test_data_files (where {:tool_id tool-id}))
-       (dorun (map (partial add-tool-data-file tool-id true) (:input_files test)))
-       (dorun (map (partial add-tool-data-file tool-id false) (:output_files test)))))))
 
 (defn- prep-app
   "Prepares an app for insertion into the database."

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -33,14 +33,6 @@
 
 (def param-reference-genome-types #{"ReferenceGenome" "ReferenceSequence" "ReferenceAnnotation"})
 
-(defn- filter-valid-app-values
-  "Filters valid keys from the given App for inserting or updating in the database, setting the
-  current date as the edited date."
-  [app]
-  (-> app
-      (select-keys [:name :description])
-      (assoc :edited_date (sqlfn now))))
-
 (defn- filter-valid-tool-values
   "Filters valid keys from the given Tool for inserting or updating in the database."
   [tool]

--- a/src/apps/persistence/tools.clj
+++ b/src/apps/persistence/tools.clj
@@ -1,0 +1,169 @@
+(ns apps.persistence.tools
+  (:use [apps.persistence.entities :only [tools
+                                          tool_test_data_files
+                                          tool_types]]
+        [apps.persistence.app-metadata :only [get-integration-data
+                                              get-integration-data-by-tool-id]]
+        [apps.util.assertions :only [assert-not-nil]]
+        [apps.util.conversions :only [remove-nil-vals]]
+        [clojure.string :only [upper-case]]
+        [kameleon.queries :only [add-query-limit
+                                 add-query-offset
+                                 add-query-sorting]]
+        [kameleon.util.search :only [format-query-wildcards]]
+        [korma.core :exclude [update]]
+        [korma.db :only [transaction]])
+  (:require [korma.core :as sql]))
+
+(defn- filter-valid-tool-values
+  "Filters valid keys from the given Tool for inserting or updating in the database."
+  [tool]
+  (select-keys tool [:id
+                     :container_images_id
+                     :name
+                     :description
+                     :attribution
+                     :location
+                     :version
+                     :integration_data_id
+                     :restricted
+                     :time_limit_seconds
+                     :tool_type_id]))
+
+(defn- get-tool-type-id
+  "Gets the ID of the given tool type name."
+  [tool-type]
+  (:id (first (select tool_types (fields :id) (where {:name tool-type})))))
+
+(defn- get-tool-data-files
+  "Fetches a tool's test data files."
+  [tool-id]
+  (let [data-files (select tool_test_data_files
+                           (fields :input_file :filename)
+                           (where {:tool_id tool-id}))
+        [input-files output-files] ((juxt filter remove) :input_file data-files)]
+    {:input_files  (map :filename input-files)
+     :output_files (map :filename output-files)}))
+
+(defn get-tool-implementation-details
+  "Fetches a tool's implementation details."
+  [tool-id]
+  (let [{:keys [integrator_name integrator_email]} (get-integration-data-by-tool-id tool-id)
+        tool-data-files (get-tool-data-files tool-id)]
+    {:implementor_email integrator_email
+     :implementor       integrator_name
+     :test              tool-data-files}))
+
+(defn- add-tool-data-file
+  "Adds a tool's test data files to the database"
+  [tool-id input-file filename]
+  (insert tool_test_data_files (values {:tool_id tool-id
+                                        :input_file input-file
+                                        :filename filename})))
+
+(defn add-tool
+  "Adds a new tool and its test data files to the database"
+  [{type :type {:keys [implementor_email implementor test]} :implementation :as tool}]
+  (transaction
+    (let [integration-data-id (:id (get-integration-data implementor_email implementor))
+          tool (-> tool
+                   (assoc :integration_data_id integration-data-id
+                          :tool_type_id (get-tool-type-id type))
+                   (filter-valid-tool-values))
+          tool-id (:id (insert tools (values tool)))]
+      (dorun (map (partial add-tool-data-file tool-id true) (:input_files test)))
+      (dorun (map (partial add-tool-data-file tool-id false) (:output_files test)))
+      tool-id)))
+
+(defn update-tool
+  "Updates a tool and its test data files in the database"
+  [{tool-id :id
+    type :type
+    {:keys [implementor_email implementor test] :as implementation} :implementation
+    :as tool}]
+  (transaction
+    (let [integration-data-id (when implementation
+                                (:id (get-integration-data implementor_email implementor)))
+          type-id (when type (get-tool-type-id type))
+          tool (-> tool
+                   (assoc :integration_data_id integration-data-id
+                          :tool_type_id        type-id)
+                   (dissoc :id)
+                   filter-valid-tool-values
+                   remove-nil-vals)]
+      (when-not (empty? tool)
+        (sql/update tools (set-fields tool) (where {:id tool-id})))
+      (when-not (empty? test)
+        (delete tool_test_data_files (where {:tool_id tool-id}))
+        (dorun (map (partial add-tool-data-file tool-id true) (:input_files test)))
+        (dorun (map (partial add-tool-data-file tool-id false) (:output_files test)))))))
+
+(defn- add-listing-where-clause
+  [query tool-ids]
+  (if (empty? tool-ids)
+    query
+    (where query {:tools.id [in tool-ids]})))
+
+(defn- add-search-where-clauses
+  "Adds where clauses to a base tool search query to restrict results to tools that contain the
+   given search term in their name or description."
+  [base-query search-term]
+  (if search-term
+    (let [search-term (format-query-wildcards search-term)
+          search-term (str "%" search-term "%")]
+      (where base-query
+             (or
+               {(sqlfn lower :tools.name) [like (sqlfn lower search-term)]}
+               {(sqlfn lower :tools.description) [like (sqlfn lower search-term)]})))
+    base-query))
+
+(defn- add-hidden-tool-types-clause
+  "Adds the clause used to filter out hidden tool types if hidden tool types are not supposed to
+   be included in the result set."
+  [base-query include-hidden]
+  (if-not include-hidden
+    (where base-query {:tool_types.hidden false})
+    base-query))
+
+(defn- tool-listing-base-query
+  "Obtains a listing query for tools, with optional search and paging params."
+  ([]
+   (-> (select* tools)
+       (fields [:tools.id :id]
+               [:tools.name :name]
+               [:tools.description :description]
+               [:tools.location :location]
+               [:tool_types.name :type]
+               [:tools.version :version]
+               [:tools.attribution :attribution]
+               [:tools.restricted :restricted]
+               [:tools.time_limit_seconds :time_limit_seconds])
+       (join tool_types)))
+  ([{search-term :search :keys [tool-ids sort-field sort-dir limit offset include-hidden]
+     :or {include-hidden false}}]
+   (let [sort-field (when sort-field (keyword (str "tools." sort-field)))
+         sort-dir (when sort-dir (keyword (upper-case sort-dir)))]
+     (-> (tool-listing-base-query)
+         (add-search-where-clauses search-term)
+         (add-listing-where-clause tool-ids)
+         (add-query-sorting sort-field sort-dir)
+         (add-query-limit limit)
+         (add-query-offset offset)
+         (add-hidden-tool-types-clause include-hidden)))))
+
+(defn get-tool-listing
+  [params]
+  (select (tool-listing-base-query params)))
+
+(defn get-tool
+  "Obtains a tool for the given tool ID, throwing a `not-found` error if the tool doesn't exist."
+  [tool-id]
+  (->> (select (tool-listing-base-query) (where {:tools.id tool-id}))
+       first
+       (assert-not-nil [:tool-id tool-id])))
+
+(defn get-tools-by-id
+  "Obtains a listing of tools for the given list of IDs."
+  [tool-ids]
+  (map remove-nil-vals
+       (select (tool-listing-base-query) (where {:tools.id [in tool-ids]}))))

--- a/src/apps/routes/schemas/permission.clj
+++ b/src/apps/routes/schemas/permission.clj
@@ -129,6 +129,17 @@
 (defschema AnalysisUnsharingResponse
   {:unsharing (describe [UserAnalysisUnsharingResponseElement] "The list of unsharing responses for individual users")})
 
+(defschema ToolIdList
+  {:tools (describe [UUID] "A List of Tool IDs")})
+
+(defschema ToolPermissionListElement
+  {:id          (describe UUID "The Tool ID")
+   :name        (describe NonBlankString "The Tool name")
+   :permissions (describe [UserPermissionListElement] "The list of user permissions for the Tool")})
+
+(defschema ToolPermissionListing
+  {:tools (describe [ToolPermissionListElement] "The list of Tool permissions")})
+
 (defschema ToolSharingRequestElement
   {:tool_id    (describe UUID "The Tool ID")
    :permission (describe ToolPermissionEnum "The requested permission level")})

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -15,6 +15,7 @@
         [ring.util.http-response :only [ok]])
   (:require [apps.routes.schemas.permission :as permission]
             [apps.service.apps :as apps]
+            [apps.tools.permissions :as tool-permissions]
             [apps.tools.sharing :as tool-sharing]))
 
 (def entrypoint-warning
@@ -146,6 +147,15 @@ Configured default values will be used for the `time_limit_seconds`, `container.
 The request may include a value less than the configured default if it's also greater than 0,
 otherwise the default value will be used."
         (ok (add-private-tool current-user body)))
+
+  (POST "/permission-lister" []
+        :query [params SecuredQueryParams]
+        :body [{:keys [tools]} (describe permission/ToolIdList "The Tool permission listing request.")]
+        :return permission/ToolPermissionListing
+        :summary "List Tool Permissions"
+        :description "This endpoint allows the caller to list the permissions for one or more Tools.
+        The authenticated user must have read permission on every Tool in the request body for this endpoint to succeed."
+        (ok (tool-permissions/list-tool-permissions current-user tools)))
 
   (POST "/sharing" []
         :query [params SecuredQueryParams]

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -4,7 +4,7 @@
         [apps.persistence.app-groups]
         [apps.persistence.app-listing]
         [apps.persistence.entities]
-        [apps.tools :only [get-tools-by-id]]
+        [apps.persistence.tools :only [get-tools-by-id]]
         [apps.util.assertions :only [assert-not-nil]]
         [apps.util.config]
         [apps.util.conversions :only [to-long remove-nil-vals]]

--- a/src/apps/service/integration_data.clj
+++ b/src/apps/service/integration_data.clj
@@ -2,6 +2,7 @@
   (:use [korma.db :only [transaction]]
         [medley.core :only [remove-vals]])
   (:require [apps.persistence.app-metadata :as amp]
+            [apps.persistence.tools :as tools-db]
             [apps.util.config :as cfg]
             [clojure.string :as string]
             [clojure-commons.exception-util :as cxu]))
@@ -109,7 +110,7 @@
     (not-found integration-data-id)))
 
 (defn update-integration-data-for-tool [_ tool-id integration-data-id]
-  (amp/get-tool tool-id)
+  (tools-db/get-tool tool-id)
   (if-let [integration-data (amp/get-integration-data-by-id integration-data-id)]
     (do (amp/update-tool-integration-data tool-id integration-data-id)
         (format-integration-data integration-data))

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -1,72 +1,15 @@
 (ns apps.tools
   (:use [apps.containers :only [add-tool-container set-tool-container tool-container-info]]
-        [apps.persistence.entities :only [tools tool_types]]
-        [apps.util.assertions :only [assert-not-nil]]
+        [apps.persistence.entities :only [tools]]
         [apps.util.conversions :only [remove-nil-vals]]
         [apps.validation :only [verify-tool-name-location validate-tool-not-used]]
-        [clojure.string :only [upper-case]]
-        [kameleon.queries]
-        [kameleon.util.search]
         [korma.core :exclude [update]]
         [korma.db :only [transaction]]
         [slingshot.slingshot :only [try+]])
   (:require [apps.clients.permissions :as perms-client]
-            [apps.persistence.app-metadata :as persistence]
+            [apps.persistence.tools :as persistence]
             [apps.tools.permissions :as permissions]
             [clojure.tools.logging :as log]))
-
-(defn- add-listing-where-clause
-  [query tool-ids]
-  (if (empty? tool-ids)
-    query
-    (where query {:tools.id [in tool-ids]})))
-
-(defn- add-search-where-clauses
-  "Adds where clauses to a base tool search query to restrict results to tools that contain the
-   given search term in their name or description."
-  [base-query search-term]
-  (if search-term
-    (let [search-term (format-query-wildcards search-term)
-          search-term (str "%" search-term "%")]
-      (where base-query
-             (or
-              {(sqlfn lower :tools.name) [like (sqlfn lower search-term)]}
-              {(sqlfn lower :tools.description) [like (sqlfn lower search-term)]})))
-    base-query))
-
-(defn- add-hidden-tool-types-clause
-  "Adds the clause used to filter out hidden tool types if hidden tool types are not supposed to
-   be included in the result set."
-  [base-query include-hidden]
-  (if-not include-hidden
-    (where base-query {:tool_types.hidden false})
-    base-query))
-
-(defn tool-listing-base-query
-  "Obtains a listing query for tools, with optional search and paging params."
-  ([]
-   (-> (select* tools)
-       (fields [:tools.id :id]
-               [:tools.name :name]
-               [:tools.description :description]
-               [:tools.location :location]
-               [:tool_types.name :type]
-               [:tools.version :version]
-               [:tools.attribution :attribution]
-               [:tools.restricted :restricted]
-               [:tools.time_limit_seconds :time_limit_seconds])
-       (join tool_types)))
-  ([{search-term :search :keys [tool-ids sort-field sort-dir limit offset include-hidden]
-                         :or {include-hidden false}}]
-   (let [sort-field (when sort-field (keyword (str "tools." sort-field)))
-         sort-dir (when sort-dir (keyword (upper-case sort-dir)))]
-     (-> (tool-listing-base-query)
-         (add-search-where-clauses search-term)
-         (add-listing-where-clause tool-ids)
-         (add-query-sorting sort-field sort-dir)
-         (add-query-limit limit)
-         (add-query-offset offset)
-         (add-hidden-tool-types-clause include-hidden)))))
 
 (defn format-tool-listing
   [perms public-tool-ids {:keys [id] :as tool}]
@@ -83,14 +26,13 @@
         public-tool-ids (perms-client/get-public-tool-ids)]
     {:tools
      (map (partial format-tool-listing perms public-tool-ids)
-       (select (tool-listing-base-query (assoc params :tool-ids tool-ids))))}))
+          (persistence/get-tool-listing (assoc params :tool-ids tool-ids)))}))
 
 (defn get-tool
   "Obtains a tool by ID."
   [user tool-id]
   (permissions/check-tool-permissions user "read" [tool-id])
-  (let [tool           (->> (first (select (tool-listing-base-query) (where {:tools.id tool-id})))
-                            (assert-not-nil [:tool-id tool-id])
+  (let [tool           (->> (persistence/get-tool tool-id)
                             (format-tool-listing (perms-client/load-tool-permissions user)
                                                  (perms-client/get-public-tool-ids)))
         container      (tool-container-info tool-id)
@@ -98,12 +40,6 @@
     (assoc tool
       :container container
       :implementation implementation)))
-
-(defn get-tools-by-id
-  "Obtains a listing of tools for the given list of IDs."
-  [tool-ids]
-  (map remove-nil-vals
-    (select (tool-listing-base-query) (where {:tools.id [in tool-ids]}))))
 
 (defn- add-new-tool
   [{:keys [container] :as tool}]

--- a/src/apps/tools/permissions.clj
+++ b/src/apps/tools/permissions.clj
@@ -2,8 +2,23 @@
   (:use [clojure-commons.error-codes :only [clj-http-error?]]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [apps.clients.permissions :as permissions]
+            [apps.persistence.tools :as tools-db]
+            [apps.util.service :as service]
             [clojure-commons.exception-util :as exception-util]
             [clojure.string :as string]))
+
+(defn- list-non-existent-tool-ids
+  [tool-id-set]
+  (->> (tools-db/get-tools-by-id tool-id-set)
+       (map :id)
+       (set)
+       (clojure.set/difference tool-id-set)))
+
+(defn- validate-tools-existence
+  [tool-ids]
+  (let [missing-ids (list-non-existent-tool-ids (set tool-ids))]
+    (when-not (empty? missing-ids)
+      (service/not-found "tools" tool-ids))))
 
 (defn check-tool-permissions
   [user required-level tool-ids]
@@ -19,3 +34,17 @@
     (catch clj-http-error? {:keys [body]}
       (throw+ {:type   ::permission-load-failure
                :reason (permissions/extract-error-message body)}))))
+
+(defn- format-tool-permissions
+  [perms {:keys [id name]}]
+  {:id          id
+   :name        name
+   :permissions (perms id)})
+
+(defn list-tool-permissions
+  [{user :shortUsername} tool-ids]
+  (validate-tools-existence tool-ids)
+  (check-tool-permissions user "read" tool-ids)
+  (let [perms (permissions/list-tool-permissions user tool-ids)
+        tools (tools-db/get-tools-by-id tool-ids)]
+    {:tools (mapv (partial format-tool-permissions perms) tools)}))

--- a/src/apps/tools/private.clj
+++ b/src/apps/tools/private.clj
@@ -3,7 +3,7 @@
         [korma.db :only [transaction]])
   (:require [apps.clients.permissions :as permissions]
             [apps.containers :as containers]
-            [apps.persistence.app-metadata :as persistence]
+            [apps.persistence.tools :as persistence]
             [apps.tools :as tools]
             [apps.util.config :as cfg]))
 

--- a/src/apps/tools/sharing.clj
+++ b/src/apps/tools/sharing.clj
@@ -3,7 +3,7 @@
         [slingshot.slingshot :only [try+]])
   (:require [apps.clients.notifications :as cn]
             [apps.clients.permissions :as perms-client]
-            [apps.tools :as tools]
+            [apps.persistence.tools :as tools-db]
             [apps.tools.permissions :as perms]
             [clojure-commons.error-codes :as error-codes]))
 
@@ -56,7 +56,7 @@
 
 (defn share-tool-with-user
   [{username :shortUsername} sharee tool-id level]
-  (if-let [tool (first (tools/get-tools-by-id [tool-id]))]
+  (if-let [tool (first (tools-db/get-tools-by-id [tool-id]))]
     (let [share-failure (partial tool-sharing-failure tool-id tool level)]
       (try+
         (if-not (perms/has-tool-permission username tool-id "own")
@@ -70,7 +70,7 @@
 
 (defn unshare-tool-with-user
   [{username :shortUsername} sharee tool-id]
-  (if-let [tool (first (tools/get-tools-by-id [tool-id]))]
+  (if-let [tool (first (tools-db/get-tools-by-id [tool-id]))]
     (let [share-failure (partial tool-unsharing-failure tool-id tool)]
       (try+
         (if-not (perms/has-tool-permission username tool-id "own")


### PR DESCRIPTION
This PR adds a `POST /tools/permission-lister` endpoint.

To prevent a circular dependency between `apps.tools.permissions` and `apps.tools`, the 2nd commit of this PR refactors tools db functions out of `apps.tools` and `apps.persistence.app-metadata` into `apps.persistence.tools`.

The last commit actually adds the new endpoint.