### PR TITLE
CORE-8921 Add ImagePublicAppToolListing response schema.

### DIFF
--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -243,6 +243,9 @@
 (defschema ToolListing
   {:tools (describe [ToolListingItem] "Listing of App Tools")})
 
+(defschema ImagePublicAppToolListing
+  {:tools (describe [Tool] "Listing of Public App Tools")})
+
 (defschema ErrorPrivateToolRequestBadParam
   (assoc ErrorResponse
     :error_code (describe (enum ERR_EXISTS ERR_BAD_OR_MISSING_FIELD) "Exists or Bad Field error code")))

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -104,7 +104,7 @@
   (GET "/:image-id/public-tools" []
         :path-params [image-id :- ImageId]
         :query [params SecuredQueryParams]
-        :return ToolListing
+        :return ImagePublicAppToolListing
         :summary "Container Image Public Tools"
         :description "Returns a list of a public tools using the given image ID."
         (ok (image-public-tools image-id))))


### PR DESCRIPTION
Added a `GET /admin/tools/container-images/{image-id}/public-tools` listing response schema with fewer details than the schema used by `GET (/admin)/tools`, since this endpoint does not use the tool listing and formatting functions that include the extra details required for the `(/admin)/tools` listing endpoints.

This fixes response schema validation errors for images used by public apps.