### PR TITLE
CORE-8885 Replace private tools cpu_shares limit with pids_limit.

### DIFF
--- a/src/apps/routes/schemas/containers.clj
+++ b/src/apps/routes/schemas/containers.clj
@@ -39,6 +39,7 @@
 (s/defschema Settings
   (describe
    {(s/optional-key :cpu_shares)         Integer
+    (s/optional-key :pids_limit)         Integer
     (s/optional-key :memory_limit)       Long
     (s/optional-key :min_memory_limit)   Long
     (s/optional-key :min_cpu_cores)      Integer

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -157,7 +157,7 @@
 Note that `type` is always set to `executable`, `restricted` is always set to `true`,
 and `container.network_mode` is always set to `none`, even if another value is set in the request.
 
-Configured default values will be used for the `time_limit_seconds`, `container.cpu_shares`, and `container.memory_limit` fields
+Configured default values will be used for the `time_limit_seconds`, `container.pids_limit`, and `container.memory_limit` fields
 The request may include a value less than the configured default if it's also greater than 0,
 otherwise the default value will be used."
         (ok (add-private-tool current-user body)))
@@ -254,7 +254,7 @@ and a configured limit may override the `time_limit_seconds` field set in the re
 but if the `container` object is present in the request, then all container settings must be included in it.
 Any existing settings not included in the request's `container` object will be removed,
 except `network_mode` is always set to `none` and configured limits may override values set (or omitted)
-for the `cpu_shares` and `memory_limit` fields."
+for the `pids_limit` and `memory_limit` fields."
          (ok (update-private-tool user (assoc body :id tool-id))))
 
   (GET "/:tool-id/apps" []

--- a/src/apps/tools/private.clj
+++ b/src/apps/tools/private.clj
@@ -26,11 +26,11 @@
 
 (defn- restrict-private-tool-container
   "Restrict the networking, CPU shares, and memory limits for the tool's container."
-  [{:keys [cpu_shares memory_limit] :or {cpu_shares   (cfg/private-tool-cpu-shares)
+  [{:keys [pids_limit memory_limit] :or {pids_limit   (cfg/private-tool-pids-limit)
                                          memory_limit (cfg/private-tool-memory-limit)}
     :as container}]
   (assoc container :network_mode "none"
-                   :cpu_shares   (restrict-private-tool-setting cpu_shares   (cfg/private-tool-cpu-shares))
+                   :pids_limit   (restrict-private-tool-setting pids_limit   (cfg/private-tool-pids-limit))
                    :memory_limit (restrict-private-tool-setting memory_limit (cfg/private-tool-memory-limit))))
 
 (defn- restrict-private-tool-time-limit

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -102,10 +102,10 @@
   [props config-valid configs]
   "apps.tools.private.time-limit-seconds" (* 24 60 60)) ;; 24 hours
 
-(cc/defprop-optint private-tool-cpu-shares
-  "The cpu shares limit to use when adding new private tools."
+(cc/defprop-optint private-tool-pids-limit
+  "The PIDs limit to use when adding new private tools."
   [props config-valid configs]
-  "apps.tools.private.cpu-shares" 4)
+  "apps.tools.private.pids-limit" 64)
 
 (cc/defprop-optint private-tool-memory-limit
   "The memory limit, in bytes, to use when adding new private tools."


### PR DESCRIPTION
This PR removes the `cpu_shares` limit automatically added to private tools, replacing it with initial support for `pids_limit` restrictions in the `POST /tools` endpoint.

The `pids_limit` is only added in this PR as a config setting (64 by default) and as an allowed `container` field in tool requests, but since it's not persisted in the database yet, it won't be returned in tool info or submitted with job info.