### PR TITLE
CORE-11 Use common-swagger-api metadata docs and schemas

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.cyverse/clojure-commons "2.8.3"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/mescal "3.0.7"]
-                 [org.cyverse/metadata-client "3.1.0"]
+                 [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-swagger-api "2.10.7-SNAPSHOT"]

--- a/src/apps/clients/metadata.clj
+++ b/src/apps/clients/metadata.clj
@@ -15,18 +15,16 @@
   (metadata-client/filter-by-avus (config/metadata-client) username [app-target-type] app-ids avus))
 
 (defn list-avus
-  ([username app-id]
-   (metadata-client/list-avus (config/metadata-client) username app-target-type app-id))
-  ([username app-id opts]
-   (metadata-client/list-avus (config/metadata-client) username app-target-type app-id opts)))
+  [username app-id]
+  (:body (metadata-client/list-avus (config/metadata-client) username app-target-type app-id {:as :json})))
 
 (defn update-avus
   [username app-id body]
-  (metadata-client/update-avus (config/metadata-client) username app-target-type app-id body))
+  (:body (metadata-client/update-avus (config/metadata-client) username app-target-type app-id body {:as :json})))
 
 (defn set-avus
   [username app-id body]
-  (metadata-client/set-avus (config/metadata-client) username app-target-type app-id body))
+  (:body (metadata-client/set-avus (config/metadata-client) username app-target-type app-id body {:as :json})))
 
 (defn get-active-hierarchy-version
   [& {:keys [validate] :or {validate true}}]

--- a/src/apps/metadata/avus.clj
+++ b/src/apps/metadata/avus.clj
@@ -3,7 +3,6 @@
             [apps.persistence.app-metadata :as app-db]
             [apps.service.apps.de.categorization :as categorization]
             [apps.service.apps.de.validation :as validation]
-            [apps.util.service :as service]
             [cheshire.core :as json]))
 
 (defn list-avus
@@ -13,17 +12,15 @@
     (metadata-client/list-avus username app-id)))
 
 (defn set-avus
-  [{username :shortUsername :as user} app-id body admin?]
-  (let [{app-name :name :as app} (app-db/get-app app-id)
-        request (service/parse-json body)]
+  [{username :shortUsername :as user} app-id request admin?]
+  (let [{app-name :name :as app} (app-db/get-app app-id)]
     (validation/verify-app-permission user app "write" admin?)
     (categorization/validate-app-name-in-hierarchy-avus username app-id app-name (:avus request))
     (metadata-client/set-avus username app-id (json/encode request))))
 
 (defn update-avus
-  [{username :shortUsername :as user} app-id body admin?]
-  (let [{app-name :name :as app} (app-db/get-app app-id)
-        request (service/parse-json body)]
+  [{username :shortUsername :as user} app-id request admin?]
+  (let [{app-name :name :as app} (app-db/get-app app-id)]
     (validation/verify-app-permission user app "write" admin?)
     (categorization/validate-app-name-in-hierarchy-avus username app-id app-name (:avus request))
     (metadata-client/update-avus username app-id (json/encode request))))

--- a/src/apps/routes/apps/communities.clj
+++ b/src/apps/routes/apps/communities.clj
@@ -2,6 +2,7 @@
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
         [common-swagger-api.schema.apps :only [AppIdParam]]
+        [common-swagger-api.schema.metadata :only [AvuList]]
         [apps.routes.params :only [SecuredQueryParams]]
         [common-swagger-api.schema.apps :only [AppCategoryMetadata]]
         [apps.user :only [current-user]]
@@ -16,6 +17,7 @@
                  :path-params [app-id :- AppIdParam]
                  :query [params SecuredQueryParams]
                  :body [body (describe AppCategoryMetadata "Community metadata to add to the App.")]
+                 :return AvuList
                  :summary "Add/Update Community Metadata AVUs"
                  :description (str
                                 "Adds or updates Community Metadata AVUs on the app."
@@ -28,8 +30,8 @@
                                   "metadata"
                                   "POST /avus/{target-type}/{target-id}")
                                 "Where `{target-type}` is `app`."
-                                " Please see the metadata service documentation for request and response information.")
-                 (communities/add-app-to-communities current-user app-id body false))
+                                " Please see the metadata service documentation for request information.")
+                 (ok (communities/add-app-to-communities current-user app-id body false)))
 
            (DELETE "/" []
                    :path-params [app-id :- AppIdParam]
@@ -56,6 +58,7 @@
                  :path-params [app-id :- AppIdParam]
                  :query [params SecuredQueryParams]
                  :body [body (describe AppCategoryMetadata "Community metadata to add to the App.")]
+                 :return AvuList
                  :summary "Add/Update Community Metadata AVUs"
                  :description (str
                                 "Adds or updates Community Metadata AVUs on the app."
@@ -63,8 +66,8 @@
                                   "metadata"
                                   "POST /avus/{target-type}/{target-id}")
                                 "Where `{target-type}` is `app`."
-                                " Please see the metadata service documentation for request and response information.")
-                 (communities/add-app-to-communities current-user app-id body true))
+                                " Please see the metadata service documentation for request information.")
+                 (ok (communities/add-app-to-communities current-user app-id body true)))
 
            (DELETE "/" []
                    :path-params [app-id :- AppIdParam]

--- a/src/apps/routes/apps/metadata.clj
+++ b/src/apps/routes/apps/metadata.clj
@@ -9,7 +9,8 @@
         [apps.routes.params :only [SecuredQueryParams]]
         [apps.user :only [current-user]]
         [ring.util.http-response :only [ok]])
-  (:require [apps.metadata.avus :as avus]
+  (:require [common-swagger-api.schema.apps.metadata :as schema]
+            [apps.metadata.avus :as avus]
             [apps.util.service :as service]
             [compojure.route :as route]))
 
@@ -19,14 +20,8 @@
        :path-params [app-id :- AppIdParam]
        :query [params SecuredQueryParams]
        :return AvuList
-       :summary "View all Metadata AVUs"
-       :description (str
-"Lists all AVUs associated with an app.
- The authenticated user must have `read` permission to view this metadata."
-(get-endpoint-delegate-block
-  "metadata"
-  "GET /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.")
+       :summary schema/AppMetadataListingSummary
+       :description schema/AppMetadataListingDocs
        (ok (avus/list-avus current-user app-id false)))
 
   (POST "/" [:as {:keys [body]}]
@@ -34,19 +29,8 @@
         :query [params SecuredQueryParams]
         :body [body AvuListRequest]
         :return AvuList
-        :summary "Add/Update Metadata AVUs"
-        :description (str
-"Adds or updates Metadata AVUs on the app.
- The authenticated user must have `write` permission to edit this metadata,
- and the app's name must not duplicate the name of any other app (visible to the requesting user)
- that also has any of the ontology hierarchy AVUs given in the request."
-(get-endpoint-delegate-block
-  "metadata"
-  "POST /avus/filter-targets")
-(get-endpoint-delegate-block
-  "metadata"
-  "POST /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.")
+        :summary schema/AppMetadataUpdateSummary
+        :description schema/AppMetadataUpdateDocs
         (ok (avus/update-avus current-user app-id body false)))
 
   (PUT "/" [:as {:keys [body]}]
@@ -54,19 +38,8 @@
        :query [params SecuredQueryParams]
        :body [body SetAvuRequest]
        :return AvuList
-       :summary "Set Metadata AVUs"
-       :description (str
-"Sets Metadata AVUs on the app.
- The authenticated user must have `write` permission to edit this metadata,
- and the app's name must not duplicate the name of any other app (visible to the requesting user)
- that also has any of the ontology hierarchy AVUs given in the request."
-(get-endpoint-delegate-block
-  "metadata"
-  "POST /avus/filter-targets")
-(get-endpoint-delegate-block
-  "metadata"
-  "PUT /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.")
+       :summary schema/AppMetadataSetSummary
+       :description schema/AppMetadataSetDocs
        (ok (avus/set-avus current-user app-id body false)))
 
   (undocumented (route/not-found (service/unrecognized-path-response))))

--- a/src/apps/routes/apps/metadata.clj
+++ b/src/apps/routes/apps/metadata.clj
@@ -2,8 +2,13 @@
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
         [common-swagger-api.schema.apps :only [AppIdParam]]
+        [common-swagger-api.schema.metadata
+         :only [AvuList
+                AvuListRequest
+                SetAvuRequest]]
         [apps.routes.params :only [SecuredQueryParams]]
-        [apps.user :only [current-user]])
+        [apps.user :only [current-user]]
+        [ring.util.http-response :only [ok]])
   (:require [apps.metadata.avus :as avus]
             [apps.util.service :as service]
             [compojure.route :as route]))
@@ -11,24 +16,26 @@
 (defroutes app-metadata
 
   (GET "/" []
-        :path-params [app-id :- AppIdParam]
-        :query [params SecuredQueryParams]
-        :summary "View all Metadata AVUs"
-        :description (str
+       :path-params [app-id :- AppIdParam]
+       :query [params SecuredQueryParams]
+       :return AvuList
+       :summary "View all Metadata AVUs"
+       :description (str
 "Lists all AVUs associated with an app.
  The authenticated user must have `read` permission to view this metadata."
 (get-endpoint-delegate-block
   "metadata"
   "GET /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.
-Please see the metadata service documentation for response information.")
-        (avus/list-avus current-user app-id false))
+"Where `{target-type}` is `app`.")
+       (ok (avus/list-avus current-user app-id false)))
 
   (POST "/" [:as {:keys [body]}]
-         :path-params [app-id :- AppIdParam]
-         :query [params SecuredQueryParams]
-         :summary "Add/Update Metadata AVUs"
-         :description (str
+        :path-params [app-id :- AppIdParam]
+        :query [params SecuredQueryParams]
+        :body [body AvuListRequest]
+        :return AvuList
+        :summary "Add/Update Metadata AVUs"
+        :description (str
 "Adds or updates Metadata AVUs on the app.
  The authenticated user must have `write` permission to edit this metadata,
  and the app's name must not duplicate the name of any other app (visible to the requesting user)
@@ -39,15 +46,16 @@ Please see the metadata service documentation for response information.")
 (get-endpoint-delegate-block
   "metadata"
   "POST /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.
-Please see the metadata service documentation for request and response information.")
-         (avus/update-avus current-user app-id body false))
+"Where `{target-type}` is `app`.")
+        (ok (avus/update-avus current-user app-id body false)))
 
   (PUT "/" [:as {:keys [body]}]
-        :path-params [app-id :- AppIdParam]
-        :query [params SecuredQueryParams]
-        :summary "Set Metadata AVUs"
-        :description (str
+       :path-params [app-id :- AppIdParam]
+       :query [params SecuredQueryParams]
+       :body [body SetAvuRequest]
+       :return AvuList
+       :summary "Set Metadata AVUs"
+       :description (str
 "Sets Metadata AVUs on the app.
  The authenticated user must have `write` permission to edit this metadata,
  and the app's name must not duplicate the name of any other app (visible to the requesting user)
@@ -58,32 +66,33 @@ Please see the metadata service documentation for request and response informati
 (get-endpoint-delegate-block
   "metadata"
   "PUT /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.
-Please see the metadata service documentation for request and response information.")
-        (avus/set-avus current-user app-id body false))
+"Where `{target-type}` is `app`.")
+       (ok (avus/set-avus current-user app-id body false)))
 
   (undocumented (route/not-found (service/unrecognized-path-response))))
 
 (defroutes admin-app-metadata
 
   (GET "/" []
-        :path-params [app-id :- AppIdParam]
-        :query [params SecuredQueryParams]
-        :summary "View all Metadata AVUs"
-        :description (str
+       :path-params [app-id :- AppIdParam]
+       :query [params SecuredQueryParams]
+       :return AvuList
+       :summary "View all Metadata AVUs"
+       :description (str
 "Lists all AVUs associated with the app."
 (get-endpoint-delegate-block
   "metadata"
   "GET /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.
-Please see the metadata service documentation for response information.")
-        (avus/list-avus current-user app-id true))
+"Where `{target-type}` is `app`.")
+       (ok (avus/list-avus current-user app-id true)))
 
   (POST "/" [:as {:keys [body]}]
-         :path-params [app-id :- AppIdParam]
-         :query [params SecuredQueryParams]
-         :summary "Add/Update Metadata AVUs"
-         :description (str
+        :path-params [app-id :- AppIdParam]
+        :query [params SecuredQueryParams]
+        :body [body AvuListRequest]
+        :return AvuList
+        :summary "Add/Update Metadata AVUs"
+        :description (str
 "Adds or updates Metadata AVUs on the app.
  The app's name must not duplicate the name of any other app (visible to the requesting user)
  that also has any of the ontology hierarchy AVUs given in the request."
@@ -93,15 +102,16 @@ Please see the metadata service documentation for response information.")
 (get-endpoint-delegate-block
   "metadata"
   "POST /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.
-Please see the metadata service documentation for request and response information.")
-         (avus/update-avus current-user app-id body true))
+"Where `{target-type}` is `app`.")
+        (ok (avus/update-avus current-user app-id body true)))
 
   (PUT "/" [:as {:keys [body]}]
-        :path-params [app-id :- AppIdParam]
-        :query [params SecuredQueryParams]
-        :summary "Set Metadata AVUs"
-        :description (str
+       :path-params [app-id :- AppIdParam]
+       :query [params SecuredQueryParams]
+       :body [body SetAvuRequest]
+       :return AvuList
+       :summary "Set Metadata AVUs"
+       :description (str
 "Sets Metadata AVUs on the app.
  The app's name must not duplicate the name of any other app (visible to the requesting user)
  that also has any of the ontology hierarchy AVUs given in the request."
@@ -111,8 +121,7 @@ Please see the metadata service documentation for request and response informati
 (get-endpoint-delegate-block
   "metadata"
   "PUT /avus/{target-type}/{target-id}")
-"Where `{target-type}` is `app`.
-Please see the metadata service documentation for request and response information.")
-        (avus/set-avus current-user app-id body true))
+"Where `{target-type}` is `app`.")
+       (ok (avus/set-avus current-user app-id body true)))
 
   (undocumented (route/not-found (service/unrecognized-path-response))))

--- a/src/apps/service/apps/de/categorization.clj
+++ b/src/apps/service/apps/de/categorization.clj
@@ -28,9 +28,7 @@
     username
     app-id
     app-name
-    (-> (metadata-client/list-avus username app-id {:as :json})
-        :body
-        :avus)))
+    (:avus (metadata-client/list-avus username app-id))))
 
 (defn- validate-app
   [app-id category-ids]


### PR DESCRIPTION
This PR will update `/apps/{app-id}/metadata` endpoint docs to use the AVU schemas and docs added by cyverse-de/common-swagger-api#21.

This also requires the updated metadata-client functions added by cyverse-de/metadata-client#5.