### PR TITLE
Add support for skip_tmp_mount column

### DIFF
--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -382,6 +382,7 @@
      :entrypoint
      :tools_id
      :interactive_apps_proxy_settings_id
+     :skip_tmp_mount
      :id]))
 
 (defn add-settings
@@ -456,6 +457,7 @@
                            :name
                            :working_directory
                            :interactive_apps_proxy_settings_id
+                           :skip_tmp_mount
                            :entrypoint)
                    (with container-devices
                      (fields :host_path :container_path :id))

--- a/src/apps/routes/schemas/containers.clj
+++ b/src/apps/routes/schemas/containers.clj
@@ -49,6 +49,7 @@
     (s/optional-key :working_directory)  s/Str
     (s/optional-key :name)               s/Str
     (s/optional-key :entrypoint)         s/Str
+    (s/optional-key :skip_tmp_mount)     Boolean
     :id                 s/Uuid}
    "The group of settings for a container."))
 


### PR DESCRIPTION
Adds support for the container_settings.skip_tmp_mount column to the apps API and to job submissions.

I tried out the changes through the Swagger UI.