### PR TITLE
CORE-9306: allow setting a specific status code when stopping jobs

### DIFF
--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -762,6 +762,17 @@
        (map (juxt :irods_path :ticket))
        (into {})))
 
+(defn add-job-status-update
+  "Adds a job status update for a given external ID"
+  [external-id message status]
+  (insert :job_status_updates
+          (values {:external_id        external-id
+                   :message            message
+                   :status             status
+                   :sent_from          "0.0.0.0"
+                   :sent_from_hostname "0.0.0.0"
+                   :sent_on            (System/currentTimeMillis)})))
+
 (defn get-job-status-updates
   "Retrieves the list of job status updates for an external ID."
   [external-id]

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -769,7 +769,7 @@
           (values {:external_id        external-id
                    :message            message
                    :status             status
-                   :sent_from          "0.0.0.0"
+                   :sent_from          (raw "'0.0.0.0'::inet")
                    :sent_from_hostname "0.0.0.0"
                    :sent_on            (System/currentTimeMillis)})))
 

--- a/src/apps/routes/analyses.clj
+++ b/src/apps/routes/analyses.clj
@@ -123,12 +123,12 @@
 
   (POST "/:analysis-id/stop" []
          :path-params [analysis-id :- AnalysisIdPathParam]
-         :query       [params SecuredQueryParams]
+         :query       [params StopAnalysisRequest]
          :return      StopAnalysisResponse
          :summary     "Stop a running analysis."
          :description       "This service allows DE users to stop running analyses."
          (ok (coerce! StopAnalysisResponse
-                  (apps/stop-job current-user analysis-id))))
+                  (apps/stop-job current-user analysis-id params))))
 
   (GET "/:analysis-id/steps" []
         :path-params [analysis-id :- AnalysisIdPathParam]

--- a/src/apps/routes/schemas/analysis.clj
+++ b/src/apps/routes/schemas/analysis.clj
@@ -2,7 +2,8 @@
   (:use [common-swagger-api.schema :only [describe]]
         [schema.core :only [defschema optional-key enum Any Bool Keyword]]
         [apps.routes.params :only [SystemId SecuredQueryParams]]
-        [apps.routes.schemas.containers :only [ToolContainer]])
+        [apps.routes.schemas.containers :only [ToolContainer]]
+        [apps.persistence.jobs :only [canceled-status failed-status completed-status]])
   (:import [java.util UUID]))
 
 (defschema ParameterValue
@@ -48,7 +49,7 @@
 (defschema StopAnalysisRequest
   (assoc SecuredQueryParams
          (optional-key :job_status)
-         (describe (enum "Canceled" "Completed" "Failed") "The job status to set. Defaults to canceled, can also be completed or failed")))
+         (describe (enum canceled-status completed-status failed-status) "The job status to set. Defaults to canceled, can also be completed or failed")))
 
 (defschema StopAnalysisResponse
   {:id (describe UUID "the ID of the stopped analysis.")})

--- a/src/apps/routes/schemas/analysis.clj
+++ b/src/apps/routes/schemas/analysis.clj
@@ -1,7 +1,7 @@
 (ns apps.routes.schemas.analysis
   (:use [common-swagger-api.schema :only [describe]]
-        [schema.core :only [defschema optional-key Any Bool Keyword]]
-        [apps.routes.params :only [SystemId]]
+        [schema.core :only [defschema optional-key enum Any Bool Keyword]]
+        [apps.routes.params :only [SystemId SecuredQueryParams]]
         [apps.routes.schemas.containers :only [ToolContainer]])
   (:import [java.util UUID]))
 
@@ -44,6 +44,11 @@
 
 (defschema AnalysisShredderRequest
   {:analyses (describe [UUID] "The identifiers of the analyses to be deleted.")})
+
+(defschema StopAnalysisRequest
+  (assoc SecuredQueryParams
+         (optional-key :job_status)
+         (describe (enum "Canceled" "Completed" "Failed") "The job status to set. Defaults to canceled, can also be completed or failed")))
 
 (defschema StopAnalysisResponse
   {:id (describe UUID "the ID of the stopped analysis.")})

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -286,7 +286,7 @@
 
 (defn stop-job
   [user job-id params]
-  (let [status (:job_status params "Canceled")]
+  (let [status (:job_status params jp/canceled-status)]
     (jobs/stop-job (get-apps-client user) user job-id status))
   {:id job-id})
 

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -285,8 +285,9 @@
   (jobs/get-job-relaunch-info (get-apps-client user) user job-id))
 
 (defn stop-job
-  [user job-id]
-  (jobs/stop-job (get-apps-client user) user job-id)
+  [user job-id params]
+  (let [status (:job_status params "Canceled")]
+    (jobs/stop-job (get-apps-client user) user job-id status))
   {:id job-id})
 
 (defn list-job-steps

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -174,6 +174,7 @@
 (defn- stop-single-job
   [apps-client status-to-set {job-id :id :as job} notify?]
   (jp/update-job job-id status-to-set (db/now))
+  (jp/add-job-status-update job-id "Job being stopped" status-to-set)
   (try+
     (stop-job-steps apps-client job (find-incomplete-job-steps job-id) notify?)
     (catch Throwable t

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -172,8 +172,8 @@
     (send-job-status-update apps-client job (first steps))))
 
 (defn- stop-single-job
-  [apps-client {job-id :id :as job} notify?]
-  (jp/update-job job-id jp/canceled-status (db/now))
+  [apps-client status-to-set {job-id :id :as job} notify?]
+  (jp/update-job job-id status-to-set (db/now))
   (try+
     (stop-job-steps apps-client job (find-incomplete-job-steps job-id) notify?)
     (catch Throwable t
@@ -182,12 +182,12 @@
       (log/warn "unable to cancel the most recent step of job, " job-id))))
 
 (defn stop-child-job
-  [apps-client {job-id :id}]
+  [apps-client status-to-set {job-id :id}]
   (transaction
     (let [{:keys [status] :as job} (jp/get-job-by-id job-id)]
       (when (jp/not-completed? status)
-        (stop-single-job apps-client job false)
-        jp/canceled-status))))
+        (stop-single-job apps-client status-to-set job false)
+        status-to-set))))
 
 (defn- stop-parent-job
   [apps-client parent-id sub-job-count]
@@ -202,13 +202,13 @@
      (log/info "batch job cancellation complete:" sub-job-count "stopped."))))
 
 (defn- stop-batch-jobs-thread
-  [apps-client parent-id]
+  [apps-client status-to-set parent-id]
   (try+
     (log/info "batch job cancellation starting...")
     ;; Re-list running children after the parent has been cancelled, to catch any new submissions.
     (let [children         (jp/list-running-child-jobs parent-id)
           stopped-sub-jobs (->> children
-                                (map (partial stop-child-job apps-client))
+                                (map (partial stop-child-job apps-client status-to-set))
                                 (remove nil?))]
       (stop-parent-job apps-client parent-id (count stopped-sub-jobs)))
     (catch Object _
@@ -216,12 +216,12 @@
                  "unable to cancel batch jobs," parent-id))))
 
 (defn- async-stop-batch-jobs
-  [apps-client parent-id]
-  (let [^Runnable target #(stop-batch-jobs-thread apps-client parent-id)]
+  [apps-client status-to-set parent-id]
+  (let [^Runnable target #(stop-batch-jobs-thread apps-client status-to-set parent-id)]
     (.start (Thread. target (str "batch_stop_" parent-id)))))
 
 (defn stop-job
-  [apps-client user job-id]
+  [apps-client user job-id status-to-set]
   (validate-jobs-for-user user [job-id] "write")
   (let [{:keys [status] :as job} (jp/get-job-by-id job-id)
         running-children (jp/list-running-child-jobs job-id)]
@@ -229,9 +229,9 @@
       (service/bad-request (str "job, " job-id ", is already completed or canceled")))
 
     ;; A parent job should be stopped right away, to prevent further child jobs from submitting.
-    (stop-single-job apps-client job true)
+    (stop-single-job apps-client status-to-set job true)
     (if (not (empty? running-children))
-      (async-stop-batch-jobs apps-client job-id))))
+      (async-stop-batch-jobs apps-client status-to-set job-id))))
 
 (defn list-job-steps
   [user job-id]


### PR DESCRIPTION
I still need to test this more than I have, but I wanted to get it up for review. I've also made it so when we stop jobs we put an entry in the `job_status_updates` table, though we do so after setting the real status. I haven't yet evaluated if I should force a propagation of job status updates at the same time, to reduce load elsewhere.