### PR TITLE
CORE-185: endpoint to get submission launch info

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,8 +43,7 @@
   :plugins [[lein-swank "1.4.4"]
             [test2junit "1.1.3"]
             [jonase/eastwood "0.3.5"]]
-  :profiles {:dev {:dependencies   [[ring "1.5.0"]]
-                   :plugins        [[lein-ring "0.12.5"]]
+  :profiles {:dev {:plugins        [[lein-ring "0.12.5"]]
                    :resource-paths ["conf/test"]}
              :repl {:source-paths ["repl"]}
              :uberjar {:aot :all}}

--- a/src/apps/persistence/submissions.clj
+++ b/src/apps/persistence/submissions.clj
@@ -1,0 +1,14 @@
+(ns apps.persistence.submissions
+  (:use [kameleon.uuids :only [uuidify]]
+        [korma.core :exclude [update]])
+  (:require [cheshire.core :as json]))
+
+(defn get-submission-by-id [submission-id]
+  (some-> (select* :submissions)
+          (fields :submission)
+          (where {:id (uuidify submission-id)})
+          select
+          first
+          :submission
+          .getValue
+          (json/decode true)))

--- a/src/apps/routes.clj
+++ b/src/apps/routes.clj
@@ -23,6 +23,7 @@
             [apps.routes.oauth :as oauth-routes]
             [apps.routes.reference-genomes :as reference-genome-routes]
             [apps.routes.status :as status-routes]
+            [apps.routes.submissions :as submission-routes]
             [apps.routes.tools :as tool-routes]
             [apps.routes.users :as user-routes]
             [apps.routes.workspaces :as workspace-routes]
@@ -59,6 +60,7 @@
                    {:name "tool-requests", :description "Tool Request endpoints."}
                    {:name "reference-genomes", :description "Reference Genome endpoints."}
                    {:name "oauth", :description "OAuth callback and information endpoints."}
+                   {:name "submissions", :description "Analysis submission endpoints"}
                    {:name "admin-analyses", :description "Admin Analysis Endpoints"}
                    {:name "admin-apps", :description "Admin App endpoints."}
                    {:name "admin-app-community-tags", :description "Admin App Community tag endpoints."}
@@ -147,6 +149,9 @@
     (context "/oauth" []
       :tags ["oauth"]
       oauth-routes/oauth)
+    (context "/submissions" []
+      :tags ["submissions"]
+      submission-routes/submissions)
     (context "/admin/analyses" []
       :tags ["admin-analyses"]
       admin-routes/admin-analyses)

--- a/src/apps/routes/params.clj
+++ b/src/apps/routes/params.clj
@@ -17,6 +17,8 @@
 
 (def AnalysisIdPathParam (describe UUID "The Analysis UUID"))
 
+(def SubmissionIdPathParam (describe UUID "The Submission UUID"))
+
 (def ResultsTotalParam
   (describe Long
     "The total number of results that would be returned without limits and offsets applied."))

--- a/src/apps/routes/submissions.clj
+++ b/src/apps/routes/submissions.clj
@@ -1,0 +1,21 @@
+(ns apps.routes.submissions
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps :only [AppJobView]]
+        [apps.routes.params :only [SecuredQueryParams SubmissionIdPathParam]]
+        [apps.user :only [current-user]]
+        [apps.util.coercions :only [coerce!]]
+        [ring.util.http-response :only [ok]])
+  (:require [apps.service.apps :as apps]))
+
+(defroutes submissions
+  (context "/:submission-id" []
+    :path-params [submission-id :- SubmissionIdPathParam]
+
+    (GET "/launch-info" []
+      :query       [params SecuredQueryParams]
+      :return      AppJobView
+      :summary     "Obtain information to launch a saved analysis submission."
+      :description "Job submissions in the DE can be stored in the DE database for later reference. This endpoint
+      retrieves the JSON for the app associated with the submission, and populates it with the parameter values in the
+      submission."
+      (ok (coerce! AppJobView (apps/get-submission-launch-info current-user submission-id))))))

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -299,6 +299,10 @@
   [user job-id]
   (jobs/get-job-relaunch-info (get-apps-client user) user job-id))
 
+(defn get-submission-launch-info
+  [user submission-id]
+  (jobs/get-submission-launch-info (get-apps-client user) submission-id))
+
 (defn stop-job
   [user job-id params]
   (let [status (:job_status params jp/canceled-status)]

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -3,9 +3,11 @@
         [slingshot.slingshot :only [try+]])
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
+            [clojure-commons.exception-util :as cxu]
             [kameleon.db :as db]
             [apps.clients.notifications :as cn]
             [apps.persistence.jobs :as jp]
+            [apps.persistence.submissions :as sp]
             [apps.service.apps.job-listings :as listings]
             [apps.service.apps.jobs.params :as job-params]
             [apps.service.apps.jobs.permissions :as job-permissions]
@@ -165,6 +167,12 @@
   [apps-client user job-id]
   (validate-jobs-for-user user [job-id] "read")
   (job-params/get-job-relaunch-info apps-client (jp/get-job-by-id job-id)))
+
+(defn get-submission-launch-info
+  [apps-client submission-id]
+  (if-let [submission (sp/get-submission-by-id submission-id)]
+    (job-params/get-submission-launch-info apps-client submission)
+    (cxu/not-found "submission information not found")))
 
 (defn- stop-job-steps
   "Stops an individual step in a job."

--- a/src/apps/service/apps/jobs/params.clj
+++ b/src/apps/service/apps/jobs/params.clj
@@ -1,8 +1,10 @@
 (ns apps.service.apps.jobs.params
   (:use [apps.util.conversions :only [remove-nil-vals]]
+        [kameleon.uuids :only [uuidify]]
         [slingshot.slingshot :only [throw+]])
   (:require [cheshire.core :as cheshire]
             [clojure.string :as string]
+            [clojure-commons.exception-util :as cxu]
             [apps.persistence.app-metadata :as ap]
             [apps.service.apps.jobs.util :as ju]
             [apps.service.util :as util]))
@@ -134,6 +136,14 @@
     (update-in (assoc (.getAppJobView apps-client system-id app-id) :debug (:debug submission false))
                [:groups]
                (partial update-app-groups (:config submission)))))
+
+(defn get-submission-launch-info
+  [apps-client {system-id :system_id app-id :app_id :as submission}]
+  (when-not system-id (cxu/internal-system-error "no system ID assocaited with submission"))
+  (when-not app-id (cxu/internal-system-error "no app ID associated with submission"))
+  (update (assoc (.getAppJobView apps-client system-id (uuidify app-id)) :debug (:debug submission false))
+          :groups
+          (partial update-app-groups (:config submission))))
 
 (defn get-job-config
   [job]


### PR DESCRIPTION
This functionality will eventually be moved to the `analyses` service, but migrating it now would require too much work, and there's little use in duplicating it. The new endpoint is intended to be called by the `analyses` service to get the launch information for a submission.