### PR TITLE
CORE-8693 Add `PATCH /tool/:tool-id` endpoint.

### DIFF
--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -14,7 +14,7 @@
         [apps.util.conversions :only [remove-nil-vals remove-empty-vals]]
         [apps.validation :only [validate-image-not-public
                                 validate-image-not-used
-                                validate-tool-not-public]]
+                                validate-tool-not-used-in-public-apps]]
         [kameleon.uuids :only [uuidify]]
         [korma.core :exclude [update]]
         [korma.db :only [transaction]])
@@ -625,7 +625,7 @@
    overwrite-public
    {:keys [container_devices container_volumes container_volumes_from] :as settings}]
   (when-not overwrite-public
-    (validate-tool-not-public tool-id))
+    (validate-tool-not-used-in-public-apps tool-id))
   (transaction
     (delete container-settings (where {:tools_id tool-id}))
     (let [img-id      (find-or-add-image-id (:image settings))

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -65,10 +65,16 @@
           containers/VolumesFromParamOptional))
 
 (defschema PrivateToolImportRequest
-  (-> Tool
-      (->optional-param :id)
+  (-> ToolImportRequest
       (->optional-param :type)
+      (->optional-param :implementation)
       (merge {:container PrivateToolContainerImportRequest})))
+
+(defschema PrivateToolUpdateRequest
+  (-> PrivateToolImportRequest
+      (->optional-param :name)
+      (->optional-param :location)
+      (->optional-param :container)))
 
 (defschema ToolsImportRequest
   {:tools (describe [ToolImportRequest] "zero or more Tool definitions")})

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -8,7 +8,7 @@
         [apps.routes.schemas.integration-data :only [IntegrationData]]
         [apps.routes.schemas.tool]
         [apps.tools :only [add-tools delete-tool get-tool search-tools update-tool]]
-        [apps.tools.private :only [add-private-tool]]
+        [apps.tools.private :only [add-private-tool update-private-tool]]
         [apps.user :only [current-user]]
         [apps.util.service]
         [slingshot.slingshot :only [throw+]]
@@ -134,7 +134,7 @@
 
   (POST "/" []
         :query [params SecuredQueryParamsRequired]
-        :body [body (describe PrivateToolImportRequest "The Tool to import.")]
+        :body [body (describe PrivateToolImportRequest "The private Tool to import.")]
         :return ToolDetails
         :summary "Add Private Tool"
         :description
@@ -189,6 +189,24 @@ otherwise the default value will be used."
         :summary "Get a Tool"
         :description "This endpoint returns the details for one tool."
         (ok (get-tool user tool-id)))
+
+  (PATCH "/:tool-id" []
+         :path-params [tool-id :- ToolIdParam]
+         :query [{:keys [user]} SecuredQueryParams]
+         :body [body (describe PrivateToolUpdateRequest "The private Tool to update.")]
+         :return ToolDetails
+         :summary "Update a Private Tool"
+         :description "This service updates a private Tool definition in the DE.
+As with new private Tools, `type` is always set to `executable` and `restricted` is always set to `true`,
+even if other values are set in the request,
+and a configured limit may override the `time_limit_seconds` field set in the request.
+
+**Note**: If the `container` object is omitted in the request, then existing container settings will not be modified,
+but if the `container` object is present in the request, then all container settings must be included in it.
+Any existing settings not included in the request's `container` object will be removed,
+except `network_mode` is always set to `none` and configured limits may override values set (or omitted)
+for the `cpu_shares` and `memory_limit` fields."
+         (ok (update-private-tool user (assoc body :id tool-id))))
 
   (GET "/:tool-id/container" []
         :path-params [tool-id :- ToolIdParam]

--- a/src/apps/tools/private.clj
+++ b/src/apps/tools/private.clj
@@ -1,11 +1,13 @@
 (ns apps.tools.private
   (:use [apps.validation :only [verify-tool-name-location validate-tool-not-used]]
         [korma.db :only [transaction]])
-  (:require [apps.clients.permissions :as permissions]
+  (:require [apps.clients.permissions :as perms-client]
             [apps.containers :as containers]
             [apps.persistence.tools :as persistence]
             [apps.tools :as tools]
-            [apps.util.config :as cfg]))
+            [apps.tools.permissions :as perms]
+            [apps.util.config :as cfg]
+            [apps.validation :as validation]))
 
 (defn- restrict-private-tool-setting
   [setting max]
@@ -22,14 +24,20 @@
                    :cpu_shares   (restrict-private-tool-setting cpu_shares   (cfg/private-tool-cpu-shares))
                    :memory_limit (restrict-private-tool-setting memory_limit (cfg/private-tool-memory-limit))))
 
-(defn- restrict-private-tool
-  "Set restricted flag, time limit, and default type."
+(defn- restrict-private-tool-time-limit
+  "Restrict the tool's time limit setting."
   [{:keys [time_limit_seconds] :or {time_limit_seconds (cfg/private-tool-time-limit-seconds)}
     :as tool}]
-  (assoc tool :type               "executable"
-              :restricted         true
-              :time_limit_seconds (restrict-private-tool-setting
-                                    time_limit_seconds (cfg/private-tool-time-limit-seconds))))
+  (assoc tool :time_limit_seconds (restrict-private-tool-setting time_limit_seconds
+                                                                 (cfg/private-tool-time-limit-seconds))))
+
+(defn- restrict-private-tool
+  "Set restricted flag, time limit, and default type."
+  [tool]
+  (-> tool
+      (assoc :restricted true
+             :type       "executable")
+      restrict-private-tool-time-limit))
 
 (defn- ensure-default-implementation
   "If implementation details were not given, then some defaults are populated with info about the current user."
@@ -50,5 +58,19 @@
                       (assoc :implementation (ensure-default-implementation user implementation))
                       persistence/add-tool)]
       (containers/add-tool-container tool-id (restrict-private-tool-container container))
-      (permissions/register-private-tool shortUsername tool-id)
+      (perms-client/register-private-tool shortUsername tool-id)
       (tools/get-tool shortUsername tool-id))))
+
+(defn update-private-tool
+  [user {:keys [container time_limit_seconds] tool-id :id :as tool}]
+  (perms/check-tool-permissions user "write" [tool-id])
+  (validation/validate-tool-not-public tool-id)
+  (let [current-time-limit (:time_limit_seconds (persistence/get-tool tool-id))
+        tool (-> tool
+                 (dissoc :type :restricted)
+                 (assoc :time_limit_seconds (or time_limit_seconds current-time-limit))
+                 restrict-private-tool-time-limit)]
+    (persistence/update-tool tool)
+    (when container
+      (containers/set-tool-container tool-id false (restrict-private-tool-container container))))
+  (tools/get-tool user tool-id))

--- a/test/apps/service/apps/public_apps_test.clj
+++ b/test/apps/service/apps/public_apps_test.clj
@@ -54,10 +54,10 @@
 (deftest validate-tool-not-public
   (let [user (get-user :testde1)
         app  (atf/create-test-tool-app user "To be published")]
-    (is (nil? (v/validate-tool-not-public atf/test-tool-id)))
+    (is (nil? (v/validate-tool-not-used-in-public-apps atf/test-tool-id)))
     (sql/delete :app_documentation (sql/where {:app_id (:id app)}))
     (apps/make-app-public user de-system-id app)
-    (is (thrown-with-msg? ExceptionInfo #"in use by public apps" (v/validate-tool-not-public atf/test-tool-id)))
+    (is (thrown-with-msg? ExceptionInfo #"in use by public apps" (v/validate-tool-not-used-in-public-apps atf/test-tool-id)))
     (permanently-delete-app user de-system-id (:id app) true)))
 
 (deftest validate-app-trash


### PR DESCRIPTION
This PR adds a `PATCH /tool/:tool-id` endpoint to allow users to update their private tools.

As with the `POST /tools` endpoint, `type` is always set to `executable` and `restricted` is always set to `true`, even if other values are set in the request, and a configured limit may override the `time_limit_seconds` field set in the request.

Also, similar to the `PATCH /admin/tool/:tool-id` endpoint, if the `container` object is omitted in the request, then existing container settings will not be modified, but if the `container` object is present in the request, then all container settings must be included in it. Any existing settings not included in the request's `container` object will be removed, except `network_mode` is always set to `none` and configured limits may override values set (or omitted) for the `cpu_shares` and `memory_limit` fields.

The `POST /tools` endpoint was also updated to allow `implementation` details in its requests (also allowed in the new PATCH endpoint).