### PR TITLE
CORE-11 Migrate GET /apps/communities/{community-id}/apps docs

### DIFF
--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -8,7 +8,10 @@
                 AppDocumentationRequest
                 StringAppIdParam
                 SystemId]]
-        [common-swagger-api.schema.apps.categories :only [AppCategoryListing AppCategoryAppListing]]
+        [common-swagger-api.schema.apps.categories
+         :only [AppCategoryListing
+                AppCategoryAppListing
+                AppCommunityGroupNameParam]]
         [common-swagger-api.schema.integration-data :only [IntegrationData]]
         [common-swagger-api.schema.ontologies
          :only [OntologyClassIRIParam

--- a/src/apps/routes/apps/categories.clj
+++ b/src/apps/routes/apps/categories.clj
@@ -12,8 +12,7 @@
         [apps.routes.params :only [SecuredQueryParams]]
         [apps.routes.schemas.app :only [AppListingPagingParams]]
         [apps.routes.schemas.app.category
-         :only [AppCommunityGroupNameParam
-                CategoryListingParams
+         :only [CategoryListingParams
                 OntologyAppListingPagingParams
                 OntologyHierarchyFilterParams]]
         [apps.user :only [current-user]]
@@ -83,14 +82,11 @@
 (defroutes app-communities
 
   (GET "/:community-id/apps" []
-       :path-params [community-id :- AppCommunityGroupNameParam]
+       :path-params [community-id :- schema/AppCommunityGroupNameParam]
        :query [params AppListingPagingParams]
        :return AppListing
-       :summary "List Apps in a Community"
-       :description (str "Lists all of the apps under an App Community that are visible to the user."
-                         (get-endpoint-delegate-block
-                           "metadata"
-                           "POST /avus/filter-targets"))
+       :summary schema/AppCommunityAppListingSummary
+       :description schema/AppCommunityAppListingDocs
        (ok (coerce! AppListing (apps/list-apps-in-community current-user community-id params))))
 
   (undocumented (route/not-found (service/unrecognized-path-response))))

--- a/src/apps/routes/schemas/app/category.clj
+++ b/src/apps/routes/schemas/app/category.clj
@@ -17,8 +17,6 @@
             [common-swagger-api.schema.ontologies :as ontologies-schema])
   (:import [java.util Date UUID]))
 
-(def AppCommunityGroupNameParam (describe String "The full group name of the App Community"))
-
 (defschema CategoryListingParams
   (merge SecuredQueryParamsEmailRequired
          categories-schema/CategoryListingParams))


### PR DESCRIPTION
This PR will use the community app listing docs migrated by cyverse-de/common-swagger-api#20.