### PR TITLE
CORE-134: set a lock timeout before attempting to obtain locks on a j…

### DIFF
--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -798,3 +798,8 @@
   (sql/update :job_status_updates
               (set-fields {:propagated true})
               (where {:external_id external-id})))
+
+(defn set-lock-timeout
+  "Sets a timeout for obtaining locks in the database."
+  []
+  (exec-raw ["SET LOCAL lock_timeout='5s'" []]))

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -221,6 +221,7 @@
   ([external-id]
    (jobs/validate-job-status-update-step-count external-id)
    (transaction
+    (jp/set-lock-timeout)
     (let [updates (jp/get-job-status-updates external-id)]
       (when (seq updates)
         (let [job-id      (:job_id (first (jp/get-job-steps-by-external-id external-id)))


### PR DESCRIPTION
…ob or job step

With this change, the following response will be returned when a lock can't be obtained:

```
$ curl -sH "Content-Type: application/json" -d '{"uuid":"2c6e0013-7c62-4f2f-a076-656c61115786"}' "http://localhost:31323/callbacks/de-job" | jq .
{
  "error_code": "ERR_UNCHECKED_EXCEPTION",
  "reason": "org.postgresql.util.PSQLException: ERROR: canceling statement due to lock timeout\n  Where: while locking tuple (14,49) in relation \"job_steps\""
}
```
