### PR TITLE
CORE-8877 Add `tool_id` to (/admin)/tool-requests endpoint responses.

### DIFF
--- a/src/apps/metadata/tool_requests.clj
+++ b/src/apps/metadata/tool_requests.clj
@@ -221,13 +221,16 @@
       (get-tool-request)
       (send-tool-request-update-notification)))
 
+(defn- format-tool-request-dates
+  [{:keys [date_submitted date_updated] :as tool-request}]
+  (assoc tool-request :date_submitted (.getTime date_submitted)
+                      :date_updated   (.getTime date_updated)))
+
 (defn list-tool-requests
   "Lists tool requests."
   [params]
   {:tool_requests
-   (map #(assoc %
-           :date_submitted (.getTime (:date_submitted %))
-           :date_updated   (.getTime (:date_updated %)))
+   (map (comp remove-nil-vals format-tool-request-dates)
         (get-tool-request-list params))})
 
 (defn- add-filter

--- a/src/apps/persistence/tool_requests.clj
+++ b/src/apps/persistence/tool_requests.clj
@@ -74,6 +74,7 @@
   (subselect [:tool_requests :tr]
              (fields [:tr.id :id]
                      [:tr.tool_name :name]
+                     :tr.tool_id
                      [:tr.version :version]
                      [:trsc.name :status]
                      [:trs.date_assigned :status_date]
@@ -98,12 +99,12 @@
   (let [status-clause (if (nil? statuses) nil ['in statuses])]
     (select
       [(subselect [(list-tool-requests-subselect user) :req]
-                  (fields :id :name :version :requested_by
+                  (fields :id :name :version :requested_by :tool_id
                           [(sqlfn :first :status_date) :date_submitted]
                           [(sqlfn :last :status) :status]
                           [(sqlfn :last :status_date) :date_updated]
                           [(sqlfn :last :updated_by) :updated_by])
-                  (group :id :name :version :requested_by)
+                  (group :id :name :version :requested_by :tool_id)
                   (order (or sort-field :date_submitted) (or sort-order :ASC))
                   (limit row-limit)
                   (offset row-offset))

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -230,11 +230,14 @@
 (defschema StatusCodeListing
   {:status_codes (describe [StatusCode] "A listing of known Status Codes")})
 
+(defschema ToolListingToolRequestSummary
+  (select-keys ToolRequestSummary [:id :status]))
+
 (defschema ToolListingItem
   (merge ToolDetails
          {:implementation              (describe ToolImplementor ToolImplementationDocs)
           :container                   ToolListingImage
-          (optional-key :tool_request) (select-keys ToolRequestSummary [:id :status])}))
+          (optional-key :tool_request) ToolListingToolRequestSummary}))
 
 (defschema ToolListing
   {:tools (describe [ToolListingItem] "Listing of App Tools")})

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -7,6 +7,7 @@
   (:import [java.util UUID]))
 
 (def ToolRequestIdParam (describe UUID "The Tool Requests's UUID"))
+(def ToolRequestToolIdParam (describe UUID "The ID of the tool the user is requesting to be made public"))
 (def ToolNameParam (describe String "The Tool's name (can be the file name or Docker image)"))
 (def ToolDescriptionParam (describe String "A brief description of the Tool"))
 (def VersionParam (describe String "The Tool's version"))
@@ -135,7 +136,7 @@
    (describe String "The phone number of the user submitting the request")
 
    (optional-key :tool_id)
-   (describe UUID "The ID of the tool the user is requesting to be made public")
+   ToolRequestToolIdParam
 
    :name
    ToolNameParam
@@ -194,15 +195,15 @@
   (dissoc ToolRequestDetails :id :submitted_by :history))
 
 (defschema ToolRequestSummary
-  {:id             ToolRequestIdParam
-   :name           ToolNameParam
-   :version        VersionParam
-   :requested_by   SubmittedByParam
-   :date_submitted (describe Long "The timestamp of the Tool Request submission")
-   :status         (describe String "The current status of the Tool Request")
-   :date_updated   (describe Long "The timestamp of the last Tool Request status update")
-   :updated_by     (describe String
-                     "The username of the user that last updated the Tool Request status")})
+  {:id                     ToolRequestIdParam
+   :name                   ToolNameParam
+   :version                VersionParam
+   :requested_by           SubmittedByParam
+   (optional-key :tool_id) ToolRequestToolIdParam
+   :date_submitted         (describe Long "The timestamp of the Tool Request submission")
+   :status                 (describe String "The current status of the Tool Request")
+   :date_updated           (describe Long "The timestamp of the last Tool Request status update")
+   :updated_by             (describe String "The username of the user that last updated the Tool Request status")})
 
 (defschema ToolRequestListing
   {:tool_requests (describe [ToolRequestSummary]


### PR DESCRIPTION
This change probably should have been part of cyverse-de/apps#58 (CORE-8749).

Also includes a fix for `ToolRequestSummary` docs, inadvertently affected by changes for CORE-8747.