### PR TITLE
CORE-9084 Speed up `GET /analyses` listing endpoint.

### DIFF
--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -391,6 +391,26 @@
                   :status    [not-in (conj completed-status-codes
                                            impending-cancellation-status)]})))
 
+(defn list-child-job-statuses
+  "Lists the child job statuses within a batch job."
+  [batch-id]
+  (-> (select* :job_listings)
+      (fields :status)
+      (aggregate (count :id) :count)
+      (where {:parent_id batch-id})
+      (group :status)
+      (select)))
+
+(defn count-child-jobs
+  "Counts the child jobs of a batch job."
+  [batch-id]
+  (-> (select* :job_listings)
+      (aggregate (count :id) :count)
+      (where {:parent_id batch-id})
+      (select)
+      first
+      :count))
+
 (defn- add-job-type-clause
   "Adds a where clause for a set of job types if the set of job types provided is not nil
    or empty."

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -34,11 +34,11 @@
 (defn- format-batch-status
   [batch-id]
   (merge empty-batch-child-status
-         (let [children (jp/list-child-jobs batch-id)]
-           (assoc (->> (group-by batch-child-status children)
-                       (map (fn [[k v]] [k (count v)]))
-                       (into {}))
-                  :total (count children)))))
+         (->> (jp/list-child-job-statuses batch-id)
+              (group-by batch-child-status)
+              (map (fn [[status counts]] [status (reduce #(+ %1 (:count %2)) 0 counts)]))
+              (into {}))
+         {:total (jp/count-child-jobs batch-id)}))
 
 (defn- job-supports-sharing?
   [apps-client perms rep-steps {:keys [parent_id id]}]


### PR DESCRIPTION
This PR will update the `GET /analyses` listing endpoint to use SQL queries to count the statuses for child jobs for batch job listings.

This will speed up the `GET /analyses` endpoint when listing large batch jobs.