### PR TITLE
CORE-11 Migrate coerce-tool-import-requests middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.4"]
+                 [org.cyverse/common-swagger-api "2.11.5"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes/schemas/containers.clj
+++ b/src/apps/routes/schemas/containers.clj
@@ -2,8 +2,7 @@
   (:use [common-swagger-api.schema :only [->optional-param describe]]
         [common-swagger-api.schema.containers]
         [apps.routes.params :only [SecuredQueryParams]])
-  (:require [apps.util.coercions :as coercions]
-            [schema.core :as s])
+  (:require [schema.core :as s])
   (:import (java.util UUID)))
 
 (s/defschema Images
@@ -23,14 +22,6 @@
   (merge SecuredQueryParams
     {(s/optional-key :overwrite-public)
      (describe Boolean "Flag to force updates of images used by public tools.")}))
-
-(defn coerce-settings-long-values
-  "Converts any values in the given settings map that should be a Long, according to the Settings schema."
-  [settings]
-  (-> settings
-      (coercions/coerce-string->long :memory_limit)
-      (coercions/coerce-string->long :min_memory_limit)
-      (coercions/coerce-string->long :min_disk_space)))
 
 (s/defschema Entrypoint
   (describe

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -3,29 +3,10 @@
         [clojure-commons.error-codes]
         [common-swagger-api.schema :only [->optional-param describe ErrorResponse]]
         [schema.core :only [defschema enum optional-key]])
-  (:require [apps.routes.schemas.containers :as containers]
-            [common-swagger-api.schema.tools :as schema])
+  (:require [common-swagger-api.schema.tools :as schema])
   (:import [java.util UUID]))
 
 (def StatusCodeId (describe UUID "The Status Code's UUID"))
-
-(defn- coerce-container-settings-long-values
-  [tool]
-  (if (contains? tool :container)
-    (update tool :container containers/coerce-settings-long-values)
-    tool))
-
-(defn coerce-tool-import-requests
-  "Middleware that converts any container values in the given tool import/update request that should be a Long."
-  [handler]
-  (fn [request]
-    (handler (update request :body-params coerce-container-settings-long-values))))
-
-(defn coerce-tool-list-import-request
-  "Middleware that converts any container values in the given tool list import request that should be a Long."
-  [handler]
-  (fn [request]
-    (handler (update-in request [:body-params :tools] (partial map coerce-container-settings-long-values)))))
 
 (defschema ToolIdsList
   {:tool_ids (describe [UUID] "A List of Tool IDs")})

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -161,7 +161,7 @@
 
   (POST "/" []
         :query [params SecuredQueryParamsRequired]
-        :middleware [coerce-tool-import-requests]
+        :middleware [schema/coerce-tool-import-requests]
         :body [body schema/PrivateToolImportRequest]
         :responses schema/PrivateToolImportResponses
         :summary schema/ToolAddSummary
@@ -212,7 +212,7 @@
   (PATCH "/:tool-id" []
          :path-params [tool-id :- schema/ToolIdParam]
          :query [{:keys [user]} SecuredQueryParams]
-         :middleware [coerce-tool-import-requests]
+         :middleware [schema/coerce-tool-import-requests]
          :body [body schema/PrivateToolUpdateRequest]
          :responses schema/ToolUpdateResponses
          :summary schema/ToolUpdateSummary
@@ -439,7 +439,7 @@
 
   (POST "/" []
         :query [params SecuredQueryParams]
-        :middleware [coerce-tool-list-import-request]
+        :middleware [schema/coerce-tool-list-import-request]
         :body [body (describe ToolsImportRequest "The Tools to import.")]
         :responses (merge CommonResponses
                           {200 {:schema      ToolIdsList
@@ -481,7 +481,7 @@
   (PATCH "/:tool-id" []
          :path-params [tool-id :- schema/ToolIdParam]
          :query [{:keys [user overwrite-public]} ToolUpdateParams]
-         :middleware [coerce-tool-import-requests]
+         :middleware [schema/coerce-tool-import-requests]
          :body [body (describe ToolUpdateRequest "The Tool to update.")]
          :responses (merge CommonResponses
                            {200 {:schema      schema/ToolDetails
@@ -708,7 +708,7 @@ included in it. Any existing settings not included in the request's `container` 
   (POST "/:tool-id/publish" []
         :path-params [tool-id :- schema/ToolIdParam]
         :query [params SecuredQueryParams]
-        :middleware [coerce-tool-import-requests]
+        :middleware [schema/coerce-tool-import-requests]
         :body [body (describe ToolUpdateRequest "The Tool to update.")]
         :responses (merge CommonResponses
                           {200 {:schema      schema/ToolDetails

--- a/src/apps/util/coercions.clj
+++ b/src/apps/util/coercions.clj
@@ -6,13 +6,6 @@
             [slingshot.slingshot :refer [throw+]])
   (:import [java.util UUID]))
 
-(defn coerce-string->long
-  "When the given map contains the given key, converts its string value to a long."
-  [m k]
-  (if (contains? m k)
-    (update m k rc/string->long)
-    m))
-
 (defn- stringify-uuids
   [v]
   (if (instance? UUID v)


### PR DESCRIPTION
This PR will replace `apps.routes.schemas.tool/coerce-tool-import-requests` and `coerce-tool-list-import-request` (and related functions) with those added by cyverse-de/common-swagger-api#28.

Missed in #165.