### PR TITLE
Add the uid field to container-settings

### DIFF
--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -384,6 +384,7 @@
      :tools_id
      :interactive_apps_proxy_settings_id
      :skip_tmp_mount
+     :uid
      :id]))
 
 (defn add-settings
@@ -460,7 +461,8 @@
                            :working_directory
                            :interactive_apps_proxy_settings_id
                            :skip_tmp_mount
-                           :entrypoint)
+                           :entrypoint
+                           :uid)
                    (with container-devices
                      (fields :host_path :container_path :id))
                    (with container-volumes

--- a/src/apps/routes/schemas/containers.clj
+++ b/src/apps/routes/schemas/containers.clj
@@ -51,6 +51,7 @@
     (s/optional-key :name)               s/Str
     (s/optional-key :entrypoint)         s/Str
     (s/optional-key :skip_tmp_mount)     Boolean
+    (s/optional-key :uid)                Integer
     :id                 s/Uuid}
    "The group of settings for a container."))
 


### PR DESCRIPTION
This should allow the `uid` field to be set on the container_settings table through the apps service.