### PR TITLE
CORE-8745 Make tool version required and location optional.

### DIFF
--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -46,8 +46,8 @@
    :name                              ToolNameParam
    (optional-key :description)        ToolDescriptionParam
    (optional-key :attribution)        AttributionParam
-   :location                          (describe String "The path of the directory containing the Tool")
-   (optional-key :version)            VersionParam
+   (optional-key :location)           (describe String "The path of the directory containing the Tool")
+   :version                           VersionParam
    :type                              (describe String "The Tool Type name")
    (optional-key :restricted)         ToolRestricted
    (optional-key :time_limit_seconds) ToolTimeLimit})
@@ -86,7 +86,7 @@
 (defschema PrivateToolUpdateRequest
   (-> PrivateToolImportRequest
       (->optional-param :name)
-      (->optional-param :location)
+      (->optional-param :version)
       (->optional-param :container)))
 
 (defschema ToolsImportRequest
@@ -95,7 +95,7 @@
 (defschema ToolUpdateRequest
   (-> ToolImportRequest
       (->optional-param :name)
-      (->optional-param :location)
+      (->optional-param :version)
       (->optional-param :type)
       (->optional-param :implementation)
       (->optional-param :container)))

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -2,7 +2,7 @@
   (:use [apps.containers :only [add-tool-container set-tool-container tool-container-info]]
         [apps.persistence.entities :only [tools]]
         [apps.util.conversions :only [remove-nil-vals]]
-        [apps.validation :only [verify-tool-name-location validate-tool-not-used]]
+        [apps.validation :only [verify-tool-name-version validate-tool-not-used]]
         [korma.core :exclude [update]]
         [korma.db :only [transaction]]
         [slingshot.slingshot :only [try+]])
@@ -78,7 +78,7 @@
 
 (defn- add-new-tool
   [{:keys [container] :as tool}]
-  (verify-tool-name-location tool)
+  (verify-tool-name-version tool)
   (let [tool-id (persistence/add-tool tool)]
     (when container
       (add-tool-container tool-id container))

--- a/src/apps/tools/private.clj
+++ b/src/apps/tools/private.clj
@@ -1,5 +1,5 @@
 (ns apps.tools.private
-  (:use [apps.validation :only [verify-tool-name-location validate-tool-not-used]]
+  (:use [apps.validation :only [verify-tool-name-version validate-tool-not-used]]
         [korma.db :only [transaction]])
   (:require [apps.clients.permissions :as perms-client]
             [apps.containers :as containers]
@@ -51,7 +51,7 @@
   "Adds a private tool to the database, returning the tool details added."
   [{:keys [shortUsername] :as user}
    {:keys [container implementation] :as tool}]
-  (verify-tool-name-location tool)
+  (verify-tool-name-version tool)
   (transaction
     (let [tool-id (-> tool
                       restrict-private-tool

--- a/src/apps/validation.clj
+++ b/src/apps/validation.clj
@@ -182,12 +182,12 @@
   ([m k path]
      (validate-json-field* m k (add-field path k))))
 
-(defn verify-tool-name-location
+(defn verify-tool-name-version
   [tool]
-  (let [existing-tool (first (select tools (where (select-keys tool [:name :location]))))]
+  (let [existing-tool (first (select tools (where (select-keys tool [:name :version]))))]
     (when existing-tool
       (throw+ {:type  :clojure-commons.exception/exists
-               :error "A Tool with that name and location already exists."
+               :error "A Tool with that name and version already exists."
                :tool  tool}))))
 
 (defn validate-image-not-public

--- a/test/apps/service/apps/test_fixtures.clj
+++ b/test/apps/service/apps/test_fixtures.clj
@@ -74,7 +74,7 @@
    :name        "test-tool"
    :type        "executable"
    :container   {:image {:name "dwr71/print-args"}}
-   :location    ""})
+   :version     "0.0.1"})
 
 (def ^:dynamic test-app-user nil)
 (def ^:dynamic test-app nil)


### PR DESCRIPTION
This PR allows the `location` field to be optional in `tools` endpoints, since all new tools are using Docker images and the `location` field is no longer required for running new tools.

Since we have many tools with duplicate names, this PR also makes the `version` field required (also updated by cyverse-de/de-db#8).