### PR TITLE
CORE-8747 Add tool request ID and status to tool listings.

### DIFF
--- a/src/apps/persistence/tools.clj
+++ b/src/apps/persistence/tools.clj
@@ -162,9 +162,11 @@
 (defn- tool-request-status-subselect
   []
   (subselect [:tool_request_status_codes :trsc]
-             (fields [(sqlfn :last :trsc.name) :status])
+             (fields [:trsc.name :status])
              (join [:tool_request_statuses :trs] {:trs.tool_request_status_code_id :trsc.id})
-             (where {:trs.tool_request_id :tool_requests.id})))
+             (where {:trs.tool_request_id :tool_requests.id})
+             (order :date_assigned :DESC)
+             (limit 1)))
 
 (defn get-tool-listing
   "Obtains a listing of tools, with optional search and paging params."

--- a/src/apps/persistence/tools.clj
+++ b/src/apps/persistence/tools.clj
@@ -159,6 +159,13 @@
               [:tools.time_limit_seconds :time_limit_seconds])
       (join tool_types)))
 
+(defn- tool-request-status-subselect
+  []
+  (subselect [:tool_request_status_codes :trsc]
+             (fields [(sqlfn :last :trsc.name) :status])
+             (join [:tool_request_statuses :trs] {:trs.tool_request_status_code_id :trsc.id})
+             (where {:trs.tool_request_id :tool_requests.id})))
+
 (defn get-tool-listing
   "Obtains a listing of tools, with optional search and paging params."
   [{search-term :search :keys [tool-ids deprecated sort-field sort-dir limit offset include-hidden]
@@ -168,11 +175,14 @@
     (-> (tool-listing-base-query)
         (join :container_images {:container_images.id :tools.container_images_id})
         (join :integration_data {:integration_data.id :tools.integration_data_id})
+        (join :tool_requests {:tool_requests.tool_id :tools.id})
         (fields [:container_images.name       :image_name]
                 [:container_images.tag        :image_tag]
                 [:container_images.deprecated :image_deprecated]
                 [:integration_data.integrator_name  :implementor]
-                [:integration_data.integrator_email :implementor_email])
+                [:integration_data.integrator_email :implementor_email]
+                [:tool_requests.id :tool_request_id]
+                [(tool-request-status-subselect) :tool_request_status])
         (add-search-where-clauses search-term)
         (add-listing-where-clause tool-ids)
         (add-deprecated-tools-clause deprecated)

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -63,11 +63,6 @@
 (defschema ToolListingImage
   {:image (dissoc containers/Image :id)})
 
-(defschema ToolListingItem
-  (merge ToolDetails
-         {:implementation (describe ToolImplementor ToolImplementationDocs)
-          :container      ToolListingImage}))
-
 (defschema ToolImportRequest
   (-> Tool
       (->optional-param :id)
@@ -103,9 +98,6 @@
       (->optional-param :type)
       (->optional-param :implementation)
       (->optional-param :container)))
-
-(defschema ToolListing
-  {:tools (describe [ToolListingItem] "Listing of App Tools")})
 
 (defschema NewTool
   (assoc Tool
@@ -237,6 +229,15 @@
 
 (defschema StatusCodeListing
   {:status_codes (describe [StatusCode] "A listing of known Status Codes")})
+
+(defschema ToolListingItem
+  (merge ToolDetails
+         {:implementation              (describe ToolImplementor ToolImplementationDocs)
+          :container                   ToolListingImage
+          (optional-key :tool_request) (select-keys ToolRequestSummary [:id :status])}))
+
+(defschema ToolListing
+  {:tools (describe [ToolListingItem] "Listing of App Tools")})
 
 (defschema ErrorPrivateToolRequestBadParam
   (assoc ErrorResponse

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -12,7 +12,16 @@
             [clojure.tools.logging :as log]))
 
 (defn format-tool-listing
-  [perms public-tool-ids {:keys [id image_name image_tag image_deprecated implementor implementor_email] :as tool}]
+  [perms public-tool-ids
+   {:keys [id
+           image_name
+           image_deprecated
+           image_tag
+           implementor
+           implementor_email
+           tool_request_id
+           tool_request_status]
+    :as tool}]
   (-> tool
       (assoc :is_public      (contains? public-tool-ids id)
              :permission     (or (perms id) "")
@@ -20,8 +29,17 @@
                               :implementor_email implementor_email}
              :container      {:image {:name       image_name
                                       :tag        image_tag
-                                      :deprecated image_deprecated}})
-      (dissoc :image_name :image_tag :image_deprecated :implementor :implementor_email)
+                                      :deprecated image_deprecated}}
+             :tool_request   (when tool_request_id (remove-nil-vals
+                                                     {:id     tool_request_id
+                                                      :status tool_request_status})))
+      (dissoc :image_name
+              :image_deprecated
+              :image_tag
+              :implementor
+              :implementor_email
+              :tool_request_id
+              :tool_request_status)
       remove-nil-vals))
 
 (defn- filter-listing-tool-ids


### PR DESCRIPTION
This PR adds tool request info like the following to tool listings, if the tool has a tool request associated with it:
```json
{
  "tool_request": {
    "id": "uuid",
    "status": "string"
  }
}
```
The following endpoints have been updated with this response info:
* `GET /admin/tools`
* `GET /apps/elements/tools`
* `GET /tools`