### PR TITLE
CORE-9057 Add Multi-Input Path List job submission support

### DIFF
--- a/apps.properties.tmpl
+++ b/apps.properties.tmpl
@@ -44,11 +44,11 @@ apps.uid.domain = {{ (key (printf "%s/de/cas-uid-domain" $base)) }}
 {{ with $v := (key (printf "%s/irods/path-max-len" $base)) }}apps.irods.path-max-len = {{ $v }}{{ end }}
 
 # Batch job settings.
-{{ with $v := (key (printf "%s/jex/batch-group" $base))                      }}apps.batch.group                           = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/apps/multi-input-path-list-info-type" $base)) }}apps.batch.multi-input-path-list.info-type = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/apps/multi-input-path-list-max-paths" $base)) }}apps.batch.multi-input-path-list.max-paths = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/apps/path-list-info-type" $base))             }}apps.batch.path-list.info-type             = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/apps/path-list-max-paths" $base))             }}apps.batch.path-list.max-paths             = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/jex/batch-group" $base))                           }}apps.batch.group                           = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/data-info/ht-path-list-info-type" $base))          }}apps.batch.path-list.ht.info-type          = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/apps/ht-path-list-max-paths" $base))               }}apps.batch.path-list.ht.max-paths          = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/data-info/multi-input-path-list-info-type" $base)) }}apps.batch.path-list.multi-input.info-type = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/apps/multi-input-path-list-max-paths" $base))      }}apps.batch.path-list.multi-input.max-paths = {{ $v }}{{ end }}
 
 # Agave connection settings.
 {{ with $v := (key (printf "%s/agave/base" $base)) }}apps.agave.base-url             = {{ $v }}{{ end }}

--- a/apps.properties.tmpl
+++ b/apps.properties.tmpl
@@ -46,6 +46,7 @@ apps.uid.domain = {{ (key (printf "%s/de/cas-uid-domain" $base)) }}
 # Batch job settings.
 {{ with $v := (key (printf "%s/jex/batch-group" $base))                      }}apps.batch.group                           = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/apps/multi-input-path-list-info-type" $base)) }}apps.batch.multi-input-path-list.info-type = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/apps/multi-input-path-list-max-paths" $base)) }}apps.batch.multi-input-path-list.max-paths = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/apps/path-list-info-type" $base))             }}apps.batch.path-list.info-type             = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/apps/path-list-max-paths" $base))             }}apps.batch.path-list.max-paths             = {{ $v }}{{ end }}
 

--- a/apps.properties.tmpl
+++ b/apps.properties.tmpl
@@ -44,9 +44,10 @@ apps.uid.domain = {{ (key (printf "%s/de/cas-uid-domain" $base)) }}
 {{ with $v := (key (printf "%s/irods/path-max-len" $base)) }}apps.irods.path-max-len = {{ $v }}{{ end }}
 
 # Batch job settings.
-{{ with $v := (key (printf "%s/jex/batch-group" $base)) }}apps.batch.group               = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/apps/path-list-info-type" $base)) }}apps.batch.path-list.info-type = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/apps/path-list-max-paths" $base)) }}apps.batch.path-list.max-paths = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/jex/batch-group" $base))                      }}apps.batch.group                           = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/apps/multi-input-path-list-info-type" $base)) }}apps.batch.multi-input-path-list.info-type = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/apps/path-list-info-type" $base))             }}apps.batch.path-list.info-type             = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/apps/path-list-max-paths" $base))             }}apps.batch.path-list.max-paths             = {{ $v }}{{ end }}
 
 # Agave connection settings.
 {{ with $v := (key (printf "%s/agave/base" $base)) }}apps.agave.base-url             = {{ $v }}{{ end }}

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -207,6 +207,12 @@
       first
       :status))
 
+(defn- submission->save-format
+  [submission]
+  (-> submission
+      (dissoc :job_config)
+      cheshire/encode))
+
 (defn save-job
   "Saves information about a job in the database."
   [{system-id :system_id username :username :as job-info} submission]
@@ -214,7 +220,7 @@
       (assoc :job_type_id (job-type-id-from-system-id system-id)
              :user_id     (get-user-id username))
       remove-nil-values
-      (save-job-with-submission (cheshire/encode submission))))
+      (save-job-with-submission (submission->save-format submission))))
 
 (defn save-job-step
   "Saves a single job step in the database."

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -207,12 +207,6 @@
       first
       :status))
 
-(defn- submission->save-format
-  [submission]
-  (-> submission
-      (dissoc :job_config)
-      cheshire/encode))
-
 (defn save-job
   "Saves information about a job in the database."
   [{system-id :system_id username :username :as job-info} submission]
@@ -220,7 +214,7 @@
       (assoc :job_type_id (job-type-id-from-system-id system-id)
              :user_id     (get-user-id username))
       remove-nil-values
-      (save-job-with-submission (submission->save-format submission))))
+      (save-job-with-submission (cheshire/encode submission))))
 
 (defn save-job-step
   "Saves a single job step in the database."

--- a/src/apps/service/apps/agave/jobs.clj
+++ b/src/apps/service/apps/agave/jobs.clj
@@ -21,13 +21,15 @@
          :query "status=${JOB_STATUS}&external-id=${JOB_ID}&end-time=${JOB_END_TIME}")))
 
 (defn- format-submission
-  [agave job-id result-folder-path submission]
-  (->> (assoc (dissoc submission :starting_step :step_number)
-         :callbackUrl          (build-callback-url job-id)
-         :job_id               job-id
-         :step_number          (:step_number submission 1)
-         :output_dir           result-folder-path
-         :create_output_subdir false)))
+  [agave job-id result-folder-path {:keys [config] :as submission}]
+  (-> submission
+      (dissoc :starting_step :step_number :job_config)
+      (assoc :config               (:job_config submission config)
+             :callbackUrl          (build-callback-url job-id)
+             :job_id               job-id
+             :step_number          (:step_number submission 1)
+             :output_dir           result-folder-path
+             :create_output_subdir false)))
 
 (defn- prepare-submission
   [agave job-id submission]

--- a/src/apps/service/apps/combined/jobs.clj
+++ b/src/apps/service/apps/combined/jobs.clj
@@ -74,13 +74,16 @@
        (validate-job-steps app-id)
        (map (partial build-job-step-save-info job-id))))
 
-(defn- prepare-de-job-step-submission
-  [job-info job-step submission]
+(defn- prepare-common-job-step-submission
+  [job-info job-step {:keys [config] :as submission}]
   (assoc submission
+    :config               (:job_config submission config)
     :create_output_subdir false
     :output_dir           (:result_folder_path job-info)
     :starting_step        (:app_step_number job-step)
     :step_number          (:step_number job-step)))
+
+(def prepare-de-job-step-submission prepare-common-job-step-submission)
 
 (defn- get-current-app-step
   [{app-id :app_id} {app-step-number :app_step_number}]
@@ -88,14 +91,11 @@
 
 (defn- prepare-agave-job-step-submission
   [job-info job-step submission]
-  (let [app-step (get-current-app-step job-info job-step)]
+  (let [app-step   (get-current-app-step job-info job-step)
+        submission (prepare-common-job-step-submission job-info job-step submission)]
     (assoc submission
-      :create_output_subdir false
-      :output_dir           (:result_folder_path job-info)
-      :app_id               (:external_app_id app-step)
-      :paramPrefix          (:step_id app-step)
-      :starting_step        (:app_step_number job-step)
-      :step_number          (:step_number job-step))))
+      :app_id      (:external_app_id app-step)
+      :paramPrefix (:step_id app-step))))
 
 (defn- prepare-job-step-submission
   [job-info job-step submission]

--- a/src/apps/service/apps/de/jobs.clj
+++ b/src/apps/service/apps/de/jobs.clj
@@ -113,8 +113,9 @@
     (submit-standalone-job user submission job)))
 
 (defn- prep-submission
-  [submission]
+  [{:keys [config] :as submission}]
   (assoc submission
+    :config               (:job_config submission config)
     :output_dir           (build-result-folder-path submission)
     :create_output_subdir false))
 

--- a/src/apps/service/apps/jobs/submissions.clj
+++ b/src/apps/service/apps/jobs/submissions.clj
@@ -177,7 +177,7 @@
             config
             multi-input-param-ids)))
 
-(defn- pre-process-config
+(defn- process-job-config
   [config user input-params-by-id input-paths-by-id path-stats]
   (if-let [multi-input-path-list-stats (->> path-stats
                                             (filter-stats-by-info-type (config/multi-input-path-list-info-type))
@@ -191,7 +191,7 @@
 
 (defn- pre-process-submission
   [{:keys [config] :as submission} user input-params-by-id input-paths-by-id path-stats]
-  (assoc submission :config (pre-process-config config user input-params-by-id input-paths-by-id path-stats)))
+  (assoc submission :job_config (process-job-config config user input-params-by-id input-paths-by-id path-stats)))
 
 (defn submit
   [apps-client user {app-id :app_id system-id :system_id :as submission}]

--- a/src/apps/service/apps/jobs/submissions/async.clj
+++ b/src/apps/service/apps/jobs/submissions/async.clj
@@ -26,8 +26,8 @@
   [path-lists]
   (let [[first-list-path first-list] (first path-lists)
         first-list-count             (count first-list)]
-    (when (> first-list-count (config/path-list-max-paths))
-      (max-batch-paths-exceeded (config/path-list-max-paths) first-list-path first-list-count))
+    (when (> first-list-count (config/ht-path-list-max-paths))
+      (max-batch-paths-exceeded (config/ht-path-list-max-paths) first-list-path first-list-count))
     (when-not (every? (comp (partial = first-list-count) count second) path-lists)
       (throw+ {:type  :clojure-commons.exception/illegal-argument
                :error "All HT Analysis Path Lists must have the same number of paths."}))

--- a/src/apps/service/apps/jobs/util.clj
+++ b/src/apps/service/apps/jobs/util.clj
@@ -1,9 +1,26 @@
 (ns apps.service.apps.jobs.util
-  (:require [apps.persistence.jobs :as jp]
-            [apps.util.service :as service]))
+  (:use [slingshot.slingshot :only [try+ throw+]])
+  (:require [apps.clients.data-info :as data-info]
+            [apps.persistence.jobs :as jp]
+            [apps.util.service :as service]
+            [clojure.tools.logging :as log]))
 
 (defn validate-job-existence
   [job-ids]
   (let [missing-ids (jp/list-non-existent-job-ids (set job-ids))]
     (when-not (empty? missing-ids)
       (service/not-found "jobs" job-ids))))
+
+(defn get-path-list-contents
+  [user path]
+  (try+
+    (when (seq path) (data-info/get-path-list-contents user path))
+    (catch Object _
+      (log/error (:throwable &throw-context)
+                 "job submission failed: Could not get file contents of Path List input"
+                 path)
+      (throw+))))
+
+(defn get-path-list-contents-map
+  [user paths]
+  (into {} (map (juxt identity (partial get-path-list-contents user)) paths)))

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -174,25 +174,25 @@
   [props config-valid configs]
   "apps.batch.group" "batch_processing")
 
-(cc/defprop-optstr multi-input-path-list-info-type
-  "The info type for Multi-Input Path Lists."
-  [props config-valid configs]
-  "apps.batch.multi-input-path-list.info-type" "multi-input-path-list")
-
 (cc/defprop-optstr ht-path-list-info-type
   "The info type for HT Analysis Path Lists."
   [props config-valid configs]
-  "apps.batch.path-list.info-type" "ht-analysis-path-list")
-
-(cc/defprop-optint multi-input-path-list-max-paths
-  "The maximum number of paths to process per Multi-Input Path List."
-  [props config-valid configs]
-  "apps.batch.multi-input-path-list.max-paths" 1000)
+  "apps.batch.path-list.ht.info-type" "ht-analysis-path-list")
 
 (cc/defprop-optint ht-path-list-max-paths
   "The maximum number of paths to process per HT Analysis Path List."
   [props config-valid configs]
-  "apps.batch.path-list.max-paths" 1000)
+  "apps.batch.path-list.ht.max-paths" 1000)
+
+(cc/defprop-optstr multi-input-path-list-info-type
+  "The info type for Multi-Input Path Lists."
+  [props config-valid configs]
+  "apps.batch.path-list.multi-input.info-type" "multi-input-path-list")
+
+(cc/defprop-optint multi-input-path-list-max-paths
+  "The maximum number of paths to process per Multi-Input Path List."
+  [props config-valid configs]
+  "apps.batch.path-list.multi-input.max-paths" 1000)
 
 (cc/defprop-optint irods-path-max-len
   "The maximum length of an iRODS path, used in max HT Path List file size calculations.

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -184,8 +184,13 @@
   [props config-valid configs]
   "apps.batch.path-list.info-type" "ht-analysis-path-list")
 
-(cc/defprop-optint path-list-max-paths
-  "The maximum number of paths to process per HT Analysis Path Lists."
+(cc/defprop-optint multi-input-path-list-max-paths
+  "The maximum number of paths to process per Multi-Input Path List."
+  [props config-valid configs]
+  "apps.batch.multi-input-path-list.max-paths" 1000)
+
+(cc/defprop-optint ht-path-list-max-paths
+  "The maximum number of paths to process per HT Analysis Path List."
   [props config-valid configs]
   "apps.batch.path-list.max-paths" 1000)
 

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -174,7 +174,12 @@
   [props config-valid configs]
   "apps.batch.group" "batch_processing")
 
-(cc/defprop-optstr path-list-info-type
+(cc/defprop-optstr multi-input-path-list-info-type
+  "The info type for Multi-Input Path Lists."
+  [props config-valid configs]
+  "apps.batch.multi-input-path-list.info-type" "multi-input-path-list")
+
+(cc/defprop-optstr ht-path-list-info-type
   "The info type for HT Analysis Path Lists."
   [props config-valid configs]
   "apps.batch.path-list.info-type" "ht-analysis-path-list")


### PR DESCRIPTION
This PR will add job submission support for a new `multi-input-path-list` file info-type, which is only valid for use in Multi-Input app parameters.

This info-type is defined in cyverse-de/heuristomancer#4.

The current strategy for `Multi-Input Path List` job submission support is to have this service "expand" the path-list contents in the input parameter job submission JSON, by replacing the original path with the downloaded list of paths.

This is similar to the strategy used for HT Path List files, except the "Multi-Input Path List expansion" does not need to be asynchronous, since the replacement can be done in a reasonable amount of time.

A bigger consideration is that a path list file of 100k paths can have a file size around 100MB, which means the JSON submission to the job services will also be at least this big, which may be too much for our job submission queues. So I will leave this PR open until we can decide if an alternative can be implemented fairly quickly, otherwise this will be the temporary solution (which should have a limit of about 20k paths) until the async job submission service is implemented.