### PR TITLE
CORE-9014 Update analyses stop endpoint to also stop all child jobs.

### DIFF
--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -382,6 +382,14 @@
           (fields :submission)
           (where {:parent_id batch-id})))
 
+(defn list-running-child-jobs
+  "Lists the child jobs within a batch job that have not yet completed."
+  [batch-id]
+  (select (job-base-query)
+          (where {:parent_id batch-id
+                  :status    [not-in (conj completed-status-codes
+                                           impending-cancellation-status)]})))
+
 (defn- add-job-type-clause
   "Adds a where clause for a set of job types if the set of job types provided is not nil
    or empty."


### PR DESCRIPTION
This PR will update `apps.service.apps.jobs/stop-job` to also stop all child jobs, even if the parent job has already been stopped in a previous request.

Stopping child jobs will run async in a named thread, allowing the endpoint to respond to the client right away.