### PR TITLE
CORE-8695 Add POST /admin/tools/{tool-id}/publish

### DIFF
--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -121,6 +121,11 @@
   [tool-id]
   (pc/grant-permission (client) (rt-tool) tool-id "group" (ipg/grouper-user-group-id) "read"))
 
+(defn make-tool-public
+  [tool-id]
+  (delete-tool-resource tool-id)
+  (register-public-tool tool-id))
+
 (defn- resource-sharing-log-msg
   [action resource-type resource-name subject-type subject-id reason]
   (render "unable to {{action}} {{resource-type}}:{{resource-name}} with {{subject-type}}:{{subject-id}}: {{reason}}"

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -11,6 +11,7 @@
         [apps.tools :only [admin-add-tools
                            admin-delete-tool
                            admin-list-tools
+                           admin-publish-tool
                            admin-update-tool
                            get-tool
                            list-tools
@@ -741,4 +742,20 @@ included in it. Any existing settings not included in the request's `container` 
         :summary "Update the Integration Data Record for a Tool"
         :description "This service allows administrators to change the integration data record
         associated with a tool."
-        (ok (apps/update-tool-integration-data current-user de-system-id tool-id integration-data-id))))
+        (ok (apps/update-tool-integration-data current-user de-system-id tool-id integration-data-id)))
+
+  (POST "/:tool-id/publish" []
+        :path-params [tool-id :- ToolIdParam]
+        :query [{:keys [user]} SecuredQueryParams]
+        :body [body (describe ToolUpdateRequest "The Tool to update.")]
+        :responses (merge CommonResponses
+                          {200 {:schema      ToolDetails
+                                :description "The Tool details."}
+                           400 {:schema      ErrorResponseNotWritable
+                                :description "The Tool is already public."}
+                           404 {:schema      ErrorResponseNotFound
+                                :description "The `tool-id` does not exist."}})
+        :summary "Make a Private Tool Public"
+        :description "This service makes a Private Tool public and available to all users.
+        The request body fields are optional and allow the admin to make updates to the tool in the same request."
+        (ok (admin-publish-tool user (assoc body :id tool-id)))))

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -127,3 +127,9 @@
     (validate-tool-not-used tool-id)
     (log/warn user "deleting tool" tool-id name version "@" location))
   (delete-tool tool-id))
+
+(defn admin-publish-tool
+  [user {:keys [id] :as tool}]
+  (admin-update-tool user false tool)
+  (perms-client/make-tool-public id)
+  (get-tool user id))


### PR DESCRIPTION
Adds an endpoint for admins to make tools public, also allowing the admin to make updates to the tool in the same request.