### PR TITLE
CORE-8697 Add `GET /admin/tools` and `GET /admin/tools/:tool-id` endpoints

### DIFF
--- a/src/apps/persistence/tools.clj
+++ b/src/apps/persistence/tools.clj
@@ -185,3 +185,8 @@
   [tool-ids]
   (map remove-nil-vals
        (select (tool-listing-base-query) (where {:tools.id [in tool-ids]}))))
+
+(defn get-tool-ids
+  "Obtains a list of all tool IDs."
+  []
+  (map :id (select tools (fields :id))))

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -15,6 +15,9 @@
 (def ToolRestricted (describe Boolean "Determines whether a time limit is applied and whether network access is granted"))
 (def ToolTimeLimit (describe Integer "The number of seconds that a tool is allowed to execute. A value of 0 means the time limit is disabled."))
 
+(defschema ToolIdsList
+  {:tool_ids (describe [UUID] "A List of Tool IDs")})
+
 (defschema PrivateToolDeleteParams
   (merge SecuredQueryParams
          {(optional-key :force-delete)

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -7,7 +7,7 @@
         [apps.routes.schemas.containers]
         [apps.routes.schemas.integration-data :only [IntegrationData]]
         [apps.routes.schemas.tool]
-        [apps.tools :only [add-tools admin-delete-tool get-tool list-tools update-tool]]
+        [apps.tools :only [add-tools admin-delete-tool admin-list-tools get-tool list-tools update-tool]]
         [apps.tools.private :only [add-private-tool delete-private-tool update-private-tool]]
         [apps.user :only [current-user]]
         [apps.util.service]
@@ -416,6 +416,13 @@ for the `cpu_shares` and `memory_limit` fields."
         (ok (list-tool-request-status-codes params))))
 
 (defroutes admin-tools
+  (GET "/" []
+       :query [params ToolSearchParams]
+       :return ToolListing
+       :summary "List Tools"
+       :description "This endpoint allows admins to get a listing of all Tools."
+       (ok (admin-list-tools params)))
+
   (POST "/" []
          :query [params SecuredQueryParams]
          :body [body (describe ToolsImportRequest "The Tools to import.")]

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -94,6 +94,7 @@
 
 (defn admin-update-tool
   [user overwrite-public {:keys [id container] :as tool}]
+  (persistence/get-tool id)
   (persistence/update-tool tool)
   (when container
     (set-tool-container id overwrite-public container))

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -49,7 +49,6 @@
 (defn get-tool
   "Obtains a tool by ID."
   [user tool-id]
-  (permissions/check-tool-permissions user "read" [tool-id])
   (let [tool           (->> (persistence/get-tool tool-id)
                             (format-tool-listing (perms-client/load-tool-permissions user)
                                                  (perms-client/get-public-tool-ids)))
@@ -58,6 +57,12 @@
     (assoc tool
       :container container
       :implementation implementation)))
+
+(defn user-get-tool
+  "Obtains tool details for a user."
+  [user tool-id]
+  (permissions/check-tool-permissions user "read" [tool-id])
+  (get-tool user tool-id))
 
 (defn admin-list-tools
   "Obtains a listing of any tool for admin users."
@@ -79,7 +84,7 @@
       (add-tool-container tool-id container))
     tool-id))
 
-(defn add-tools
+(defn admin-add-tools
   "Adds a list of tools to the database, returning a list of IDs of the tools added."
   [{:keys [tools]}]
   (transaction
@@ -87,7 +92,7 @@
       (dorun (map perms-client/register-public-tool tool-ids))
       {:tool_ids tool-ids})))
 
-(defn update-tool
+(defn admin-update-tool
   [user overwrite-public {:keys [id container] :as tool}]
   (persistence/update-tool tool)
   (when container

--- a/test/apps/service/apps/test_fixtures.clj
+++ b/test/apps/service/apps/test_fixtures.clj
@@ -160,7 +160,7 @@
    (create-tool implementor (:name tool-definition)))
   ([implementor name]
    (sql/delete :tools (sql/where {:name name}))
-   (tools/add-tools {:tools [(assoc tool-definition
+   (tools/admin-add-tools {:tools [(assoc tool-definition
                                     :name           name
                                     :implementation (implementation-for-user implementor))]})))
 

--- a/test/apps/tools_test.clj
+++ b/test/apps/tools_test.clj
@@ -26,12 +26,12 @@
     (testing "(update-tool) actually updates the tool"
       (let [tool-id      (:id tool-map)
             user         (:shortUsername current-user)
-            updated-tool (update-tool user false (-> tool-map
-                                                     (assoc :restricted true)
-                                                     (assoc :time_limit_seconds 10)))]
+            updated-tool (admin-update-tool user false (-> tool-map
+                                                           (assoc :restricted true)
+                                                           (assoc :time_limit_seconds 10)))]
         (is (= tool-id (:id updated-tool)))
         (is (contains? updated-tool :restricted))
         (is (contains? updated-tool :time_limit_seconds))
         (is (:restricted updated-tool))
         (is (= (:time_limit_seconds updated-tool) 10))
-        (update-tool user false tool-map)))))
+        (admin-update-tool user false tool-map)))))


### PR DESCRIPTION
This PR adds admin endpoints to list all tools and fetch details for any tool.

The swagger docs for some /admin/tools endpoints were also updated, and the `PATCH /admin/tools/:id` endpoint now validates a tool exists before attempting to update it.