### PR TITLE
Add (interapps-url) function for later use in notifications

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,8 @@
                  [org.cyverse/event-messages "0.0.1"]
                  [com.novemberain/langohr "3.7.0"]
                  [me.raynes/fs "1.4.6"]
-                 [mvxcvi/clj-pgp "0.8.0"]]
+                 [mvxcvi/clj-pgp "0.8.0"]
+                 [pandect "0.6.1"]]
   :eastwood {:exclude-namespaces [apps.protocols :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[lein-swank "1.4.4"]

--- a/src/apps/clients/notifications.clj
+++ b/src/apps/clients/notifications.clj
@@ -11,7 +11,9 @@
             [apps.clients.notifications.tool-sharing :as tool-notifications]
             [apps.persistence.jobs :as jp]
             [apps.persistence.tool-requests :as tp]
-            [apps.util.config :as config]))
+            [apps.util.config :as config])
+  (:use [pandect.algo.sha256 :only [sha256]]
+        [cemerick.url :only [url]]))
 
 (def ^:private emailable-job-statuses
   #{jp/completed-status
@@ -48,6 +50,18 @@
   [job-info]
   (boolean (and (:notify job-info false)
                 (emailable-job-statuses (:status job-info)))))
+
+
+(defn- interapps-url
+  "Returns the externally accessible URL to the interactive app as a URL from
+   cemerick.url.
+
+   Example usage:
+       (str (interapps-url (url (config/interapps-base)) job-info))
+     Returns:
+       https://abb9730df.cyverse.run"
+  [{host :host :as base} {user-id :user_id analysis-id :uuid}]
+  (assoc base :host (str "a" (-> (str user-id analysis-id) sha256 (subs 0 8)) "." host)))
 
 (defn- format-job-status-update
   "Formats a job status update notification to send to the notification agent."

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -293,6 +293,11 @@
   [props config-valid configs]
   "apps.metadata.base-url" "http://metadata:60000")
 
+(cc/defprop-optstr interapps-base
+  "The external URL for interactive applications."
+  [props config-valid configs]
+  "app.interactive-apps.base" "https://cyverse.run")
+
 (cc/defprop-optint job-status-poll-interval
   "The job status polling interval in minutes."
   [props config-valid configs]


### PR DESCRIPTION
Sarah will be adding support for an interactive apps analysis type later on, at which point we'll be able to add the URL for the interactive app to the Running job status notifications as appropriate. This pull request adds the (interapps-url) function and the (configs/interapps-base) setting to the apps service, so that the URLs can be generated correctly.