### PR TITLE
CORE-11 Migrate /apps/{app-id}/communities docs

### DIFF
--- a/src/apps/routes/apps/communities.clj
+++ b/src/apps/routes/apps/communities.clj
@@ -1,14 +1,17 @@
 (ns apps.routes.apps.communities
   (:use [common-swagger-api.routes]
         [common-swagger-api.schema]
-        [common-swagger-api.schema.apps :only [AppIdParam]]
+        [common-swagger-api.schema.apps
+         :only [AppCategoryMetadataAddRequest
+                AppCategoryMetadataDeleteRequest
+                AppIdParam]]
         [common-swagger-api.schema.metadata :only [AvuList]]
         [apps.routes.params :only [SecuredQueryParams]]
-        [common-swagger-api.schema.apps :only [AppCategoryMetadata]]
         [apps.user :only [current-user]]
         [ring.util.http-response :only [ok]])
   (:require [apps.service.apps.communities :as communities]
             [apps.util.service :as service]
+            [common-swagger-api.schema.apps.communities :as schema]
             [compojure.route :as route]))
 
 (defroutes app-community-tags
@@ -16,38 +19,18 @@
            (POST "/" []
                  :path-params [app-id :- AppIdParam]
                  :query [params SecuredQueryParams]
-                 :body [body (describe AppCategoryMetadata "Community metadata to add to the App.")]
+                 :body [body AppCategoryMetadataAddRequest]
                  :return AvuList
-                 :summary "Add/Update Community Metadata AVUs"
-                 :description (str
-                                "Adds or updates Community Metadata AVUs on the app."
-                                " The authenticated user must be a community admin for every Community AVU in the request,"
-                                " in order to add or edit this metadata."
-                                (get-endpoint-delegate-block
-                                  "iplant-groups"
-                                  "GET /groups/{group-name}/privileges")
-                                (get-endpoint-delegate-block
-                                  "metadata"
-                                  "POST /avus/{target-type}/{target-id}")
-                                "Where `{target-type}` is `app`."
-                                " Please see the metadata service documentation for request information.")
+                 :summary schema/AppCommunityMetadataAddSummary
+                 :description schema/AppCommunityMetadataAddDocs
                  (ok (communities/add-app-to-communities current-user app-id body false)))
 
            (DELETE "/" []
                    :path-params [app-id :- AppIdParam]
                    :query [params SecuredQueryParams]
-                   :body [body (describe AppCategoryMetadata "Community metadata to remove from the App.")]
-                   :summary "Remove Community Metadata AVUs"
-                   :description (str
-                                  "Removes the given Community AVUs associated with an app."
-                                  " The authenticated user must be a community admin for every Community AVU in the request,"
-                                  " in order to remove those AVUs."
-                                  (get-endpoint-delegate-block
-                                    "iplant-groups"
-                                    "GET /groups/{group-name}/privileges")
-                                  (get-endpoint-delegate-block
-                                    "metadata"
-                                    "POST /avus/deleter"))
+                   :body [body AppCategoryMetadataDeleteRequest]
+                   :summary schema/AppCommunityMetadataDeleteSummary
+                   :description schema/AppCommunityMetadataDeleteDocs
                    (ok (communities/remove-app-from-communities current-user app-id body false)))
 
            (undocumented (route/not-found (service/unrecognized-path-response))))
@@ -57,7 +40,7 @@
            (POST "/" []
                  :path-params [app-id :- AppIdParam]
                  :query [params SecuredQueryParams]
-                 :body [body (describe AppCategoryMetadata "Community metadata to add to the App.")]
+                 :body [body AppCategoryMetadataAddRequest]
                  :return AvuList
                  :summary "Add/Update Community Metadata AVUs"
                  :description (str
@@ -72,7 +55,7 @@
            (DELETE "/" []
                    :path-params [app-id :- AppIdParam]
                    :query [params SecuredQueryParams]
-                   :body [body (describe AppCategoryMetadata "Community metadata to remove from the App.")]
+                   :body [body AppCategoryMetadataDeleteRequest]
                    :summary "Remove Community Metadata AVUs"
                    :description (str
                                   "Removes the given Community AVUs associated with an app."


### PR DESCRIPTION
This PR will replace `/apps/{app-id}/communities` endpoint docs and schemas in `apps.routes.apps.communities` with those added by cyverse-de/common-swagger-api#22.