### PR TITLE
CORE-8857 Add tool details to app tasks and pipeline ui endpoints.

### DIFF
--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -7,7 +7,7 @@
                                           SortFieldOptionalKey]]
         [apps.routes.params]
         [apps.routes.schemas.app.rating]
-        [apps.routes.schemas.tool :only [Tool ToolListingImage ToolListingItem]]
+        [apps.routes.schemas.tool :only [Tool ToolDetails ToolListingImage ToolListingItem]]
         [schema.core :only [Any defschema enum optional-key recursive]])
   (:require [clojure.set :as sets])
   (:import [java.util UUID Date]))
@@ -221,12 +221,13 @@
    :required    (describe Boolean "Whether or not a value is required for this Parameter")})
 
 (defschema AppTask
-  {:system_id   (describe String "The Task's System ID")
-   :id          (describe String "The Task's ID")
-   :name        (describe String "The Task's name")
-   :description (describe String "The Task's description")
-   :inputs      (describe [AppFileParameterDetails] "The Task's input parameters")
-   :outputs     (describe [AppFileParameterDetails] "The Task's output parameters")})
+  {:system_id           (describe String "The Task's System ID")
+   :id                  (describe String "The Task's ID")
+   :name                (describe String "The Task's name")
+   :description         (describe String "The Task's description")
+   (optional-key :tool) ToolDetails
+   :inputs              (describe [AppFileParameterDetails] "The Task's input parameters")
+   :outputs             (describe [AppFileParameterDetails] "The Task's output parameters")})
 
 (defschema AppTaskListing
   (assoc AppBase

--- a/src/apps/service/apps/de/pipeline_edit.clj
+++ b/src/apps/service/apps/de/pipeline_edit.clj
@@ -102,11 +102,11 @@
 
 (defn- format-workflow
   "Prepares a JSON response for editing a Workflow in the client."
-  [app]
+  [user app]
   (let [steps (get-steps (:id app))
         mappings (get-mappings steps)
         task-ids (set (map :task_id steps))
-        tasks (listings/get-tasks-with-file-params task-ids)
+        tasks (listings/get-tasks-with-file-params user task-ids)
         steps (map format-step steps)]
     (-> app
         (select-keys [:id :name :description])
@@ -133,7 +133,7 @@
   [user app-id]
   (let [app (get-app app-id)]
     (verify-app-editable user app)
-    (format-workflow app)))
+    (format-workflow user app)))
 
 (defn- add-app-mapping
   [app-id steps {:keys [source_step target_step map] :as mapping}]


### PR DESCRIPTION
This PR will add tool details to each DE task in the following endpoint responses:
* `GET /apps/de/{app-id}/tasks`
* `GET /apps/pipelines/{app-id}/ui`

This will allow the UI to check for deprecated tools in apps added to workflows, or already included in workflows when first opened for editing.