### PR TITLE
CORE-9189 Update to create tickets for inputs and output folders for use in OSG submissions

### DIFF
--- a/src/apps/clients/data_info.clj
+++ b/src/apps/clients/data_info.clj
@@ -94,3 +94,15 @@
 (defn unshare-path
   [user path unshare-with]
   (unshare-data-item user (get-data-id user path) unshare-with))
+
+(defn create-tickets
+  [user paths & {:as ticket-params}]
+  (when (seq paths)
+    (:body
+      (http/post (data-info-url "tickets")
+                 {:query-params (merge (secured-params user)
+                                       {:public true}
+                                       ticket-params)
+                  :body         (cheshire/encode {:paths paths})
+                  :content-type :json
+                  :as           :json}))))

--- a/src/apps/service/apps/de/jobs/io_tickets.clj
+++ b/src/apps/service/apps/de/jobs/io_tickets.clj
@@ -1,0 +1,42 @@
+(ns apps.service.apps.de.jobs.io-tickets
+  (:require [apps.clients.data-info :as data-info]
+            [apps.service.apps.jobs.util :as util]))
+
+(defn update-with-download-tickets
+  "Takes a list if input params,
+   creates a download ticket for the path of each input's :value,
+   and updates those inputs with the created ticket in a :ticket field.
+   For use with apps.service.apps.de.jobs.protocol/buildInputs"
+  [user params]
+  (if (or (empty? params) (every? (comp empty? :value) params))
+    params
+    (let [paths      (remove empty? (map :value params))
+          ticket-map (->> (data-info/create-tickets user
+                                                    paths
+                                                    :mode       "read"
+                                                    :public     false
+                                                    :uses-limit 1)
+                          :tickets
+                          (map (juxt :path :ticket-id))
+                          (into {}))]
+      (map #(assoc % :ticket (ticket-map (:value %)))
+           params))))
+
+(defn update-with-output-dir-ticket
+  "Returns the given submission updated with an :output_dir_ticket field,
+   containting an upload ticket for :output_dir (which will also be created if necessary).
+   For use with apps.service.apps.de.jobs.protocol/buildSubmission"
+  [user submission]
+  (let [output-dir (util/create-output-dir user submission)
+        ticket     (->> (data-info/create-tickets user
+                                                  [output-dir]
+                                                  :mode             "write"
+                                                  :public           false
+                                                  :uses-limit       0
+                                                  :file-write-limit 0)
+                        :tickets
+                        first
+                        :ticket-id)]
+    (assoc submission
+           :output_dir        output-dir
+           :output_dir_ticket ticket)))

--- a/src/apps/service/apps/jobs/util.clj
+++ b/src/apps/service/apps/jobs/util.clj
@@ -3,7 +3,9 @@
   (:require [apps.clients.data-info :as data-info]
             [apps.persistence.jobs :as jp]
             [apps.util.service :as service]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [clojure-commons.error-codes :as ce]
+            [clojure-commons.file-utils :as ft]))
 
 (defn validate-job-existence
   [job-ids]
@@ -24,3 +26,19 @@
 (defn get-path-list-contents-map
   [user paths]
   (into {} (map (juxt identity (partial get-path-list-contents user)) paths)))
+
+(defn create-output-dir
+  [user submission]
+  (let [output-dir (ft/build-result-folder-path submission)]
+    (try+
+     (data-info/get-path-info user :paths [output-dir] :filter-include "path")
+     ; FIXME Update this when data-info's exception handling is updated
+     (catch [:status 500] {:keys [body]}
+       ;; The caught error can't be rethrown since we parse the body to examine its error code.
+       ;; So we must throw the parsed body, but also clear out the `cause` in our `throw+` call,
+       ;; since transactions wrapping these functions will try to only rethrow this caught error.
+       (let [error (service/parse-json body)]
+         (if (= (:error_code error) ce/ERR_DOES_NOT_EXIST)
+           (data-info/create-directory user output-dir)
+           (throw+ error nil)))))
+    output-dir))


### PR DESCRIPTION
This PR will add `apps.service.apps.de.jobs.io-tickets/update-with-download-tickets` for use with
`apps.service.apps.de.jobs.protocol/buildInputs` and `update-with-output-dir-ticket` for use with `buildSubmission`.

These new functions will use a new `apps.clients.data-info/create-tickets` function for calling the `data-info` endpoint.

Also refactored `apps.service.apps.jobs.submissions/get-batch-output-dir` into a common `apps.service.apps.jobs.util/create-output-dir` function, for use in both `update-with-output-dir-ticket` and batch output folder creation.