### PR TITLE
CORE-11 Migrate /apps/hierarchies docs and schemas

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.6-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "2.10.6"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -10,7 +10,7 @@
                 SystemId]]
         [common-swagger-api.schema.apps.categories :only [AppCategoryListing AppCategoryAppListing]]
         [common-swagger-api.schema.integration-data :only [IntegrationData]]
-        [common-swagger-api.schema.ontologies]
+        [common-swagger-api.schema.ontologies :only [OntologyClassIRIParam OntologyVersionParam]]
         [common-swagger-api.schema.tools :only [ToolRequestIdParam]]
         [apps.metadata.reference-genomes
          :only [add-reference-genome

--- a/src/apps/routes/apps/categories.clj
+++ b/src/apps/routes/apps/categories.clj
@@ -1,14 +1,18 @@
 (ns apps.routes.apps.categories
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
-        [common-swagger-api.schema.ontologies]
         [common-swagger-api.schema.apps
          :only [AppCategoryIdPathParam
                 AppListing
                 SystemId]]
+        [common-swagger-api.schema.ontologies :only [OntologyClassIRIParam]]
         [apps.routes.params :only [SecuredQueryParams]]
         [apps.routes.schemas.app :only [AppListingPagingParams]]
-        [apps.routes.schemas.app.category]
+        [apps.routes.schemas.app.category
+         :only [AppCommunityGroupNameParam
+                CategoryListingParams
+                OntologyAppListingPagingParams
+                OntologyHierarchyFilterParams]]
         [apps.user :only [current-user]]
         [apps.util.coercions :only [coerce!]]
         [ring.util.http-response :only [ok]])

--- a/src/apps/routes/apps/categories.clj
+++ b/src/apps/routes/apps/categories.clj
@@ -45,53 +45,33 @@
 (defroutes app-hierarchies
 
   (GET "/" []
-        :query [params SecuredQueryParams]
-        :summary "List App Hierarchies"
-        :description (str
-"Lists all hierarchies saved for the active ontology version."
-(get-endpoint-delegate-block
-  "metadata"
-  "GET /ontologies/{ontology-version}")
-"Please see the metadata service documentation for response information.")
-        (listings/list-hierarchies current-user))
+       :query [params SecuredQueryParams]
+       :summary schema/AppHierarchiesListingSummary
+       :description-file "docs/apps/categories/hierarchies-listing.md"
+       (listings/list-hierarchies current-user))
 
-  (GET "/:root-iri" []
-        :path-params [root-iri :- OntologyClassIRIParam]
-        :query [{:keys [attr]} OntologyHierarchyFilterParams]
-        :summary "List App Category Hierarchy"
-        :description (str
-"Gets the list of app categories that are visible to the user for the active ontology version,
- rooted at the given `root-iri`."
-(get-endpoint-delegate-block
-  "metadata"
-  "POST /ontologies/{ontology-version}/{root-iri}/filter")
-"Please see the metadata service documentation for response information.")
-        (listings/get-app-hierarchy current-user root-iri attr))
+  (context "/:root-iri" []
+    :path-params [root-iri :- OntologyClassIRIParam]
 
-  (GET "/:root-iri/apps" []
-        :path-params [root-iri :- OntologyClassIRIParam]
-        :query [{:keys [attr] :as params} OntologyAppListingPagingParams]
-        :return AppListing
-        :summary "List Apps in a Category"
-        :description (str
-"Lists all of the apps under an app category hierarchy that are visible to the user."
-(get-endpoint-delegate-block
-  "metadata"
-  "POST /ontologies/{ontology-version}/{root-iri}/filter-targets"))
-        (ok (coerce! AppListing (apps/list-apps-under-hierarchy current-user root-iri attr params))))
+    (GET "/" []
+         :query [{:keys [attr]} OntologyHierarchyFilterParams]
+         :summary schema/AppCategoryHierarchyListingSummary
+         :description-file "docs/apps/categories/category-hierarchy-listing.md"
+         (listings/get-app-hierarchy current-user root-iri attr))
 
-  (GET "/:root-iri/unclassified" []
-        :path-params [root-iri :- OntologyClassIRIParam]
-        :query [{:keys [attr] :as params} OntologyAppListingPagingParams]
-        :return AppListing
-        :summary "List Unclassified Apps"
-        :description (str
-"Lists all of the apps that are visible to the user that are not under the given app category or any of
- its subcategories."
-(get-endpoint-delegate-block
-  "metadata"
-  "POST /ontologies/{ontology-version}/{root-iri}/filter-unclassified"))
-        (ok (coerce! AppListing (listings/get-unclassified-app-listing current-user root-iri attr params))))
+    (GET "/apps" []
+         :query [{:keys [attr] :as params} OntologyAppListingPagingParams]
+         :return AppListing
+         :summary schema/AppCategoryAppListingSummary
+         :description-file "docs/apps/categories/hierarchy-app-listing.md"
+         (ok (coerce! AppListing (apps/list-apps-under-hierarchy current-user root-iri attr params))))
+
+    (GET "/unclassified" []
+         :query [{:keys [attr] :as params} OntologyAppListingPagingParams]
+         :return AppListing
+         :summary schema/AppHierarchyUnclassifiedListingSummary
+         :description-file "docs/apps/categories/hierarchy-unclassified-app-listing.md"
+         (ok (coerce! AppListing (listings/get-unclassified-app-listing current-user root-iri attr params)))))
 
   (undocumented (route/not-found (service/unrecognized-path-response))))
 

--- a/src/apps/routes/schemas/app/category.clj
+++ b/src/apps/routes/schemas/app/category.clj
@@ -6,7 +6,6 @@
                 SortFieldDocs
                 SortFieldOptionalKey]]
         [common-swagger-api.schema.apps :only [SystemId]]
-        [common-swagger-api.schema.ontologies :only [OntologyDetails]]
         [apps.routes.params
          :only [SecuredQueryParams
                 SecuredQueryParamsEmailRequired]]
@@ -14,7 +13,8 @@
          :only [AdminAppListingValidSortFields
                 AppListingPagingParams]]
         [schema.core :only [defschema optional-key enum]])
-  (:require [common-swagger-api.schema.apps.categories :as categories-schema])
+  (:require [common-swagger-api.schema.apps.categories :as categories-schema]
+            [common-swagger-api.schema.ontologies :as ontologies-schema])
   (:import [java.util Date UUID]))
 
 (def AppCommunityGroupNameParam (describe String "The full group name of the App Community"))
@@ -69,7 +69,7 @@
    :applied    (describe Date "The date this version was set as active")})
 
 (defschema ActiveOntologyDetails
-  (merge OntologyDetails
+  (merge ontologies-schema/OntologyDetails
          {:active (describe Boolean
                             "Marks this Ontology version as the active version used when querying
                              metadata service ontology endpoints")}))
@@ -79,11 +79,11 @@
 
 (defschema OntologyHierarchyFilterParams
   (merge SecuredQueryParams
-         {:attr (describe String "The metadata attribute that stores class IRIs under the given root IRI")}))
+         ontologies-schema/OntologyHierarchyFilterParams))
 
 (defschema OntologyAppListingPagingParams
-  (merge AppListingPagingParams
-         {:attr (describe String "The metadata attribute that stores the given class IRI")}))
+  (merge SecuredQueryParamsEmailRequired
+         categories-schema/OntologyAppListingPagingParams))
 
 (defschema AdminOntologyAppListingPagingParams
   (assoc OntologyAppListingPagingParams


### PR DESCRIPTION
This PR will use the `/apps/hierarchies` endpoint docs and schemas migrated in cyverse-de/common-swagger-api#18.