### PR TITLE
#129: mark job status updates for non-existent job steps as propagated …

### DIFF
--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -787,6 +787,14 @@
 (defn mark-job-status-updates-propagated
   "Marks a set of job status updates as propagated."
   [ids]
+  (when (seq ids)
+    (sql/update :job_status_updates
+                (set-fields {:propagated true})
+                (where {:id [in ids]}))))
+
+(defn mark-job-status-updates-for-external-id-completed
+  "Marks all job status updates for an external ID as completed."
+  [external-id]
   (sql/update :job_status_updates
               (set-fields {:propagated true})
-              (where {:id [in ids]})))
+              (where {:external_id external-id})))

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -219,12 +219,11 @@
 
 (defn update-job-status
   ([external-id]
+   (jobs/validate-job-status-update-step-count external-id)
    (transaction
-    (let [updates (jp/get-job-status-updates external-id)
-          steps   (jp/get-job-steps-by-external-id external-id)]
+    (let [updates (jp/get-job-status-updates external-id)]
       (when (seq updates)
-        (jobs/validate-job-status-update-step-count external-id updates steps)
-        (let [job-id      (:job_id (first steps))
+        (let [job-id      (:job_id (jp/get-job-steps-by-external-id external-id))
               job-step    (jobs/lock-job-step job-id external-id)
               job         (jobs/lock-job job-id)
               batch       (when-let [parent-id (:parent_id job)] (jp/get-job-by-id parent-id))

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -223,7 +223,7 @@
    (transaction
     (let [updates (jp/get-job-status-updates external-id)]
       (when (seq updates)
-        (let [job-id      (:job_id (jp/get-job-steps-by-external-id external-id))
+        (let [job-id      (:job_id (first (jp/get-job-steps-by-external-id external-id)))
               job-step    (jobs/lock-job-step job-id external-id)
               job         (jobs/lock-job job-id)
               batch       (when-let [parent-id (:parent_id job)] (jp/get-job-by-id parent-id))

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -17,14 +17,15 @@
 (defn validate-job-status-update-step-count
   "Validates the number of steps for an external ID provided in a set of job status updates. If there are too many or
   too few matching job steps then all of the job status updates will be marked as propagated and an exception will be
-  thrown."
-  [external-id updates job-steps]
-  (when (empty? job-steps)
-    (jp/mark-job-status-updates-propagated (mapv :id updates))
-    (service/not-found "job step" external-id))
-  (when (> (count job-steps) 1)
-    (jp/mark-job-status-updates-propagated (mapv :id updates))
-    (service/not-unique "job step" external-id)))
+  thrown. This function should not be called from within a transaction."
+  [external-id]
+  (let [job-steps (jp/get-job-steps-by-external-id external-id)]
+    (when (empty? job-steps)
+      (jp/mark-job-status-updates-for-external-id-completed external-id)
+      (service/not-found "job step" external-id))
+    (when (> (count job-steps) 1)
+      (jp/mark-job-status-updates-for-external-id-completed external-id)
+      (service/not-unique "job step" external-id))))
 
 (defn lock-job-step
   [job-id external-id]

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -14,16 +14,17 @@
             [apps.service.apps.jobs.util :as ju]
             [apps.util.service :as service]))
 
-(defn get-unique-job-step
-  "Gets a unique job step for an external ID. An exception is thrown if no job step
-  is found or if multiple job steps are found."
-  [external-id]
-  (let [job-steps (jp/get-job-steps-by-external-id external-id)]
-    (when (empty? job-steps)
-      (service/not-found "job step" external-id))
-    (when (> (count job-steps) 1)
-      (service/not-unique "job step" external-id))
-    (first job-steps)))
+(defn validate-job-status-update-step-count
+  "Validates the number of steps for an external ID provided in a set of job status updates. If there are too many or
+  too few matching job steps then all of the job status updates will be marked as propagated and an exception will be
+  thrown."
+  [external-id updates job-steps]
+  (when (empty? job-steps)
+    (jp/mark-job-status-updates-propagated (mapv :id updates))
+    (service/not-found "job step" external-id))
+  (when (> (count job-steps) 1)
+    (jp/mark-job-status-updates-propagated (mapv :id updates))
+    (service/not-unique "job step" external-id)))
 
 (defn lock-job-step
   [job-id external-id]


### PR DESCRIPTION
…if there are too many or too few matching job steps for processing