### PR TITLE
CORE-9240: added the access URL to job status update notifications fo…

### DIFF
--- a/src/apps/clients/notifications.clj
+++ b/src/apps/clients/notifications.clj
@@ -57,11 +57,11 @@
    cemerick.url.
 
    Example usage:
-       (str (interapps-url (url (config/interapps-base)) job-info))
+       (str (interapps-url (url (config/interapps-base)) username external-id))
      Returns:
        https://abb9730df.cyverse.run"
-  [{host :host :as base} {user-id :user_id analysis-id :uuid}]
-  (assoc base :host (str "a" (-> (str user-id analysis-id) sha256 (subs 0 8)) "." host)))
+  [{host :host :as base} username external-id]
+  (assoc base :host (str "a" (-> (str username external-id) sha256 (subs 0 8)) "." host)))
 
 (defn- format-job-status-update
   "Formats a job status update notification to send to the notification agent."
@@ -93,6 +93,14 @@
    (send-job-status-update username email-address job-info (str job-name " " (string/lower-case (:status job-info)))))
   ([{username :shortUsername email-address :email} job-info]
      (send-job-status-update username email-address job-info)))
+
+(defn send-interactive-job-status-update
+  "Sends notification of an interactive job status update to the user."
+  ([username email-address job-info {external-id :external_id :as job-step-info}]
+   (let [access-url (interapps-url (url (config/interapps-base)) username external-id)]
+     (send-job-status-update username email-address (assoc job-info :access_url access-url))))
+  ([{username :shortUsername email-address :email} job-info job-step-info]
+   (send-interactive-job-status-update username email-address job-info job-step-info)))
 
 (defn- format-tool-request-notification
   [tool-req user-details]

--- a/src/apps/clients/notifications.clj
+++ b/src/apps/clients/notifications.clj
@@ -96,8 +96,8 @@
 
 (defn send-interactive-job-status-update
   "Sends notification of an interactive job status update to the user."
-  ([username email-address job-info {external-id :external_id :as job-step-info}]
-   (let [access-url (interapps-url (url (config/interapps-base)) username external-id)]
+  ([username email-address {user-id :user_id :as job-info} {external-id :external_id :as job-step-info}]
+   (let [access-url (interapps-url (url (config/interapps-base)) user-id external-id)]
      (send-job-status-update username email-address (assoc job-info :access_url access-url))))
   ([{username :shortUsername email-address :email} job-info job-step-info]
    (send-interactive-job-status-update username email-address job-info job-step-info)))

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -471,7 +471,8 @@
               :j.notify
               :j.app_wiki_url
               [:j.submission         :submission]
-              :j.parent_id)
+              :j.parent_id
+              :j.user_id)
       (where {:j.id id})
       (#(str (as-sql %) " for update"))
       (#(exec-raw [% [id]] :results))
@@ -487,11 +488,10 @@
 
 (defn- add-job-username
   "Determines the username of the user who submitted a job."
-  [{job-id :id :as job}]
-  (merge job (first (select [:jobs :j]
-                            (join [:users :u] {:j.user_id :u.id})
+  [{user-id :user_id :as job}]
+  (merge job (first (select [:users :u]
                             (fields :u.username)
-                            (where {:j.id job-id})))))
+                            (where {:u.id user-id})))))
 
 (defn lock-job
   "Retrieves a job by its internal identifier, placing a lock on the row. For-update queries


### PR DESCRIPTION
…r interactive apps

We need the job step information both in order to determine whether the current job step is interactive and to actually build the access URL. To minimize the scope of this change, I chose to omit cases where it would be cumbersome to obtain the job step information. Fortunately, these cases were all for newly submitted apps as far as I can tell. The upshot is that the access URL will not be included in notifications for interactive apps in the `Submitted` state. This seemed reasonable to me because the URL won't be reachable yet anyway.