### PR TITLE
CORE-11 Migrate /apps/categories schemas and docs

### DIFF
--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -1,7 +1,6 @@
 (ns apps.routes.admin
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
-        [common-swagger-api.schema.ontologies]
         [common-swagger-api.schema.apps
          :only [AppCategoryIdPathParam
                 AppDeletionRequest
@@ -9,7 +8,9 @@
                 AppDocumentationRequest
                 StringAppIdParam
                 SystemId]]
+        [common-swagger-api.schema.apps.categories :only [AppCategoryListing AppCategoryAppListing]]
         [common-swagger-api.schema.integration-data :only [IntegrationData]]
+        [common-swagger-api.schema.ontologies]
         [common-swagger-api.schema.tools :only [ToolRequestIdParam]]
         [apps.metadata.reference-genomes
          :only [add-reference-genome

--- a/src/apps/routes/apps/categories.clj
+++ b/src/apps/routes/apps/categories.clj
@@ -22,9 +22,8 @@
   (GET "/" []
         :query [params CategoryListingParams]
         :return schema/AppCategoryListing
-        :summary "List App Categories"
-        :description "This service is used by the DE to obtain the list of app categories that
-         are visible to the user."
+        :summary schema/AppCategoryListingSummary
+        :description schema/AppCategoryListingDocs
         (ok (apps/get-app-categories current-user params)))
 
   (GET "/:system-id/:category-id" []
@@ -32,12 +31,8 @@
                       category-id :- AppCategoryIdPathParam]
         :query [params AppListingPagingParams]
         :return schema/AppCategoryAppListing
-        :summary "List Apps in a Category"
-        :description "This service lists all of the apps within an app category or any of its
-         descendents. The DE uses this service to obtain the list of apps when a user
-         clicks on a category in the _Apps_ window.
-         This endpoint accepts optional URL query parameters to limit and sort Apps,
-         which will allow pagination of results."
+        :summary schema/AppCategoryAppListingSummary
+        :description schema/AppCategoryAppListingDocs
         (ok (coerce! schema/AppCategoryAppListing
                  (apps/list-apps-in-category current-user system-id category-id params))))
 

--- a/src/apps/routes/apps/categories.clj
+++ b/src/apps/routes/apps/categories.clj
@@ -15,12 +15,13 @@
   (:require [apps.service.apps :as apps]
             [apps.service.apps.de.listings :as listings]
             [apps.util.service :as service]
+            [common-swagger-api.schema.apps.categories :as schema]
             [compojure.route :as route]))
 
 (defroutes app-categories
   (GET "/" []
         :query [params CategoryListingParams]
-        :return AppCategoryListing
+        :return schema/AppCategoryListing
         :summary "List App Categories"
         :description "This service is used by the DE to obtain the list of app categories that
          are visible to the user."
@@ -30,14 +31,14 @@
         :path-params [system-id :- SystemId
                       category-id :- AppCategoryIdPathParam]
         :query [params AppListingPagingParams]
-        :return AppCategoryAppListing
+        :return schema/AppCategoryAppListing
         :summary "List Apps in a Category"
         :description "This service lists all of the apps within an app category or any of its
          descendents. The DE uses this service to obtain the list of apps when a user
          clicks on a category in the _Apps_ window.
          This endpoint accepts optional URL query parameters to limit and sort Apps,
          which will allow pagination of results."
-        (ok (coerce! AppCategoryAppListing
+        (ok (coerce! schema/AppCategoryAppListing
                  (apps/list-apps-in-category current-user system-id category-id params))))
 
   (undocumented (route/not-found (service/unrecognized-path-response))))

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -13,7 +13,6 @@
                 AppDetails
                 AppDisabledParam
                 AppDocUrlParam
-                AppFilterParams
                 AppListing
                 AppListingDetail
                 AppListingJobStats
@@ -59,10 +58,7 @@
 
 (defschema AppListingPagingParams
   (merge SecuredQueryParamsEmailRequired
-         PagingParams
-         AppFilterParams
-         {SortFieldOptionalKey
-          (describe (apply enum AppListingValidSortFields) SortFieldDocs)}))
+         app-schema/AppListingPagingParams))
 
 (def AdminAppSearchValidSortFields
   (sets/union AppSearchValidSortFields AdminAppListingJobStatsKeys))


### PR DESCRIPTION
This PR will replace some of the schemas in `apps.routes.schemas.app` and `apps.routes.schemas.app.category`, and some `apps.routes.apps.categories` docs, with those migrated to `common-swagger-api.schema.apps.categories` in cyverse-de/common-swagger-api#17