### PR TITLE
CORE-11 Migrate remaining /tools endpoint schemas and docs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.7"]
+                 [org.cyverse/common-swagger-api "2.11.0"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes/apps/elements.clj
+++ b/src/apps/routes/apps/elements.clj
@@ -1,11 +1,11 @@
 (ns apps.routes.apps.elements
-  (:use [common-swagger-api.schema]
-        [apps.metadata.element-listings :only [list-elements]]
+  (:use [apps.metadata.element-listings :only [list-elements]]
         [apps.routes.params]
-        [apps.routes.schemas.tool :only [ToolListing]]
+        [common-swagger-api.schema]
+        [common-swagger-api.schema.tools :only [ToolListing]]
         [ring.util.http-response :only [ok]])
-  (:require [common-swagger-api.schema.apps.elements :as elements-schema]
-            [apps.util.service :as service]
+  (:require [apps.util.service :as service]
+            [common-swagger-api.schema.apps.elements :as elements-schema]
             [compojure.route :as route]))
 
 (defroutes app-elements

--- a/src/apps/routes/params.clj
+++ b/src/apps/routes/params.clj
@@ -6,8 +6,9 @@
                                           SortFieldDocs
                                           SortFieldOptionalKey
                                           StandardUserQueryParams]]
-        [common-swagger-api.schema.apps :only [IncludeHiddenParams]])
-  (:require [common-swagger-api.schema.apps.elements :as app-elements-schema]
+        [common-swagger-api.schema.common :only [IncludeHiddenParams]])
+  (:require [common-swagger-api.schema.apps.elements :as elements-schema]
+            [common-swagger-api.schema.tools :as tools-schema]
             [schema.core :as s])
   (:import [java.util UUID]))
 
@@ -95,14 +96,10 @@
         `[{\"field\":\"ownership\",\"value\":\"mine\"}]`.")}))
 
 (s/defschema ToolSearchParams
-  (merge SecuredPagingParams IncludeHiddenParams
-    {(s/optional-key :search) (describe String "The pattern to match in an Tool's Name or Description.")
-     (s/optional-key :public) (describe Boolean
-                                        "Set to `true` to list only public Tools, `false` to list only private Tools,
-                                         or leave unset to list all Tools.")}))
+  (merge SecuredPagingParams tools-schema/ToolSearchParams))
 
 (s/defschema AppParameterTypeParams
-  (merge SecuredQueryParams app-elements-schema/AppParameterTypeParams))
+  (merge SecuredQueryParams elements-schema/AppParameterTypeParams))
 
 (s/defschema IntegrationDataSortFields
   (s/enum :email :name :username))

--- a/src/apps/routes/schemas/containers.clj
+++ b/src/apps/routes/schemas/containers.clj
@@ -11,11 +11,6 @@
     {:container_images [Image]}
     "A list of container images."))
 
-(s/defschema NewImage
-  (describe
-   (dissoc Image :id)
-   "The values needed to add a new image to a tool."))
-
 (s/defschema ImageId
   (describe
     UUID
@@ -41,11 +36,6 @@
   (describe
    {:entrypoint (s/maybe s/Str)}
    "The entrypoint for a tool container"))
-
-(s/defschema NewSettings
-  (describe
-   (->optional-param Settings :id)
-   "The values needed to add a new container to a tool."))
 
 (s/defschema CPUShares
   (describe
@@ -87,11 +77,6 @@
    {:name (s/maybe s/Str)}
    "The name given to the tool container."))
 
-(s/defschema NewDevice
-  (describe
-   (dissoc Device :id)
-   "The map needed to add a device to a container."))
-
 (s/defschema DeviceHostPath
   (describe
    {:host_path s/Str}
@@ -111,11 +96,6 @@
   (describe
    {:container_devices [Device]}
    "A list of devices associated with a tool's container."))
-
-(s/defschema NewVolume
-  (describe
-   (dissoc Volume :id)
-   "A map for adding a new volume to a container."))
 
 (def VolumeIdParam
   (describe
@@ -155,11 +135,6 @@
         (dissoc :id))
     "A map for updating data container settings."))
 
-(s/defschema NewVolumesFrom
-  (describe
-   (dissoc VolumesFrom :id)
-   "A map for adding a new container from which to bind mount volumes."))
-
 (def VolumesFromIdParam
   (describe
     UUID
@@ -169,25 +144,3 @@
   (describe
    {:container_volumes_from [VolumesFrom]}
    "The list of VolumeFroms associated with a tool's container."))
-
-(s/defschema NewPort
-  (describe
-   (dissoc Port :id)
-   "A map for adding a new port configuration to a tool container."))
-
-(s/defschema NewProxySettings
-  (describe
-   (dissoc ProxySettings :id)
-   "A map for adding new interactive app reverse proxy settings."))
-
-(s/defschema NewToolContainer
-  (describe
-   (merge
-    NewSettings
-    {DevicesParamOptional       [NewDevice]
-     VolumesParamOptional       [NewVolume]
-     VolumesFromParamOptional   [NewVolumesFrom]
-     PortsParamOptional         [NewPort]
-     ProxySettingsParamOptional NewProxySettings
-     :image                     NewImage})
-   "The settings for adding a new full container definition to a tool."))

--- a/src/apps/routes/schemas/permission.clj
+++ b/src/apps/routes/schemas/permission.clj
@@ -7,7 +7,6 @@
   (:import [java.util UUID]))
 
 (def AnalysisPermissionEnum (enum "read" "own" ""))
-(def ToolPermissionEnum perms-schema/AppPermissionEnum)
 
 (defschema PermissionListerQueryParams
   (merge SecuredQueryParams perms-schema/PermissionListerQueryParams))
@@ -73,59 +72,3 @@
 (defschema AnalysisUnsharingResponse
   {:unsharing
    (describe [SubjectAnalysisUnsharingResponseElement] "The list of unsharing responses for individual subjects")})
-
-(defschema ToolIdList
-  {:tools (describe [UUID] "A List of Tool IDs")})
-
-(defschema ToolPermissionListElement
-  {:id          (describe UUID "The Tool ID")
-   :name        (describe NonBlankString "The Tool name")
-   :permissions (describe [perms-schema/SubjectPermissionListElement] "The list of subject permissions for the Tool")})
-
-(defschema ToolPermissionListing
-  {:tools (describe [ToolPermissionListElement] "The list of Tool permissions")})
-
-(defschema ToolSharingRequestElement
-  {:tool_id    (describe UUID "The Tool ID")
-   :permission (describe ToolPermissionEnum "The requested permission level")})
-
-(defschema ToolSharingResponseElement
-  (assoc ToolSharingRequestElement
-    :tool_name            (describe NonBlankString "The Tool name")
-    :success              (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
-    (optional-key :error) (describe ErrorResponse "Information about any error that may have occurred")))
-
-(defschema SubjectToolSharingRequestElement
-  {:subject (describe perms-schema/Subject "The user or group identification.")
-   :tools   (describe [ToolSharingRequestElement] "The list of Tool sharing requests for the subject")})
-
-(defschema SubjectToolSharingResponseElement
-  (assoc SubjectToolSharingRequestElement
-    :tools (describe [ToolSharingResponseElement] "The list of Tool sharing responses for the subject")))
-
-(defschema ToolSharingRequest
-  {:sharing (describe [SubjectToolSharingRequestElement] "The list of Tool sharing requests")})
-
-(defschema ToolSharingResponse
-  {:sharing (describe [SubjectToolSharingResponseElement] "The list of Tool sharing responses")})
-
-(defschema ToolUnsharingResponseElement
-  {:tool_id              (describe UUID "The Tool ID")
-   :tool_name            (describe NonBlankString "The Tool name")
-   :success              (describe Boolean "A Boolean flag indicating whether the unsharing request succeeded")
-   (optional-key :error) (describe ErrorResponse "Information about any error that may have occurred")})
-
-(defschema SubjectToolUnsharingRequestElement
-  {:subject (describe perms-schema/Subject "The user or group identification.")
-   :tools   (describe [UUID] "The identifiers of the Tools to unshare")})
-
-(defschema SubjectToolUnsharingResponseElement
-  (assoc SubjectToolUnsharingRequestElement
-    :tools (describe [ToolUnsharingResponseElement] "The list of Tool unsharing responses for the subject")))
-
-(defschema ToolUnsharingRequest
-  {:unsharing (describe [SubjectToolUnsharingRequestElement] "The list of unsharing requests for individual subjects")})
-
-(defschema ToolUnsharingResponse
-  {:unsharing
-   (describe [SubjectToolUnsharingResponseElement] "The list of unsharing responses for individual subjects")})

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -2,10 +2,9 @@
   (:use [apps.routes.params :only [SecuredPagingParams SecuredQueryParams]]
         [clojure-commons.error-codes]
         [common-swagger-api.schema :only [->optional-param describe ErrorResponse]]
-        [common-swagger-api.schema.tools]
         [schema.core :only [defschema enum optional-key]])
   (:require [apps.routes.schemas.containers :as containers]
-            [common-swagger-api.schema.containers :as containers-schema])
+            [common-swagger-api.schema.tools :as schema])
   (:import [java.util UUID]))
 
 (def StatusCodeId (describe UUID "The Status Code's UUID"))
@@ -32,45 +31,18 @@
   {:tool_ids (describe [UUID] "A List of Tool IDs")})
 
 (defschema PrivateToolDeleteParams
-  (merge SecuredQueryParams
-         {(optional-key :force-delete)
-          (describe Boolean "Flag to force deletion of a Tool already in use by Apps.")}))
+  (merge SecuredQueryParams schema/PrivateToolDeleteParams))
 
 (defschema ToolUpdateParams
   (merge SecuredQueryParams
     {(optional-key :overwrite-public)
      (describe Boolean "Flag to force container settings updates of public tools.")}))
 
-(defschema ToolImportRequest
-  (-> Tool
-      (->optional-param :id)
-      (merge
-        {:implementation (describe ToolImplementation ToolImplementationDocs)
-         :container      containers/NewToolContainer})))
-
-(defschema PrivateToolContainerImportRequest
-  (dissoc containers/NewToolContainer
-          containers-schema/DevicesParamOptional
-          containers-schema/VolumesParamOptional
-          containers-schema/VolumesFromParamOptional))
-
-(defschema PrivateToolImportRequest
-  (-> ToolImportRequest
-      (->optional-param :type)
-      (->optional-param :implementation)
-      (merge {:container PrivateToolContainerImportRequest})))
-
-(defschema PrivateToolUpdateRequest
-  (-> PrivateToolImportRequest
-      (->optional-param :name)
-      (->optional-param :version)
-      (->optional-param :container)))
-
 (defschema ToolsImportRequest
-  {:tools (describe [ToolImportRequest] "zero or more Tool definitions")})
+  {:tools (describe [schema/ToolImportRequest] "zero or more Tool definitions")})
 
 (defschema ToolUpdateRequest
-  (-> ToolImportRequest
+  (-> schema/ToolImportRequest
       (->optional-param :name)
       (->optional-param :version)
       (->optional-param :type)
@@ -97,22 +69,22 @@
 
 (defschema ToolRequestDetails
   {:id
-   ToolRequestIdParam
+   schema/ToolRequestIdParam
 
    :submitted_by
-   SubmittedByParam
+   schema/SubmittedByParam
 
    (optional-key :phone)
    (describe String "The phone number of the user submitting the request")
 
    (optional-key :tool_id)
-   ToolRequestToolIdParam
+   schema/ToolRequestToolIdParam
 
    :name
-   ToolNameParam
+   schema/ToolNameParam
 
    :description
-   ToolDescriptionParam
+   schema/ToolDescriptionParam
 
    (optional-key :source_url)
    (describe String "A link that can be used to obtain the tool")
@@ -124,10 +96,10 @@
    (describe String "A link to the tool documentation")
 
    :version
-   VersionParam
+   schema/VersionParam
 
    (optional-key :attribution)
-   AttributionParam
+   schema/AttributionParam
 
    (optional-key :multithreaded)
    (describe Boolean
@@ -162,13 +134,13 @@
    (describe [ToolRequestStatus] "A history of status updates for this Tool Request")
 
    (optional-key :interactive)
-   Interactive})
+   schema/Interactive})
 
 (defschema ToolRequest
   (dissoc ToolRequestDetails :id :submitted_by :history))
 
 (defschema ToolRequestListing
-  {:tool_requests (describe [ToolRequestSummary]
+  {:tool_requests (describe [schema/ToolRequestSummary]
                     "A listing of high level details about tool requests that have been submitted")})
 
 (defschema ToolRequestListingParams
@@ -193,18 +165,5 @@
 (defschema StatusCodeListing
   {:status_codes (describe [StatusCode] "A listing of known Status Codes")})
 
-(defschema ToolListing
-  {:tools (describe [ToolListingItem] "Listing of App Tools")})
-
 (defschema ImagePublicAppToolListing
-  {:tools (describe [Tool] "Listing of Public App Tools")})
-
-(defschema ErrorPrivateToolRequestBadParam
-  (assoc ErrorResponse
-    :error_code (describe (enum ERR_EXISTS ERR_BAD_OR_MISSING_FIELD) "Exists or Bad Field error code")))
-
-(def PrivateToolImportResponse400
-  {:schema      ErrorPrivateToolRequestBadParam
-   :description "
-* `ERR_EXISTS`: A Tool with the given `name` already exists.
-* `ERR_BAD_OR_MISSING_FIELD`: The image with the given `name` and `tag` has been deprecated."})
+  {:tools (describe [schema/Tool] "Listing of Public App Tools")})


### PR DESCRIPTION
This PR will replace the remaining `/tools` endpoint schemas and docs in `apps.routes.tools` with those added by cyverse-de/common-swagger-api#23.