### PR TITLE
CORE-8882 Update admin tool publish endpoint to complete tool requests.

### DIFF
--- a/src/apps/persistence/tool_requests.clj
+++ b/src/apps/persistence/tool_requests.clj
@@ -110,3 +110,11 @@
                   (offset row-offset))
        :reqs]
       (where-if-defined {:status status-clause}))))
+
+(defn get-request-id-for-tool
+  [tool-id]
+  (-> (select :tool_requests
+              (fields :id)
+              (where {:tool_id tool-id}))
+      first
+      :id))


### PR DESCRIPTION
This PR updates the `POST /admin/tools/{tool-id}/publish` endpoint to auto-complete the tool request for the given tool.

This also required that I move new tool request `tool-id` validation into `apps.tools` to avoid a circular dependency with `apps.metadata.tool-requests`.

I also added a check for an existing tool request for the given `tool-id`, otherwise tool listings for tools with 2 tool requests would be duplicated, since tool listings now include the latest tool request status.