### PR TITLE
CORE-8748 / CORE-7531: Update tool listings and search

### DIFF
--- a/src/apps/routes/params.clj
+++ b/src/apps/routes/params.clj
@@ -101,7 +101,10 @@
 
 (s/defschema ToolSearchParams
   (merge SecuredPagingParams IncludeHiddenParams
-    {:search (describe String "The pattern to match in an Tool's Name or Description.")}))
+    {(s/optional-key :search) (describe String "The pattern to match in an Tool's Name or Description.")
+     (s/optional-key :public) (describe Boolean
+                                        "Set to `true` to list only public Tools, `false` to list only private Tools,
+                                         or leave unset to list all Tools.")}))
 
 (s/defschema AppParameterTypeParams
   (merge SecuredQueryParams

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -30,10 +30,13 @@
    :input_files           (describe [String] "The list of paths to test input files in iRODS")
    :output_files          (describe [String] "The list of paths to expected output files in iRODS")})
 
-(defschema ToolImplementation
+(defschema ToolImplementor
   {:implementor       (describe String "The name of the implementor")
-   :implementor_email (describe String "The email address of the implementor")
-   :test              (describe ToolTestData "The test data for the Tool")})
+   :implementor_email (describe String "The email address of the implementor")})
+
+(defschema ToolImplementation
+  (merge ToolImplementor
+         {:test (describe ToolTestData "The test data for the Tool")}))
 
 (defschema Tool
   {:id                                ToolIdParam
@@ -54,8 +57,9 @@
           :container      containers/ToolContainer}))
 
 (defschema ToolListingItem
-  (merge (dissoc ToolDetails :implementation)
-         {:container {:image (dissoc containers/Image :id)}}))
+  (merge ToolDetails
+         {:implementation (describe ToolImplementor ToolImplementationDocs)
+          :container      {:image (dissoc containers/Image :id)}}))
 
 (defschema ToolImportRequest
   (-> Tool

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -46,15 +46,16 @@
    (optional-key :restricted)         ToolRestricted
    (optional-key :time_limit_seconds) ToolTimeLimit})
 
-(defschema ToolListingItem
-  (merge Tool
-    {:is_public  (describe Boolean "Whether the Tool has been published and is viewable by all users")
-     :permission (describe String "The user's access level for the Tool")}))
-
 (defschema ToolDetails
-  (merge ToolListingItem
-    {:implementation (describe ToolImplementation ToolImplementationDocs)
-     :container      containers/ToolContainer}))
+  (merge Tool
+         {:is_public      (describe Boolean "Whether the Tool has been published and is viewable by all users")
+          :permission     (describe String "The user's access level for the Tool")
+          :implementation (describe ToolImplementation ToolImplementationDocs)
+          :container      containers/ToolContainer}))
+
+(defschema ToolListingItem
+  (merge (dissoc ToolDetails :implementation)
+         {:container {:image (dissoc containers/Image :id)}}))
 
 (defschema ToolImportRequest
   (-> Tool

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -7,7 +7,7 @@
         [apps.routes.schemas.containers]
         [apps.routes.schemas.integration-data :only [IntegrationData]]
         [apps.routes.schemas.tool]
-        [apps.tools :only [add-tools admin-delete-tool get-tool search-tools update-tool]]
+        [apps.tools :only [add-tools admin-delete-tool get-tool list-tools update-tool]]
         [apps.tools.private :only [add-private-tool delete-private-tool update-private-tool]]
         [apps.user :only [current-user]]
         [apps.util.service]
@@ -125,12 +125,11 @@
 
 (defroutes tools
   (GET "/" []
-        :query [params ToolSearchParams]
-        :return ToolListing
-        :summary "Search Tools"
-        :description "This endpoint allows users to search for a tool with a name or description that
-        contains the given search term."
-        (ok (search-tools params)))
+       :query [params ToolSearchParams]
+       :return ToolListing
+       :summary "List Tools"
+       :description "This endpoint allows users to get a listing of all Tools accessible to the user."
+       (ok (list-tools params)))
 
   (POST "/" []
         :query [params SecuredQueryParamsRequired]

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -12,13 +12,15 @@
             [clojure.tools.logging :as log]))
 
 (defn format-tool-listing
-  [perms public-tool-ids {:keys [id image_name image_tag] :as tool}]
+  [perms public-tool-ids {:keys [id image_name image_tag implementor implementor_email] :as tool}]
   (-> tool
-      (assoc :is_public  (contains? public-tool-ids id)
-             :permission (or (perms id) "")
-             :container  {:image {:name image_name
-                                  :tag  image_tag}})
-      (dissoc :image_name :image_tag)
+      (assoc :is_public      (contains? public-tool-ids id)
+             :permission     (or (perms id) "")
+             :implementation {:implementor       implementor
+                              :implementor_email implementor_email}
+             :container      {:image {:name image_name
+                                      :tag  image_tag}})
+      (dissoc :image_name :image_tag :implementor :implementor_email)
       remove-nil-vals))
 
 (defn- filter-listing-tool-ids

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -12,10 +12,13 @@
             [clojure.tools.logging :as log]))
 
 (defn format-tool-listing
-  [perms public-tool-ids {:keys [id] :as tool}]
+  [perms public-tool-ids {:keys [id image_name image_tag] :as tool}]
   (-> tool
       (assoc :is_public  (contains? public-tool-ids id)
-             :permission (or (perms id) ""))
+             :permission (or (perms id) "")
+             :container  {:image {:name image_name
+                                  :tag  image_tag}})
+      (dissoc :image_name :image_tag)
       remove-nil-vals))
 
 (defn- filter-listing-tool-ids


### PR DESCRIPTION
This PR updates the `GET /tools` listing endpoint (which also updates the `GET /apps/elements/tools` listing response):

* The `search` param is now optional.
* An optional `public` param now allows `GET /tools` to return only public, only private, or all tools.
* The tool's Docker image `name` and `tag` are now included in listing results.
* The tool's implementor name and implementor email are now included in listing results.
* The `search` param can now match a tool's Docker image name, integrator name, or integrator email.