### PR TITLE
CORE-63: Add code to load extra fields when submitting

### DIFF
--- a/src/apps/service/apps/de/jobs/common.clj
+++ b/src/apps/service/apps/de/jobs/common.clj
@@ -114,7 +114,7 @@
        (take-while (comp nil? :external_app_id))
        (reduce #(.buildStep request-builder %1 %2) [])))
 
-(defn load-htcondor-extra-requirements
+(defn- load-htcondor-extra-requirements
   [app-id]
   (first
     (select :apps_htcondor_extra

--- a/src/apps/service/apps/de/jobs/common.clj
+++ b/src/apps/service/apps/de/jobs/common.clj
@@ -114,6 +114,16 @@
        (take-while (comp nil? :external_app_id))
        (reduce #(.buildStep request-builder %1 %2) [])))
 
+(defn load-htcondor-extra-requirements
+  [app-id]
+  (select :apps_htcondor_extra
+          (fields [:extra_requirements])
+          (where {:app_id app-id})))
+
+(defn build-extra
+  [request-builder app]
+  {:htcondor {:extra_requirements (load-htcondor-extra-requirements (:id app))}})
+
 (defn- interactive?
   "Returns true if the given submission is for an interactive job."
   [job]
@@ -143,6 +153,7 @@
          :output_dir           (:output_dir submission)
          :request_type         "submit"
          :steps                (.buildSteps request-builder)
+         :extra                (.buildExtra request-builder)
          :username             (:shortUsername user)
          :user_id              (get-user-id (:username user))
          :user_groups          (map (comp ipg/remove-environment-from-group :name) groups)

--- a/src/apps/service/apps/de/jobs/common.clj
+++ b/src/apps/service/apps/de/jobs/common.clj
@@ -116,13 +116,14 @@
 
 (defn load-htcondor-extra-requirements
   [app-id]
-  (select :apps_htcondor_extra
-          (fields [:extra_requirements])
-          (where {:app_id app-id})))
+  (first
+    (select :apps_htcondor_extra
+            (fields [:extra_requirements])
+            (where {:app_id app-id}))))
 
 (defn build-extra
   [request-builder app]
-  {:htcondor {:extra_requirements (load-htcondor-extra-requirements (:id app))}})
+  {:htcondor (load-htcondor-extra-requirements (:id app))})
 
 (defn- interactive?
   "Returns true if the given submission is for an interactive job."

--- a/src/apps/service/apps/de/jobs/condor.clj
+++ b/src/apps/service/apps/de/jobs/condor.clj
@@ -71,6 +71,9 @@
   (buildSteps [this]
     (ca/build-steps this app submission))
 
+  (buildExtra [this]
+    (ca/build-extra this app))
+
   (buildSubmission [this]
     (let [submission  (ca/build-submission this user email submission app)
           osg-compat? (fn [step] (not (string/blank? (some-> step :component :container :image :osg_image_path))))]

--- a/src/apps/service/apps/de/jobs/protocol.clj
+++ b/src/apps/service/apps/de/jobs/protocol.clj
@@ -19,4 +19,5 @@
   (buildComponent [_ step])
   (buildStep [_ steps step])
   (buildSteps [_])
+  (buildExtra [_])
   (buildSubmission [_]))


### PR DESCRIPTION
This pulls the `extra_requirements` column from `apps_htcondor_extra` and adds it to the submission.

Still needs the downstream jex-adapter etc. work, of course, but hopefully if I did anything too blatantly dumb it can get caught here :laughing: