### PR TITLE
CORE-8749 Add `tool_id` to tool-requests endpoints.

### DIFF
--- a/src/apps/metadata/tool_requests.clj
+++ b/src/apps/metadata/tool_requests.clj
@@ -9,6 +9,8 @@
   (:require [apps.clients.notifications :as cn]
             [apps.persistence.tool-requests :as queries]
             [apps.persistence.users :as users]
+            [apps.tools :as tools]
+            [apps.tools.permissions :as permissions]
             [apps.util.params :as params]
             [clojure.string :as string])
   (:import [java.util UUID]))
@@ -41,10 +43,17 @@
              (fields :id)
              (where {:name status-code})))
 
+(defn- validate-tool
+  "Ensures the given tool ID exists and the user has 'own' permission for that tool."
+  [user tool-id]
+  (tools/get-tool user tool-id)
+  (permissions/check-tool-permissions user "own" [tool-id]))
+
 (defn- handle-new-tool-request
   "Submits a tool request on behalf of the authenticated user."
-  [username req]
+  [{:keys [shortUsername username]} {:keys [tool_id] :as req}]
   (transaction
+   (when tool_id (validate-tool shortUsername tool_id))
    (let [user-id         (users/get-user-id username)
          architecture-id (architecture-name-to-id (:architecture req "Others"))
          uuid            (UUID/randomUUID)]
@@ -52,7 +61,7 @@
      (insert tool_requests
              (values {:phone                (:phone req)
                       :id                   uuid
-                      :tool_id              (:tool_id req)
+                      :tool_id              tool_id
                       :tool_name            (required-field req :name)
                       :description          (required-field req :description)
                       :source_url           (required-field req :source_url :source_upload_file)
@@ -189,8 +198,8 @@
 
 (defn submit-tool-request
   "Submits a tool request on behalf of a user."
-  [{:keys [username] :as user} request]
-  (-> (handle-new-tool-request username request)
+  [user request]
+  (-> (handle-new-tool-request user request)
       (get-tool-request)
       (send-tool-request-notification user)))
 

--- a/src/apps/metadata/tool_requests.clj
+++ b/src/apps/metadata/tool_requests.clj
@@ -52,6 +52,7 @@
      (insert tool_requests
              (values {:phone                (:phone req)
                       :id                   uuid
+                      :tool_id              (:tool_id req)
                       :tool_name            (required-field req :name)
                       :description          (required-field req :description)
                       :source_url           (required-field req :source_url :source_upload_file)

--- a/src/apps/persistence/tool_requests.clj
+++ b/src/apps/persistence/tool_requests.clj
@@ -22,6 +22,7 @@
             (fields :tr.id
                     [:requestor.username :submitted_by]
                     :tr.phone
+                    :tr.tool_id
                     [:tr.tool_name :name]
                     :tr.description
                     :tr.source_url

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -6,7 +6,7 @@
   (:import [java.util UUID]))
 
 (def ToolRequestIdParam (describe UUID "The Tool Requests's UUID"))
-(def ToolNameParam (describe String "The Tool's name (should be the file name)"))
+(def ToolNameParam (describe String "The Tool's name (can be the file name or Docker image)"))
 (def ToolDescriptionParam (describe String "A brief description of the Tool"))
 (def VersionParam (describe String "The Tool's version"))
 (def AttributionParam (describe String "The Tool's author or publisher"))
@@ -140,6 +140,9 @@
 
    (optional-key :phone)
    (describe String "The phone number of the user submitting the request")
+
+   (optional-key :tool_id)
+   (describe UUID "The ID of the tool the user is requesting to be made public")
 
    :name
    ToolNameParam


### PR DESCRIPTION
A `tool_id` may now be submitted in new tool requests, and it will be returned in tool request details.

The following endpoints have been updated with a `tool_id` field:
* `GET /admin/tool-requests/{request-id}`
* `POST /admin/tool-requests/{request-id}/status`
* `POST /tool-requests`