### PR TITLE
CORE-9086 Fix `job_config` in `format-submission-in-batch` function.

### DIFF
--- a/src/apps/service/apps/jobs/submissions/async.clj
+++ b/src/apps/service/apps/jobs/submissions/async.clj
@@ -51,12 +51,15 @@
        (into {})))
 
 (defn- format-submission-in-batch
-  [submission job-number path-map]
-  (let [job-suffix (str "analysis-" (inc job-number))]
-    (assoc (update-in submission [:config] (partial substitute-param-values path-map))
-      :group      (config/jex-batch-group-name)
-      :name       (str (:name submission) "-" job-suffix)
-      :output_dir (ft/path-join (:output_dir submission) job-suffix))))
+  [{:keys [config] :as submission} job-number path-map]
+  (let [job-suffix (str "analysis-" (inc job-number))
+        job-config (substitute-param-values path-map (:job_config submission config))
+        config     (substitute-param-values path-map config)]
+    (assoc submission :job_config job-config
+                      :config     config
+                      :group      (config/jex-batch-group-name)
+                      :name       (str (:name submission) "-" job-suffix)
+                      :output_dir (ft/path-join (:output_dir submission) job-suffix))))
 
 (defn- submit-job-in-batch
   [apps-client user submission job-number path-map]


### PR DESCRIPTION
This PR will fix the `POST /analyses` endpoint for HT Path List file inputs.

A bug was introduced to batch job processing by #86, which required a new `job_config` submission setting for Multi-Input Path List inputs.

Since #86, the user's original submission `config` is stored in the database for re-launching jobs, but the new `job_config` submission setting is used to submit actual parameters to the job services. The `job_config` submission setting is just a copy of the original submission `config` for jobs without any Multi-Input Path List inputs.

This PR will fix the `apps.service.apps.jobs.submissions.async/format-submission-in-batch` function so that it also substitutes HT path inputs in each sub-job's `job_config` submission settings.