### PR TITLE
CORE-8746 Allow tool request `architecture` field to be optional.

### DIFF
--- a/src/apps/metadata/tool_requests.clj
+++ b/src/apps/metadata/tool_requests.clj
@@ -46,7 +46,7 @@
   [username req]
   (transaction
    (let [user-id         (users/get-user-id username)
-         architecture-id (architecture-name-to-id (required-field req :architecture))
+         architecture-id (architecture-name-to-id (:architecture req "Others"))
          uuid            (UUID/randomUUID)]
 
      (insert tool_requests

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -183,7 +183,7 @@
    (describe String
      "Any additional data file that may be helpful during tool installation or validation")
 
-   :architecture
+   (optional-key :architecture)
    (describe (enum "32-bit Generic" "64-bit Generic" "Others" "Don't know")
      "One of the architecture names known to the DE. Currently, the valid values are
       `32-bit Generic` for a 32-bit executable that will run in the DE,


### PR DESCRIPTION
The `POST /tool-requests` endpoint no longer requires the `architecture` field.

Since a `tool_architecture_id` is still required by the `tool_requests` db table, the service will default this value to `Others` if it's not sent in the request from the client.