### PR TITLE
CORE-9016 Make HT Path List job submissions async

### DIFF
--- a/apps.properties.tmpl
+++ b/apps.properties.tmpl
@@ -39,11 +39,14 @@ apps.uid.domain = {{ (key (printf "%s/de/cas-uid-domain" $base)) }}
 # The path to the home directory in iRODS.
 {{ with $v := (key (printf "%s/de/irods-home" $base)) }}apps.irods.home = {{ $v }}{{ end }}
 
+# The maximum length of an iRODS path, used in max HT Path List file size calculations.
+# See https://github.com/irods/irods/blob/805c01f55ea23a141cb0fa3f449f5172b3a19657/lib/core/include/rodsDef.h#L59-L61
+{{ with $v := (key (printf "%s/irods/path-max-len" $base)) }}apps.irods.path-max-len = {{ $v }}{{ end }}
+
 # Batch job settings.
 {{ with $v := (key (printf "%s/jex/batch-group" $base)) }}apps.batch.group               = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/apps/path-list-info-type" $base)) }}apps.batch.path-list.info-type = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/apps/path-list-max-paths" $base)) }}apps.batch.path-list.max-paths = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/apps/path-list-max-size" $base)) }}apps.batch.path-list.max-size  = {{ $v }}{{ end }}
 
 # Agave connection settings.
 {{ with $v := (key (printf "%s/agave/base" $base)) }}apps.agave.base-url             = {{ $v }}{{ end }}

--- a/src/apps/clients/notifications.clj
+++ b/src/apps/clients/notifications.clj
@@ -78,6 +78,15 @@
   ([{username :shortUsername email-address :email} job-info]
      (send-job-status-update username email-address job-info)))
 
+(defn send-batch-submission-completed
+  [{username :shortUsername email-address :email} {job-name :name :as job-info} sub-job-count]
+  (try
+    (-> (format-job-status-update username email-address job-info)
+        (assoc :message (str job-name " successfully submitted " sub-job-count " analyses"))
+        send-notification)
+    (catch Exception e
+      (log/warn e "unable to send batch job status update notification for" (:id job-info)))))
+
 (defn- format-tool-request-notification
   [tool-req user-details]
   (let [{:keys [comments]} (last (:history tool-req))]

--- a/src/apps/clients/notifications.clj
+++ b/src/apps/clients/notifications.clj
@@ -51,11 +51,11 @@
 
 (defn- format-job-status-update
   "Formats a job status update notification to send to the notification agent."
-  [username email-address {job-name :name :as job-info}]
+  [username email-address {job-name :name :as job-info} message]
   {:type           "analysis"
    :user           username
    :subject        (str job-name " status changed.")
-   :message        (str job-name " " (string/lower-case (:status job-info)))
+   :message        message
    :email          (send-email? job-info)
    :email_template "analysis_status_change"
    :payload        (assoc job-info
@@ -70,22 +70,15 @@
 
 (defn send-job-status-update
   "Sends notification of an Agave or DE job status update to the user."
-  ([username email-address job-info]
+  ([username email-address job-info message]
      (try
-       (send-notification (format-job-status-update username email-address job-info))
+       (send-notification (format-job-status-update username email-address job-info message))
        (catch Exception e
          (log/warn e "unable to send job status update notification for" (:id job-info)))))
+  ([username email-address {job-name :name :as job-info}]
+   (send-job-status-update username email-address job-info (str job-name " " (string/lower-case (:status job-info)))))
   ([{username :shortUsername email-address :email} job-info]
      (send-job-status-update username email-address job-info)))
-
-(defn send-batch-submission-completed
-  [{username :shortUsername email-address :email} {job-name :name :as job-info} sub-job-count]
-  (try
-    (-> (format-job-status-update username email-address job-info)
-        (assoc :message (str job-name " successfully submitted " sub-job-count " analyses"))
-        send-notification)
-    (catch Exception e
-      (log/warn e "unable to send batch job status update notification for" (:id job-info)))))
 
 (defn- format-tool-request-notification
   [tool-req user-details]

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -201,6 +201,12 @@
       {:status "Failed"
        :enddate (now-str)})))
 
+(defn get-job-status
+  [job-id]
+  (-> (select :job_listings (fields :status) (where {:id job-id}))
+      first
+      :status))
+
 (defn save-job
   "Saves information about a job in the database."
   [{system-id :system_id username :username :as job-info} submission]

--- a/src/apps/service/apps/agave/jobs.clj
+++ b/src/apps/service/apps/agave/jobs.clj
@@ -126,7 +126,7 @@
     :notify          (:notify job)
     :resultfolderid  (:resultfolderid job)
     :startdate       (str (.getTime (:startdate job)))
-    :status          jp/submitted-status
+    :status          (:status job)
     :username        (:username job)
     :wiki_url        (:wiki_url job)
     :parent_id       (:parent_id submission)}))

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -1,12 +1,8 @@
 (ns apps.service.apps.jobs
-  (:use [korma.db :only [transaction]]
-        [slingshot.slingshot :only [try+]])
+  (:use [slingshot.slingshot :only [try+]])
   (:require [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
-            [clojure-commons.exception-util :as cxu]
             [kameleon.db :as db]
             [apps.clients.notifications :as cn]
-            [apps.clients.permissions :as perms-client]
             [apps.persistence.jobs :as jp]
             [apps.service.apps.job-listings :as listings]
             [apps.service.apps.jobs.params :as job-params]
@@ -15,10 +11,6 @@
             [apps.service.apps.jobs.submissions :as submissions]
             [apps.service.apps.jobs.util :as ju]
             [apps.util.service :as service]))
-
-(defn supports-job-type
-  [apps-client job-type]
-  (contains? (set (.getJobTypes apps-client)) job-type))
 
 (defn get-unique-job-step
   "Gets a unique job step for an external ID. An exception is thrown if no job step
@@ -181,10 +173,7 @@
 
 (defn submit
   [apps-client user submission]
-  (transaction
-   (let [job-info (submissions/submit apps-client user submission)]
-     (perms-client/register-private-analysis (:shortUsername user) (:id job-info))
-     job-info)))
+  (submissions/submit apps-client user submission))
 
 (defn list-job-permissions
   [apps-client user job-ids]

--- a/src/apps/service/apps/jobs/submissions.clj
+++ b/src/apps/service/apps/jobs/submissions.clj
@@ -230,11 +230,10 @@
         {:status jp/failed-status}))))
 
 (defn- async-submit-batch-jobs
-  [apps-client user path-list-stats {job-id :parent_id :as submission}]
+  [apps-client user ht-paths {job-id :parent_id :as submission}]
   (future
     (try+
-      (let [ht-paths      (set (map :path path-list-stats))
-            path-lists    (get-path-list-contents-map user ht-paths)
+      (let [path-lists    (get-path-list-contents-map user ht-paths)
             paths-exist   (validate-path-lists user path-lists)
             path-maps     (map-slices path-lists)
             job-stats     (->> path-maps
@@ -273,10 +272,11 @@
   [apps-client user input-params-by-id input-paths-by-id path-list-stats job-types app submission]
   (pre-submit-batch-validation input-params-by-id input-paths-by-id path-list-stats)
 
-  (let [output-dir (get-batch-output-dir user submission)
+  (let [ht-paths   (set (map :path path-list-stats))
+        output-dir (get-batch-output-dir user submission)
         batch-id   (save-batch user job-types app submission output-dir)
         submission (preprocess-batch-submission submission output-dir batch-id)]
-    (async-submit-batch-jobs apps-client user path-list-stats submission)
+    (async-submit-batch-jobs apps-client user ht-paths submission)
     (job-listings/list-job apps-client batch-id)))
 
 (defn submit

--- a/src/apps/service/apps/jobs/submissions.clj
+++ b/src/apps/service/apps/jobs/submissions.clj
@@ -67,8 +67,12 @@
 
 (defn- validate-path-list-stats
   [{path :path actual-size :file-size}]
-  (when (> actual-size (config/path-list-max-size))
-    (max-path-list-size-exceeded (config/path-list-max-size) path actual-size)))
+  ;; Ensure the file size is within a reasonable limit, based on the iRODS max path length:
+  ;; the iRODS max path length + 1 (for newlines) * the path limit + 1 (for some file header overhead).
+  (let [path-list-max-size (* (+ 1 (config/irods-path-max-len))
+                              (+ 1 (config/path-list-max-paths)))]
+    (when (> actual-size path-list-max-size)
+      (max-path-list-size-exceeded path-list-max-size path actual-size))))
 
 (defn- validate-ht-params
   [ht-params]

--- a/src/apps/service/apps/jobs/submissions/async.clj
+++ b/src/apps/service/apps/jobs/submissions/async.clj
@@ -1,0 +1,118 @@
+(ns apps.service.apps.jobs.submissions.async
+  (:use [clojure-commons.core :only [remove-nil-values]]
+        [slingshot.slingshot :only [try+ throw+]])
+  (:require [clojure.tools.logging :as log]
+            [clojure-commons.file-utils :as ft]
+            [apps.clients.data-info :as data-info]
+            [apps.clients.notifications :as notifications]
+            [apps.persistence.jobs :as jp]
+            [apps.service.apps.job-listings :as job-listings]
+            [apps.service.apps.jobs.submissions.submit :as submit]
+            [apps.util.config :as config]))
+
+(defn- max-batch-paths-exceeded
+  [max-paths first-list-path first-list-count]
+  (throw+
+    {:type       :clojure-commons.exception/illegal-argument
+     :error      (str "The HT Analysis Path List exceeds the maximum of "
+                      max-paths
+                      " allowed paths.")
+     :path       first-list-path
+     :path-count first-list-count}))
+
+(defn- validate-path-lists
+  [path-lists]
+  (let [[first-list-path first-list] (first path-lists)
+        first-list-count             (count first-list)]
+    (when (> first-list-count (config/path-list-max-paths))
+      (max-batch-paths-exceeded (config/path-list-max-paths) first-list-path first-list-count))
+    (when-not (every? (comp (partial = first-list-count) count second) path-lists)
+      (throw+ {:type  :clojure-commons.exception/illegal-argument
+               :error "All HT Analysis Path Lists must have the same number of paths."}))
+    path-lists))
+
+(defn- get-path-list-contents
+  [user path]
+  (try+
+    (when (seq path) (data-info/get-path-list-contents user path))
+    (catch Object _
+      (log/error (:throwable &throw-context)
+                 "job submission failed: Could not get file contents of path list input.")
+      (throw+))))
+
+(defn- get-path-list-contents-map
+  [user paths]
+  (into {} (map (juxt identity (partial get-path-list-contents user)) paths)))
+
+(defn- map-slice
+  [m n]
+  (->> (map (fn [[k v]] (vector k (nth v n))) m)
+       (into {})
+       (remove-nil-values)))
+
+(defn- map-slices
+  [m]
+  (let [max-count (apply max (map (comp count val) m))]
+    (mapv (partial map-slice m) (range max-count))))
+
+
+(defn- substitute-param-values
+  [path-map config]
+  (->> (map (fn [[k v]] (vector k (get path-map v v))) config)
+       (into {})))
+
+(defn- format-submission-in-batch
+  [submission job-number path-map]
+  (let [job-suffix (str "analysis-" (inc job-number))]
+    (assoc (update-in submission [:config] (partial substitute-param-values path-map))
+      :group      (config/jex-batch-group-name)
+      :name       (str (:name submission) "-" job-suffix)
+      :output_dir (ft/path-join (:output_dir submission) job-suffix))))
+
+(defn- submit-job-in-batch
+  [apps-client user submission job-number path-map]
+  (try+
+    (submit/submit-and-register-private-job apps-client
+                                            user
+                                            (format-submission-in-batch submission job-number path-map))
+    (catch Object _
+      (log/error (:throwable &throw-context)
+                 "batch job submission failed.")
+      {:status jp/failed-status})))
+
+(defn- preprocess-batch-submission
+  [submission output-dir parent-id]
+  (assoc submission
+    :output_dir           output-dir
+    :parent_id            parent-id
+    :create_output_subdir false))
+
+(defn submit-batch-jobs
+  "Asynchronously submits sub-jobs for a parent batch job,
+   where `ht-paths` is a list of paths of the HT Path List input files,
+   `submission` is the original parent submission map,
+   `output-dir` is the path to the output folder created for the parent job,
+   and `parent-id` is the parent job's ID to use for each sub-job's `parent_id` field.
+   A notification will be sent to the user on success or on failure to submit all sub-jobs."
+  [apps-client user ht-paths submission output-dir parent-id]
+  (future
+    (try+
+      (let [path-lists    (validate-path-lists (get-path-list-contents-map user ht-paths))
+            path-maps     (map-slices path-lists)
+            submission    (preprocess-batch-submission submission output-dir parent-id)
+            job-stats     (->> path-maps
+                               (map-indexed (partial submit-job-in-batch apps-client user submission))
+                               doall)
+            success-count (->> job-stats
+                               (filter (comp (partial = jp/submitted-status) :status))
+                               count)]
+        (if (> success-count 0)
+          (notifications/send-batch-submission-completed user
+                                                         (job-listings/list-job apps-client parent-id)
+                                                         success-count)
+          (throw+ "all batch sub-job submissions failed.")))
+      (catch Object _
+        (log/error (:throwable &throw-context)
+                   "batch job submission failed.")
+        (jp/update-job parent-id jp/failed-status nil)
+        (notifications/send-job-status-update user (job-listings/list-job apps-client parent-id))))))

--- a/src/apps/service/apps/jobs/submissions/async.clj
+++ b/src/apps/service/apps/jobs/submissions/async.clj
@@ -39,7 +39,8 @@
     (when (seq path) (data-info/get-path-list-contents user path))
     (catch Object _
       (log/error (:throwable &throw-context)
-                 "job submission failed: Could not get file contents of path list input.")
+                 "job submission failed: Could not get file contents of HT Path List input"
+                 path)
       (throw+))))
 
 (defn- get-path-list-contents-map

--- a/src/apps/service/apps/jobs/submissions/submit.clj
+++ b/src/apps/service/apps/jobs/submissions/submit.clj
@@ -1,0 +1,10 @@
+(ns apps.service.apps.jobs.submissions.submit
+  (:use [korma.db :only [transaction]])
+  (:require [apps.clients.permissions :as perms-client]))
+
+(defn submit-and-register-private-job
+  [apps-client user submission]
+  (transaction
+    (let [job-info (.submitJob apps-client submission)]
+      (perms-client/register-private-analysis (:shortUsername user) (:id job-info))
+      job-info)))

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -182,12 +182,13 @@
 (cc/defprop-optint path-list-max-paths
   "The maximum number of paths to process per HT Analysis Path Lists."
   [props config-valid configs]
-  "apps.batch.path-list.max-paths" 16)
+  "apps.batch.path-list.max-paths" 1000)
 
-(cc/defprop-optint path-list-max-size
-  "The maximum size of each HT Analysis Path List that can be fetched from the data-info service."
+(cc/defprop-optint irods-path-max-len
+  "The maximum length of an iRODS path, used in max HT Path List file size calculations.
+   See https://github.com/irods/irods/blob/805c01f55ea23a141cb0fa3f449f5172b3a19657/lib/core/include/rodsDef.h#L59-L61"
   [props config-valid configs]
-  "apps.batch.path-list.max-size" 1048576)
+  "apps.irods.path-max-len" 1067)
 
 (cc/defprop-optstr agave-base-url
   "The base URL to use when connecting to Agave."


### PR DESCRIPTION
This PR will migrate batch job submissions into a separate thread, allowing the `POST /analyses` endpoint to submit the parent job and respond to the client right away, while sub-jobs are submitted in the background thread.

Once the background thread submits all sub-jobs, it will send a notification to the user which includes the count of successful sub-job submissions. If an exception is caught, or if all sub-jobs fail to submit, then the parent job will be marked as failed, and the user will receive a job failure notification for the parent.

This will allow us to lift the 128-paths limit on jobs submitted with HT Path List files to something much larger. We should probably keep some limit in place for now, until we have async job submissions that are 0-downtime compatible, since these sub-job submissions will be lost and the user will not be notified if the apps service goes down during HT Path List processing.

A side-effect of these updates means the `POST /analyses` endpoint no longer always returns the `Submitted` status for every job, and may now return a `Failed` status.