### PR TITLE
CORE-8694 Add DELETE /tools/:tool-id endpoint.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.0.0"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.8.2"]
+                 [org.cyverse/common-swagger-api "2.8.3"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]
                  [org.cyverse/event-messages "0.0.1"]

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -402,6 +402,13 @@
                 (set-fields (assoc (filter-valid-task-values task) :job_type_id job-type-id))
                 (where {:id task-id}))))
 
+(defn remove-tool-from-tasks
+  "Removes the given tool ID from all tasks."
+  [tool-id]
+  (sql/update tasks
+              (set-fields {:tool_id nil})
+              (where      {:tool_id tool-id})))
+
 (defn remove-app-steps
   "Removes all steps from an App. This delete will cascade to workflow_io_maps and
   input_output_mapping entries."

--- a/src/apps/persistence/tools.clj
+++ b/src/apps/persistence/tools.clj
@@ -3,7 +3,8 @@
                                           tool_test_data_files
                                           tool_types]]
         [apps.persistence.app-metadata :only [get-integration-data
-                                              get-integration-data-by-tool-id]]
+                                              get-integration-data-by-tool-id
+                                              remove-tool-from-tasks]]
         [apps.util.assertions :only [assert-not-nil]]
         [apps.util.conversions :only [remove-nil-vals]]
         [clojure.string :only [upper-case]]
@@ -97,6 +98,12 @@
         (delete tool_test_data_files (where {:tool_id tool-id}))
         (dorun (map (partial add-tool-data-file tool-id true) (:input_files test)))
         (dorun (map (partial add-tool-data-file tool-id false) (:output_files test)))))))
+
+(defn delete-tool
+  [tool-id]
+  (transaction
+    (remove-tool-from-tasks tool-id)
+    (delete tools (where {:id tool-id}))))
 
 (defn- add-listing-where-clause
   [query tool-ids]

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -15,6 +15,11 @@
 (def ToolRestricted (describe Boolean "Determines whether a time limit is applied and whether network access is granted"))
 (def ToolTimeLimit (describe Integer "The number of seconds that a tool is allowed to execute. A value of 0 means the time limit is disabled."))
 
+(defschema PrivateToolDeleteParams
+  (merge SecuredQueryParams
+         {(optional-key :force-delete)
+          (describe Boolean "Flag to force deletion of a Tool already in use by Apps.")}))
+
 (defschema ToolUpdateParams
   (merge SecuredQueryParams
     {(optional-key :overwrite-public)

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -7,8 +7,8 @@
         [apps.routes.schemas.containers]
         [apps.routes.schemas.integration-data :only [IntegrationData]]
         [apps.routes.schemas.tool]
-        [apps.tools :only [add-tools delete-tool get-tool search-tools update-tool]]
-        [apps.tools.private :only [add-private-tool update-private-tool]]
+        [apps.tools :only [add-tools admin-delete-tool get-tool search-tools update-tool]]
+        [apps.tools.private :only [add-private-tool delete-private-tool update-private-tool]]
         [apps.user :only [current-user]]
         [apps.util.service]
         [slingshot.slingshot :only [throw+]]
@@ -181,6 +181,17 @@ otherwise the default value will be used."
         The authenticated user must have ownership permission to every Tool in the request body for this endoint to fully succeed.
         Note: like Tool sharing, this is a potentially slow operation."
         (ok (tool-sharing/unshare-tools current-user unsharing)))
+
+  (DELETE "/:tool-id" []
+          :path-params [tool-id :- ToolIdParam]
+          :query [{:keys [user force-delete]} PrivateToolDeleteParams]
+          :summary "Delete a Private Tool"
+          :description "Deletes a private Tool, as long as it is not in use by any Apps.
+          The requesting user must have ownership permission for the Tool.
+          If the Tool is already in use in private Apps,
+          then an `ERR_NOT_WRITEABLE` will be returned along with a listing of the Apps using this Tool,
+          unless the `force-delete` flag is set to `true`."
+          (ok (delete-private-tool user tool-id force-delete)))
 
   (GET "/:tool-id" []
         :path-params [tool-id :- ToolIdParam]
@@ -401,7 +412,7 @@ for the `cpu_shares` and `memory_limit` fields."
            :query [{:keys [user]} SecuredQueryParams]
            :summary "Delete a Tool"
            :description "Deletes a tool, as long as it is not in use by any apps."
-           (ok (delete-tool user tool-id)))
+           (ok (admin-delete-tool user tool-id)))
 
   (PATCH "/:tool-id" []
           :path-params [tool-id :- ToolIdParam]

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -185,6 +185,14 @@ otherwise the default value will be used."
   (DELETE "/:tool-id" []
           :path-params [tool-id :- ToolIdParam]
           :query [{:keys [user force-delete]} PrivateToolDeleteParams]
+          :responses (merge CommonResponses
+                            {200 {:description "The Tool was successfully deleted."}
+                             400 {:schema      ErrorResponseNotWritable
+                                  :description "The Tool could not be deleted."}
+                             403 {:schema      ErrorResponseForbidden
+                                  :description "The requesting user does not have permission to delete this Tool."}
+                             404 {:schema      ErrorResponseNotFound
+                                  :description "A Tool with the given `tool-id` does not exist."}})
           :summary "Delete a Private Tool"
           :description "Deletes a private Tool, as long as it is not in use by any Apps.
           The requesting user must have ownership permission for the Tool.

--- a/src/apps/tools/private.clj
+++ b/src/apps/tools/private.clj
@@ -74,3 +74,14 @@
     (when container
       (containers/set-tool-container tool-id false (restrict-private-tool-container container))))
   (tools/get-tool user tool-id))
+
+(defn delete-private-tool
+  "Deletes a private tool if user has `own` permission for the tool.
+   If `force-delete` is not truthy, then the tool is validated as not in use by any apps."
+  [user tool-id force-delete]
+  (persistence/get-tool tool-id)
+  (perms/check-tool-permissions user "own" [tool-id])
+  (validation/validate-tool-not-public tool-id)
+  (when-not force-delete
+    (validate-tool-not-used tool-id))
+  (tools/delete-tool tool-id))


### PR DESCRIPTION
This PR adds a `DELETE /tools/:tool-id` endpoint that allows a user to delete a private tool, as long as it is not in use by any apps.

The requesting user must have ownership permission for the tool.

If the tool is already in use in private apps, then an `ERR_NOT_WRITEABLE` will be returned along with a listing of the apps using this tool (same as the `DELETE /admin/tools/:tool-id` endpoint); unless the `force-delete` flag is set to `true`, then the tool will be removed from those apps and then deleted.