### PR TITLE
CORE-8885 Update (/admin)/tools endpoints to persist pids_limit setting.

### DIFF
--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -367,7 +367,8 @@
 (defn- filter-container-settings
   [settings-map]
   (select-keys settings-map
-    [:cpu_shares
+    [:pids_limit
+     :cpu_shares
      :memory_limit
      :min_memory_limit
      :min_cpu_cores
@@ -434,6 +435,7 @@
     (when (tool-has-settings? id)
       (->  (select container-settings
                    (fields :id
+                           :pids_limit
                            :cpu_shares
                            :memory_limit
                            :min_memory_limit


### PR DESCRIPTION
The `POST (/admin)/tools` and `PATCH (/admin)/tools/:id` endpoints will now save `pids_limit` container settings to the db. This setting will also now be included in `GET (/admin)/tool/:id` responses and in job submissions.

Note that this PR depends on cyverse-de/de-db#13 getting merged first.