### PR TITLE
CORE-8750: Add `deprecated` flag to tool images

### DIFF
--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -105,7 +105,7 @@
   "Updates the record for a container image. Basically, just allows you to set a new URL
    at this point."
   [image-id user overwrite-public image-info]
-  (let [update-info (select-keys image-info [:name :tag :url])]
+  (let [update-info (select-keys image-info [:name :tag :url :deprecated])]
     (when-not (empty? update-info)
       (when-not overwrite-public
         (validate-image-not-public image-id))

--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -81,11 +81,11 @@
 (defn find-or-add-image-info
   "Finds or inserts an image with the given name and tag in the container_images table."
   [{:keys [name tag url] :or {tag "latest"} :as image-map}]
-  (let [existing-image (find-image-by-name-and-tag image-map)]
-    (or existing-image
-        (insert container-images (values {:name name
-                                          :tag  tag
-                                          :url  url})))))
+  (if-let [existing-image (find-image-by-name-and-tag image-map)]
+    existing-image
+    (insert container-images (values {:name name
+                                      :tag  tag
+                                      :url  url}))))
 
 (defn image?
   "Returns true if the given name and tag exist in the container_images table."

--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -47,11 +47,11 @@
     (when registry
       (encode-auth registry))))
 
-(defn public-image-info
+(defn- public-image-info
   "Returns a map containing only publicly-permissible image info (no auth)"
   [image-uuid]
   (first (select container-images
-                (fields :name :tag :url :id)
+                (fields :name :tag :url :deprecated :id)
                 (where {:id (uuidify image-uuid)}))))
 
 (defn image-info
@@ -68,7 +68,7 @@
   []
   {:container_images
     (select container-images
-      (fields :name :tag :url :id))})
+      (fields :name :tag :url :deprecated :id))})
 
 (defn image-public-tools
   [id]
@@ -478,7 +478,7 @@
                      (with data-containers
                        (fields :name_prefix :read_only)
                        (with container-images
-                         (fields :name :tag :url))))
+                         (fields :name :tag :url :deprecated))))
                    (where {:tools_id id}))
            first
            (update :container_volumes_from add-data-container-auth :auth? auth?)

--- a/src/apps/metadata/element_listings.clj
+++ b/src/apps/metadata/element_listings.clj
@@ -86,7 +86,8 @@
         public-tool-ids (perms-client/get-public-tool-ids)
         tools           (-> params
                             (select-keys [:include-hidden])
-                            (assoc :tool-ids tool-ids)
+                            (assoc :tool-ids   tool-ids
+                                   :deprecated false)
                             (tools-db/get-tool-listing))]
     {:tools (map (partial format-tool-listing perms public-tool-ids) tools)}))
 

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -260,9 +260,10 @@
   [app-id]
   (select (get-tool-listing-base-query)
           (join :container_images {:tool_listing.container_images_id :container_images.id})
-          (fields [:container_images.name :image_name]
-                  [:container_images.tag  :image_tag]
-                  [:container_images.url  :image_url])
+          (fields [:container_images.name       :image_name]
+                  [:container_images.tag        :image_tag]
+                  [:container_images.url        :image_url]
+                  [:container_images.deprecated :deprecated])
           (where {:app_id app-id})))
 
 (defn get-tools-by-image-id

--- a/src/apps/persistence/tools.clj
+++ b/src/apps/persistence/tools.clj
@@ -168,8 +168,9 @@
     (-> (tool-listing-base-query)
         (join :container_images {:container_images.id :tools.container_images_id})
         (join :integration_data {:integration_data.id :tools.integration_data_id})
-        (fields [:container_images.name :image_name]
-                [:container_images.tag  :image_tag]
+        (fields [:container_images.name       :image_name]
+                [:container_images.tag        :image_tag]
+                [:container_images.deprecated :image_deprecated]
                 [:integration_data.integrator_name  :implementor]
                 [:integration_data.integrator_email :implementor_email])
         (add-search-where-clauses search-term)

--- a/src/apps/persistence/tools.clj
+++ b/src/apps/persistence/tools.clj
@@ -137,6 +137,13 @@
     (where base-query {:tool_types.hidden false})
     base-query))
 
+(defn- add-deprecated-tools-clause
+  "Adds the clause used to filter out deprecated tools if the tool's image is marked as deprecated."
+  [base-query deprecated]
+  (if-not (nil? deprecated)
+    (where base-query {:container_images.deprecated deprecated})
+    base-query))
+
 (defn- tool-listing-base-query
   "Obtains a listing query for tools, with common fields for tool details and listings."
   []
@@ -154,7 +161,7 @@
 
 (defn get-tool-listing
   "Obtains a listing of tools, with optional search and paging params."
-  [{search-term :search :keys [tool-ids sort-field sort-dir limit offset include-hidden]
+  [{search-term :search :keys [tool-ids deprecated sort-field sort-dir limit offset include-hidden]
     :or {include-hidden false}}]
   (let [sort-field (when sort-field (keyword (str "tools." sort-field)))
         sort-dir (when sort-dir (keyword (upper-case sort-dir)))]
@@ -167,6 +174,7 @@
                 [:integration_data.integrator_email :implementor_email])
         (add-search-where-clauses search-term)
         (add-listing-where-clause tool-ids)
+        (add-deprecated-tools-clause deprecated)
         (add-query-sorting sort-field sort-dir)
         (add-query-limit limit)
         (add-query-offset offset)

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -207,7 +207,11 @@
 
 (defschema App
   (merge AppBase
-         {OptionalToolsKey           (describe [Tool] ToolListDocs)
+         {OptionalToolsKey           (describe [(merge Tool
+                                                       {(optional-key :deprecated)
+                                                        (describe Boolean
+                                                                  "Flag indicating if this Tool has been deprecated")})]
+                                               ToolListDocs)
           (optional-key :references) AppReferencesParam
           OptionalGroupsKey          (describe [AppGroup] GroupListDocs)}))
 

--- a/src/apps/routes/schemas/containers.clj
+++ b/src/apps/routes/schemas/containers.clj
@@ -5,12 +5,13 @@
 
 (s/defschema Image
   (describe
-   {:name                  s/Str
-    :id                    s/Uuid
-    (s/optional-key :tag)  s/Str
-    (s/optional-key :url)  (s/maybe s/Str)
-    (s/optional-key :auth) (s/maybe s/Str)}
-   "A map describing a container image."))
+    {:name                        s/Str
+     :id                          s/Uuid
+     (s/optional-key :tag)        s/Str
+     (s/optional-key :url)        (s/maybe s/Str)
+     (s/optional-key :deprecated) Boolean
+     (s/optional-key :auth)       (s/maybe s/Str)}
+    "A map describing a container image."))
 
 (s/defschema Images
   (describe

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -1,5 +1,6 @@
 (ns apps.routes.schemas.tool
-  (:use [common-swagger-api.schema :only [->optional-param describe]]
+  (:use [clojure-commons.error-codes]
+        [common-swagger-api.schema :only [->optional-param describe ErrorResponse]]
         [apps.routes.params]
         [schema.core :only [defschema enum optional-key]])
   (:require [apps.routes.schemas.containers :as containers])
@@ -236,3 +237,13 @@
 
 (defschema StatusCodeListing
   {:status_codes (describe [StatusCode] "A listing of known Status Codes")})
+
+(defschema ErrorPrivateToolRequestBadParam
+  (assoc ErrorResponse
+    :error_code (describe (enum ERR_EXISTS ERR_BAD_OR_MISSING_FIELD) "Exists or Bad Field error code")))
+
+(def PrivateToolImportResponse400
+  {:schema      ErrorPrivateToolRequestBadParam
+   :description "
+* `ERR_EXISTS`: A Tool with the given `name` already exists.
+* `ERR_BAD_OR_MISSING_FIELD`: The image with the given `name` and `tag` has been deprecated."})

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -73,7 +73,7 @@
         :return Image
         :summary "Add Container Image"
         :description "Adds a new container image to the system."
-        (ok (add-image-info body)))
+        (ok (find-or-add-image-info body)))
 
   (DELETE "/:image-id" []
            :path-params [image-id :- ImageId]
@@ -147,8 +147,7 @@
         :responses (merge CommonResponses
                           {200 {:schema      ToolDetails
                                 :description "The new Tool details."}
-                           400 {:schema      ErrorResponseExists
-                                :description "A Tool with the given `name` already exists."}})
+                           400 PrivateToolImportResponse400})
         :summary "Add Private Tool"
         :description
 "This service adds a new private Tool to the DE for the requesting user.
@@ -239,7 +238,10 @@ otherwise the default value will be used."
          :path-params [tool-id :- ToolIdParam]
          :query [{:keys [user]} SecuredQueryParams]
          :body [body (describe PrivateToolUpdateRequest "The private Tool to update.")]
-         :return ToolDetails
+         :responses (merge CommonResponses
+                           {200 {:schema      ToolDetails
+                                 :description "The updated Tool details."}
+                            400 PrivateToolImportResponse400})
          :summary "Update a Private Tool"
          :description "This service updates a private Tool definition in the DE.
 As with new private Tools, `type` is always set to `executable` and `restricted` is always set to `true`,

--- a/src/apps/service/apps/de/edit.clj
+++ b/src/apps/service/apps/de/edit.clj
@@ -191,7 +191,7 @@
 
 (defn- format-app-tool
   [tool]
-  (remove-nil-vals (select-keys tool [:id :name :description :location :type :version :attribution])))
+  (remove-nil-vals (select-keys tool [:id :name :description :location :type :version :attribution :deprecated])))
 
 (defn- format-app-for-editing
   [app]

--- a/src/apps/service/apps/de/validation.clj
+++ b/src/apps/service/apps/de/validation.clj
@@ -60,11 +60,13 @@
         public-tool-ids  (perms-client/get-public-tool-ids)
         is-public?       (contains? public-app-ids app-id)
         private-tools    (remove #(contains? public-tool-ids (:id %)) tools)
+        deprecated-tools (filter :deprecated tools)
         private-apps     (private-apps-for task-ids public-app-ids)]
     (cond is-public?             [false "app is already public"]
           (empty? task-ids)      [false "no app ID provided"]
           (seq unrunnable-tasks) [false "contains unrunnable tasks" unrunnable-tasks]
           (seq private-tools)    [false "contains private tools" private-tools]
+          (seq deprecated-tools) [false "contains deprecated tools" deprecated-tools]
           (= 1 (count task-ids)) [true]
           (seq private-apps)     [false "contains private apps" private-apps]
           :else                  [true])))

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -44,7 +44,7 @@
         tool-ids        (filter-listing-tool-ids (set (keys perms)) public-tool-ids params)]
     {:tools
      (map (partial format-tool-listing perms public-tool-ids)
-          (persistence/get-tool-listing (assoc params :tool-ids tool-ids)))}))
+          (persistence/get-tool-listing (assoc params :tool-ids tool-ids :deprecated false)))}))
 
 (defn get-tool
   "Obtains a tool by ID."

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -12,15 +12,16 @@
             [clojure.tools.logging :as log]))
 
 (defn format-tool-listing
-  [perms public-tool-ids {:keys [id image_name image_tag implementor implementor_email] :as tool}]
+  [perms public-tool-ids {:keys [id image_name image_tag image_deprecated implementor implementor_email] :as tool}]
   (-> tool
       (assoc :is_public      (contains? public-tool-ids id)
              :permission     (or (perms id) "")
              :implementation {:implementor       implementor
                               :implementor_email implementor_email}
-             :container      {:image {:name image_name
-                                      :tag  image_tag}})
-      (dissoc :image_name :image_tag :implementor :implementor_email)
+             :container      {:image {:name       image_name
+                                      :tag        image_tag
+                                      :deprecated image_deprecated}})
+      (dissoc :image_name :image_tag :image_deprecated :implementor :implementor_email)
       remove-nil-vals))
 
 (defn- filter-listing-tool-ids

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -93,13 +93,23 @@
       (dorun (map perms-client/register-public-tool tool-ids))
       {:tool_ids tool-ids})))
 
+(defn verify-tool-name-version-for-update
+  "Given the current tool and the tool values for update,
+   verifies the name and version values for update do not already exist for another tool."
+  [{current-name :name current-version :version} {:keys [name version]}]
+  (when (or (and name (not= current-name name))
+            (and version (not= current-version version)))
+    (verify-tool-name-version {:name    (or name current-name)
+                               :version (or version current-version)})))
+
 (defn admin-update-tool
   [user overwrite-public {:keys [id container] :as tool}]
-  (persistence/get-tool id)
-  (persistence/update-tool tool)
-  (when container
-    (set-tool-container id overwrite-public container))
-  (get-tool user id))
+  (transaction
+    (verify-tool-name-version-for-update (persistence/get-tool id) tool)
+    (persistence/update-tool tool)
+    (when container
+      (set-tool-container id overwrite-public container))
+    (get-tool user id)))
 
 (defn delete-tool
   [tool-id]

--- a/src/apps/validation.clj
+++ b/src/apps/validation.clj
@@ -184,11 +184,13 @@
 
 (defn verify-tool-name-version
   [tool]
-  (let [existing-tool (first (select tools (where (select-keys tool [:name :version]))))]
+  (let [existing-tool (first (select tools
+                                     (fields :id :name :version)
+                                     (where (select-keys tool [:name :version]))))]
     (when existing-tool
       (throw+ {:type  :clojure-commons.exception/exists
                :error "A Tool with that name and version already exists."
-               :tool  tool}))))
+               :tool  existing-tool}))))
 
 (defn validate-image-not-public
   [image-id]

--- a/src/apps/validation.clj
+++ b/src/apps/validation.clj
@@ -5,7 +5,8 @@
         [korma.core :exclude [update]]
         [slingshot.slingshot :only [throw+]])
   (:require [apps.clients.permissions :as perms-client]
-            [apps.persistence.app-metadata :as persistence]))
+            [apps.persistence.app-metadata :as persistence]
+            [clojure-commons.exception-util :as exception-util]))
 
 (defn missing-json-field-exception
   "Thrown when a required field is missing from a JSON request body."
@@ -184,13 +185,10 @@
 
 (defn verify-tool-name-version
   [tool]
-  (let [existing-tool (first (select tools
-                                     (fields :id :name :version)
-                                     (where (select-keys tool [:name :version]))))]
-    (when existing-tool
-      (throw+ {:type  :clojure-commons.exception/exists
-               :error "A Tool with that name and version already exists."
-               :tool  existing-tool}))))
+  (when-let [existing-tool (first (select tools
+                                          (fields :id :name :version)
+                                          (where (select-keys tool [:name :version]))))]
+    (exception-util/exists "A Tool with that name and version already exists." :tool existing-tool)))
 
 (defn validate-image-not-public
   [image-id]

--- a/test/apps/containers_test.clj
+++ b/test/apps/containers_test.clj
@@ -16,7 +16,7 @@
 (def ^:dynamic volumes-from-map nil)
 
 (defn- add-image-info-map []
-  (add-image-info {:name "discoenv/de-db" :tag "latest" :url "https://www.google.com"}))
+  (find-or-add-image-info {:name "discoenv/de-db" :tag "latest" :url "https://www.google.com"}))
 
 (defn- add-data-container-map []
   (add-data-container {:name        "discoenv/foo"

--- a/test/apps/containers_test.clj
+++ b/test/apps/containers_test.clj
@@ -91,7 +91,7 @@
 
   (is (not (nil? (image-id {:name "discoenv/de-db" :tag "latest"}))))
 
-  (is (= {:name "discoenv/de-db" :tag "latest" :url "https://www.google.com"}
+  (is (= {:name "discoenv/de-db" :tag "latest" :url "https://www.google.com" :deprecated false}
          (dissoc (image-info (image-id {:name "discoenv/de-db" :tag "latest"})) :id))))
 
 
@@ -99,6 +99,9 @@
   (is (not (nil? (:id settings-map))))
 
   (is (= {:name "test"
+          :min_cpu_cores nil
+          :min_memory_limit nil
+          :min_disk_space nil
           :cpu_shares 1024
           :memory_limit 2048
           :network_mode "bridge"


### PR DESCRIPTION
This PR adds the `deprecated` flag to tool details in app and tool listing endpoints.

The following endpoints now use the `deprecated` flag in the tool JSON object:
* `PUT /apps/{system-id}/{app-id}`
* `POST /apps/{system-id}/{app-id}/copy`
* `GET /apps/{system-id}/{app-id}/ui`

The following endpoints now use the `deprecated` flag in the tool's container image JSON object:
* `GET /admin/apps/{system-id}/{app-id}/details`
* `GET /admin/tools`
* `POST /admin/tools`
* `GET /admin/tools/container-images`
* `POST /admin/tools/container-images`
* `GET /admin/tools/container-images/{image-id}`
* `PATCH /admin/tools/container-images/{image-id}`
* `GET /admin/tools/{tool-id}`
* `PATCH /admin/tools/{tool-id}`
* `GET /apps/{system-id}/{app-id}/details`
* `GET /tools`
* `POST /tools`
* `GET /tools/{tool-id}`
* `PATCH /tools/{tool-id}`

Tools using deprecated images will no longer be included in user tool listings.
Admins can update container image `deprecated` flags with the `PATCH /admin/tools/container-images/{image-id}` endpoint.
The `POST /tools` and `PATCH /tools/{tool-id}` endpoints will return an `ERR_BAD_OR_MISSING_FIELD` if the request includes a container image that has been deprecated.
The `POST /apps/{system-id}/{app-id}/publish` endpoint will return an `ERR_BAD_OR_MISSING_FIELD` if the app uses a deprecated tool (if the tool is using a deprecated image).
The `POST /tool-requests` endpoint will return an `ERR_BAD_OR_MISSING_FIELD` if the request includes a `tool_id` for a deprecated tool.