### PR TITLE
Add container settings String->Long coercion middleware.

### DIFF
--- a/src/apps/routes/schemas/containers.clj
+++ b/src/apps/routes/schemas/containers.clj
@@ -37,15 +37,21 @@
     {(s/optional-key :overwrite-public)
      (describe Boolean "Flag to force updates of images used by public tools.")}))
 
+(def LongString
+  (describe (s/either Long
+                      (s/pred #(try (Long/parseLong %) true (catch Exception e false))
+                              'long-string?))
+            "A string representing a Long number."))
+
 (s/defschema Settings
   (describe
    {(s/optional-key :cpu_shares)         Integer
     (s/optional-key :pids_limit)         Integer
-    (s/optional-key :memory_limit)       Long
-    (s/optional-key :min_memory_limit)   Long
+    (s/optional-key :memory_limit)       LongString
+    (s/optional-key :min_memory_limit)   LongString
     (s/optional-key :min_cpu_cores)      Double
     (s/optional-key :max_cpu_cores)      Double
-    (s/optional-key :min_disk_space)     Long
+    (s/optional-key :min_disk_space)     LongString
     (s/optional-key :network_mode)       s/Str
     (s/optional-key :working_directory)  s/Str
     (s/optional-key :name)               s/Str

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -19,6 +19,24 @@
 (def StatusCodeId (describe UUID "The Status Code's UUID"))
 (def Interactive (describe Boolean "Determines whether the tool is interactive."))
 
+(defn- coerce-container-settings-long-values
+  [tool]
+  (if (contains? tool :container)
+    (update tool :container containers/coerce-settings-long-values)
+    tool))
+
+(defn coerce-tool-import-requests
+  "Middleware that converts any container values in the given tool import/update request that should be a Long."
+  [handler]
+  (fn [request]
+    (handler (update request :body-params coerce-container-settings-long-values))))
+
+(defn coerce-tool-list-import-request
+  "Middleware that converts any container values in the given tool list import request that should be a Long."
+  [handler]
+  (fn [request]
+    (handler (update-in request [:body-params :tools] (partial map coerce-container-settings-long-values)))))
+
 (defschema ToolIdsList
   {:tool_ids (describe [UUID] "A List of Tool IDs")})
 

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -145,6 +145,7 @@
 
   (POST "/" []
         :query [params SecuredQueryParamsRequired]
+        :middleware [coerce-tool-import-requests]
         :body [body (describe PrivateToolImportRequest "The private Tool to import.")]
         :responses (merge CommonResponses
                           {200 {:schema      ToolDetails
@@ -239,6 +240,7 @@ otherwise the default value will be used."
   (PATCH "/:tool-id" []
          :path-params [tool-id :- ToolIdParam]
          :query [{:keys [user]} SecuredQueryParams]
+         :middleware [coerce-tool-import-requests]
          :body [body (describe PrivateToolUpdateRequest "The private Tool to update.")]
          :responses (merge CommonResponses
                            {200 {:schema      ToolDetails
@@ -481,6 +483,7 @@ for the `pids_limit` and `memory_limit` fields."
 
   (POST "/" []
         :query [params SecuredQueryParams]
+        :middleware [coerce-tool-list-import-request]
         :body [body (describe ToolsImportRequest "The Tools to import.")]
         :responses (merge CommonResponses
                           {200 {:schema      ToolIdsList
@@ -522,6 +525,7 @@ for the `pids_limit` and `memory_limit` fields."
   (PATCH "/:tool-id" []
          :path-params [tool-id :- ToolIdParam]
          :query [{:keys [user overwrite-public]} ToolUpdateParams]
+         :middleware [coerce-tool-import-requests]
          :body [body (describe ToolUpdateRequest "The Tool to update.")]
          :responses (merge CommonResponses
                            {200 {:schema      ToolDetails

--- a/src/apps/util/coercions.clj
+++ b/src/apps/util/coercions.clj
@@ -6,6 +6,13 @@
             [slingshot.slingshot :refer [throw+]])
   (:import [java.util UUID]))
 
+(defn coerce-string->long
+  "When the given map contains the given key, converts its string value to a long."
+  [m k]
+  (if (contains? m k)
+    (update m k rc/string->long)
+    m))
+
 (defn- stringify-uuids
   [v]
   (if (instance? UUID v)


### PR DESCRIPTION
This PR will add container settings String->Long coercion middleware, which allows container settings that require Long integer values to be submitted as either a JSON number or a string representation.

This resolves #136.