### PR TITLE
CORE-11 Bump common-swagger-api to release version 2.11.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.1"]
+                 [org.cyverse/common-swagger-api "2.11.3"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes/params.clj
+++ b/src/apps/routes/params.clj
@@ -59,7 +59,7 @@
       case-insensitive, in the corresponding field.")})
 
 (s/defschema AnalysisListingParams
-  (merge SecuredPagingParams analyses-schema/AnalysisListingParams))
+  (merge SecuredQueryParams analyses-schema/AnalysisListingParams))
 
 (s/defschema ToolSearchParams
   (merge SecuredPagingParams tools-schema/ToolSearchParams))


### PR DESCRIPTION
This PR will update apps with `common-swagger-api` version `2.11.3`, which includes a bug fix for listing batch job status counts.

It will also update `apps.routes.params/AnalysisListingParams` to merge `SecuredQueryParams` with `common-swagger-api.schema.analyses.listing/AnalysisListingParams`, which now includes paging params in the latest `common-swagger-api` version.