### PR TITLE
CORE-6903: change the notification type for URL upload jobs

### DIFF
--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -267,6 +267,17 @@
                   [:container_images.deprecated :deprecated])
           (where {:app_id app-id})))
 
+(defn get-app-notification-types
+  "Loads information about the notification types to use for an app."
+  [app-id]
+  (->> (select [:app_steps :step]
+               (join [:tasks :task] {:step.task_id :task.id})
+               (join [:tools :tool] {:task.tool_id :tool.id})
+               (join [:tool_types :tt] {:tool.tool_type_id :tt.id})
+               (fields :tt.notification_type)
+               (where {:step.app_id (uuidify app-id)}))
+       (map :notification_type)))
+
 (defn subselect-tool-ids-using-data-container
   "Query subselect for tool IDs of tools using a Docker image as a data container."
   [data-container-image-id]


### PR DESCRIPTION
This may not be the last PR associated with this change. Some notification format changes might be necessary in cases where the notification type is `data`. I want to get this change deployed in our development environment for testing, though.