### PR TITLE
CORE-9082 Prevent PSQLException in the GET /analyses endpoint when user has 32k+ jobs/sub-jobs

### DIFF
--- a/src/apps/persistence/app_groups.clj
+++ b/src/apps/persistence/app_groups.clj
@@ -1,18 +1,17 @@
 (ns apps.persistence.app-groups
   (:use [apps.persistence.entities]
         [korma.core :exclude [update]]
-        [korma.db :only [transaction *current-conn*]]
+        [korma.db :only [transaction]]
         [slingshot.slingshot :only [throw+]])
-  (:require [kameleon.uuids :refer [uuid]]
+  (:require [apps.persistence.util :as util]
+            [kameleon.uuids :refer [uuid]]
             [korma.core :as sql]))
 
 (defn get-app-group-hierarchy
   "Gets the app group hierarchy rooted at the node with the given identifier."
   [root-id {:keys [agave-enabled app-ids] :or {agave-enabled "false"}}]
   (if (seq app-ids)
-    (transaction
-     (let [app-ids (.createArrayOf (:connection *current-conn*) "uuid" (into-array app-ids))]
-       (select (sqlfn :app_category_hierarchy root-id (Boolean/parseBoolean agave-enabled) app-ids))))
+    (select (sqlfn :app_category_hierarchy root-id (Boolean/parseBoolean agave-enabled) (util/sql-array "uuid" app-ids)))
     (select (sqlfn :app_category_hierarchy root-id (Boolean/parseBoolean agave-enabled)))))
 
 (defn get-visible-workspaces

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -9,6 +9,7 @@
         [korma.core :exclude [update]]
         [slingshot.slingshot :only [throw+]])
   (:require [apps.constants :as c]
+            [apps.persistence.util :as util]
             [cheshire.core :as cheshire]
             [clojure.set :as set]
             [clojure.string :as string]
@@ -265,7 +266,7 @@
   ((comp :count first)
    (select (add-job-query-filter-clause (count-jobs-base include-hidden) username filter)
            (where {:j.deleted false})
-           (where {:j.id [in accessible-ids]})
+           (where {:j.id (util/sqlfn-any-array "uuid" accessible-ids)})
            (where (not (exists (job-type-subselect types)))))))
 
 (defn- translate-sort-field
@@ -346,7 +347,7 @@
   [username search-params types accessible-ids]
   (-> (select* (add-job-query-filter-clause (job-base-query) username (:filter search-params)))
       (where {:j.deleted false})
-      (where {:j.id [in accessible-ids]})
+      (where {:j.id (util/sqlfn-any-array "uuid" accessible-ids)})
       (where (not (exists (job-type-subselect types))))
       (add-internal-app-clause (:include-hidden search-params))
       (add-order search-params)

--- a/src/apps/persistence/util.clj
+++ b/src/apps/persistence/util.clj
@@ -1,0 +1,25 @@
+(ns apps.persistence.util
+  (:use [korma.db :only [transaction *current-conn*]])
+  (:require [korma.core :as sql]))
+
+(defn sql-array
+  "Returns a SQL ARRAY(...) object,
+   typically for use with a large (>32k) list of items that need to be passed to a SQL function.
+
+   array-type:  the SQL name of the type of the `array-items` (e.g. 'varchar' or 'uuid').
+   array-items: the elements that populate the returned SQL ARRAY object."
+  [array-type array-items]
+  ;; This transaction is required in order for *current-conn* to be non-nil, in case we're not already in a transaction.
+  (transaction
+    (.createArrayOf (:connection *current-conn*) array-type (into-array array-items))))
+
+(defn sqlfn-any-array
+  "Returns a SQL function ANY(ARRAY(...)) for use in a `where` clause, since using an `IN(...)` with a large (>32k) list
+   will cause a PSQLException (I/O error) from too many query parameters.
+   For example, use `(when {:id (sqlfn-any-array \"uuid\" id-list)})` instead of
+   `(when {:id [in id-list]})`.
+
+   array-type:  the SQL name of the type of the `array-items` (e.g. 'varchar' or 'uuid').
+   array-items: the elements that populate the SQL ARRAY passed to the ANY function."
+  [array-type array-items]
+  (sql/sqlfn :any (sql-array array-type array-items)))


### PR DESCRIPTION
This PR will add an `apps.persistence.util/sqlfn-any-array` for use in a `where` clause, in order to prevent a `PSQLException` when passing too many items in a `(when {:id [in id-list]})` clause.

The `PSQLException` (caused by `java.io.IOException`: "Tried to send an out-of-range integer as a 2-byte value") is thrown because the JDBC driver is hitting a limit on the number of bind variables per PostgreSQL statement.