### PR TITLE
CORE-7576 Update (un)share analyses to allow input (un)share errors.

### DIFF
--- a/src/apps/routes/schemas/permission.clj
+++ b/src/apps/routes/schemas/permission.clj
@@ -99,6 +99,7 @@
   (assoc AnalysisSharingRequestElement
     :analysis_name                (describe NonBlankString "The analysis name")
     :success                      (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
+    (optional-key :input_errors)  (describe [NonBlankString] "A list of any analysis input sharing errors")
     (optional-key :outputs_error) (describe NonBlankString "A brief reason for any result folder sharing errors")
     (optional-key :app_error)     (describe NonBlankString "A brief reason for any app sharing errors")
     (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")))
@@ -121,6 +122,7 @@
   {:analysis_id                  (describe UUID "The analysis ID")
    :analysis_name                (describe NonBlankString "The analysis name")
    :success                      (describe Boolean "A Boolean flag indicating whether the unsharing request succeeded")
+   (optional-key :input_errors)  (describe [NonBlankString] "A list of any analysis input unsharing errors")
    (optional-key :outputs_error) (describe NonBlankString "A brief reason for the result folder unsharing error")
    (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")})
 


### PR DESCRIPTION
The `/analyses/sharing` and `/analyses/unsharing` endpoints have been updated to return error messages for any input (un)share errors, but job (un)shares can still be marked as a `success` with those errors.

Most (un)sharing validation functions have been refactored to throw exceptions for errors, which are caught in the calling (un)sharing function and formatted as a failure message. Also, these endpoints used to return only the first input (un)sharing failure message, but this PR collects all failure messages and returns them in the response.