### PR TITLE
CORE-7290 Fix DELETE/PATCH /admin/tools/container-images/:id validation.

### DIFF
--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -1,5 +1,5 @@
 (ns apps.containers
-  (:use [apps.persistence.app-metadata :only [get-public-tools-by-image-id]]
+  (:use [apps.persistence.app-metadata :only [get-tools-in-public-apps-by-image-id]]
         [apps.persistence.entities :only [tools
                                           container-images
                                           container-settings
@@ -11,7 +11,7 @@
         [apps.persistence.tools :only [update-tool]]
         [apps.util.assertions :only [assert-not-nil]]
         [apps.util.conversions :only [remove-nil-vals remove-empty-vals]]
-        [apps.validation :only [validate-image-not-public
+        [apps.validation :only [validate-image-not-used-in-public-apps
                                 validate-image-not-used
                                 validate-tool-not-used-in-public-apps]]
         [kameleon.uuids :only [uuidify]]
@@ -60,7 +60,7 @@
 (defn image-public-tools
   [id]
   (assert-not-nil [:image_id id] (image-info id))
-  {:tools (map remove-nil-vals (get-public-tools-by-image-id id))})
+  {:tools (map remove-nil-vals (get-tools-in-public-apps-by-image-id id))})
 
 (defn tool-image-info
   "Returns a map containing information about a container image. Info is looked up by the tool UUID"
@@ -107,7 +107,7 @@
   (let [update-info (select-keys image-info [:name :tag :url :deprecated])]
     (when-not (empty? update-info)
       (when-not overwrite-public
-        (validate-image-not-public image-id))
+        (validate-image-not-used-in-public-apps image-id))
       (log/warn user "updating image" image-id image-info)
       (sql/update container-images
         (set-fields update-info)

--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -1,6 +1,5 @@
 (ns apps.containers
-  (:use [apps.persistence.app-metadata :only [get-public-tools-by-image-id
-                                              get-tools-by-image-id]]
+  (:use [apps.persistence.app-metadata :only [get-public-tools-by-image-id]]
         [apps.persistence.entities :only [tools
                                           container-images
                                           container-settings

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -266,13 +266,6 @@
                   [:container_images.deprecated :deprecated])
           (where {:app_id app-id})))
 
-(defn get-tools-by-image-id
-  "Loads information about the tools associated with a Docker image."
-  [image-id]
-  (select (get-tool-listing-base-query)
-          (modifier "DISTINCT")
-          (where {:container_images_id image-id})))
-
 (defn get-public-tools-by-image-id
   "Loads information about public tools associated with a Docker image."
   [img-id]

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -266,8 +266,8 @@
                   [:container_images.deprecated :deprecated])
           (where {:app_id app-id})))
 
-(defn get-public-tools-by-image-id
-  "Loads information about public tools associated with a Docker image."
+(defn get-tools-in-public-apps-by-image-id
+  "Loads information about tools used by public apps associated with a Docker image."
   [img-id]
   (select (get-tool-listing-base-query)
           (modifier "DISTINCT")

--- a/src/apps/validation.clj
+++ b/src/apps/validation.clj
@@ -201,13 +201,14 @@
   (let [tools (persistence/get-tools-in-public-apps-by-image-id image-id)]
     (when-not (empty? tools)
       (throw+ {:type  :clojure-commons.exception/not-writeable
-               :error "Image already used by public tools."
+               :error "Image already used by tools in public apps."
                :tools tools}))))
 
 (defn validate-image-not-used
   [image-id]
   (let [tools (-> (brief-tool-details-base-query)
-                  (where {:container_images_id image-id})
+                  (where (or {:container_images_id image-id}
+                             {:id [in (persistence/subselect-tool-ids-using-data-container image-id)]}))
                   select)]
     (when-not (empty? tools)
       (throw+ {:type  :clojure-commons.exception/not-writeable

--- a/src/apps/validation.clj
+++ b/src/apps/validation.clj
@@ -196,9 +196,9 @@
                                first)]
     (exception-util/exists "A Tool with that name and version already exists." :tool existing-tool)))
 
-(defn validate-image-not-public
+(defn validate-image-not-used-in-public-apps
   [image-id]
-  (let [tools (persistence/get-public-tools-by-image-id image-id)]
+  (let [tools (persistence/get-tools-in-public-apps-by-image-id image-id)]
     (when-not (empty? tools)
       (throw+ {:type  :clojure-commons.exception/not-writeable
                :error "Image already used by public tools."


### PR DESCRIPTION
Updated the `DELETE` and `PATCH /admin/tools/container-images/:id` endpoint validations to look for all tools using the given image, not just for tools already used in apps, and also to check for tools using the given image as a data container.

Also renamed some functions related to images in public apps for clarity, since tools can be private now.