### PR TITLE
CORE-11 Migrate remaining /tool-requests endpoint schemas and docs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.7"]
+                 [org.cyverse/common-swagger-api "2.11.8-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -18,7 +18,11 @@
          :only [OntologyClassIRIParam
                 OntologyHierarchy
                 OntologyVersionParam]]
-        [common-swagger-api.schema.tools :only [ToolRequestIdParam]]
+        [common-swagger-api.schema.tools
+         :only [ToolRequestStatusCodeId
+                ToolRequestDetails
+                ToolRequestIdParam
+                ToolRequestListing]]
         [apps.metadata.reference-genomes
          :only [add-reference-genome
                 delete-reference-genome
@@ -52,7 +56,7 @@
     (ok (list-tool-requests params)))
 
   (DELETE "/status-codes/:status-code-id" []
-    :path-params [status-code-id :- StatusCodeId]
+    :path-params [status-code-id :- ToolRequestStatusCodeId]
     :query [params SecuredQueryParams]
     :summary "Delete a Tool Request Status Code"
     :description "This service allows administrators to delete a tool request status code provided that

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -10,13 +10,12 @@
   (:require [common-swagger-api.schema.tools :as schema])
   (:import [java.util UUID]))
 
-(def StatusCodeId (describe UUID "The Status Code's UUID"))
-
 (defschema ToolIdsList
   {:tool_ids (describe [UUID] "A List of Tool IDs")})
 
 (defschema PrivateToolDeleteParams
-  (merge SecuredQueryParams schema/PrivateToolDeleteParams))
+  (merge SecuredQueryParams
+         schema/PrivateToolDeleteParams))
 
 (defschema ToolUpdateParams
   (merge SecuredQueryParams
@@ -34,122 +33,16 @@
       (->optional-param :implementation)
       (->optional-param :container)))
 
-(defschema ToolRequestStatus
-  {(optional-key :status)
-   (describe String
-     "The status code of the Tool Request update. The status code is case-sensitive, and if it isn't
-      defined in the database already then it will be added to the list of known status codes")
-
-   :status_date
-   (describe Long "The timestamp of the Tool Request status update")
-
-   :updated_by
-   (describe String "The username of the user that updated the Tool Request status")
-
-   (optional-key :comments)
-   (describe String "The administrator comments of the Tool Request status update")})
-
 (defschema ToolRequestStatusUpdate
-  (dissoc ToolRequestStatus :updated_by :status_date))
-
-(defschema ToolRequestDetails
-  {:id
-   schema/ToolRequestIdParam
-
-   :submitted_by
-   schema/SubmittedByParam
-
-   (optional-key :phone)
-   (describe String "The phone number of the user submitting the request")
-
-   (optional-key :tool_id)
-   schema/ToolRequestToolIdParam
-
-   :name
-   schema/ToolNameParam
-
-   :description
-   schema/ToolDescriptionParam
-
-   (optional-key :source_url)
-   (describe String "A link that can be used to obtain the tool")
-
-   (optional-key :source_upload_file)
-   (describe String "The path to a file that has been uploaded into iRODS")
-
-   :documentation_url
-   (describe String "A link to the tool documentation")
-
-   :version
-   schema/VersionParam
-
-   (optional-key :attribution)
-   schema/AttributionParam
-
-   (optional-key :multithreaded)
-   (describe Boolean
-     "A flag indicating whether or not the tool is multithreaded. This can be `true` to indicate
-      that the user requesting the tool knows that it is multithreaded, `false` to indicate that the
-      user knows that the tool is not multithreaded, or omitted if the user does not know whether or
-      not the tool is multithreaded")
-
-   :test_data_path
-   (describe String "The path to a test data file that has been uploaded to iRODS")
-
-   :cmd_line
-   (describe String "Instructions for using the tool")
-
-   (optional-key :additional_info)
-   (describe String
-     "Any additional information that may be helpful during tool installation or validation")
-
-   (optional-key :additional_data_file)
-   (describe String
-     "Any additional data file that may be helpful during tool installation or validation")
-
-   (optional-key :architecture)
-   (describe (enum "32-bit Generic" "64-bit Generic" "Others" "Don't know")
-     "One of the architecture names known to the DE. Currently, the valid values are
-      `32-bit Generic` for a 32-bit executable that will run in the DE,
-      `64-bit Generic` for a 64-bit executable that will run in the DE,
-      `Others` for tools run in a virtual machine or interpreter, and
-      `Don't know` if the user requesting the tool doesn't know what the architecture is")
-
-   :history
-   (describe [ToolRequestStatus] "A history of status updates for this Tool Request")
-
-   (optional-key :interactive)
-   schema/Interactive})
-
-(defschema ToolRequest
-  (dissoc ToolRequestDetails :id :submitted_by :history))
-
-(defschema ToolRequestListing
-  {:tool_requests (describe [schema/ToolRequestSummary]
-                    "A listing of high level details about tool requests that have been submitted")})
+  (dissoc schema/ToolRequestStatus :updated_by :status_date))
 
 (defschema ToolRequestListingParams
   (merge SecuredQueryParams
-         PagingParams
-         {(optional-key :status)
-          (describe String
-                    "The name of a status code to include in the results. The name of the status code is case
-                     sensitive. If the status code isn't already defined, it will be added to the database")}))
+         schema/ToolRequestListingParams))
 
-(defschema StatusCodeListingParams
+(defschema ToolRequestStatusCodeListingParams
   (merge SecuredQueryParams
-    {(optional-key :filter)
-     (describe String
-       "If this parameter is set then only the status codes that contain the string passed in this
-        query parameter will be listed. This is a case-insensitive search")}))
-
-(defschema StatusCode
-  {:id          StatusCodeId
-   :name        (describe String "The Status Code")
-   :description (describe String "A brief description of the Status Code")})
-
-(defschema StatusCodeListing
-  {:status_codes (describe [StatusCode] "A listing of known Status Codes")})
+         schema/ToolRequestStatusCodeListingParams))
 
 (defschema ImagePublicAppToolListing
   {:tools (describe [schema/Tool] "Listing of Public App Tools")})

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -401,33 +401,26 @@
 
 (defroutes tool-requests
   (GET "/" []
-        :query [params ToolRequestListingParams]
-        :return schema/ToolRequestListing
-        :summary "List Tool Requests"
-        :description "This endpoint lists high level details about tool requests that have been submitted.
-        A user may track their own tool requests with this endpoint."
-        (ok (tool-requests/list-tool-requests (assoc params :username (:username current-user)))))
+       :query [params ToolRequestListingParams]
+       :return schema/ToolRequestListing
+       :summary schema/ToolInstallRequestListingSummary
+       :description schema/ToolInstallRequestListingDocs
+       (ok (tool-requests/list-tool-requests (assoc params :username (:username current-user)))))
 
   (POST "/" []
-         :query [params SecuredQueryParams]
-         :body [body (describe schema/ToolRequest
-                       "A tool installation request. One of `source_url` or `source_upload_file`
-                        fields are required, but not both.")]
-         :return schema/ToolRequestDetails
-         :summary "Request Tool Installation"
-         :description "This service submits a request for a tool to be installed so that it can be used
-         from within the Discovery Environment. The installation request and all status updates
-         related to the tool request will be tracked in the Discovery Environment database."
-         (ok (submit-tool-request current-user body)))
+        :query [params SecuredQueryParams]
+        :body [body schema/ToolRequest]
+        :return schema/ToolRequestDetails
+        :summary schema/ToolInstallRequestSummary
+        :description schema/ToolInstallRequestDocs
+        (ok (submit-tool-request current-user body)))
 
   (GET "/status-codes" []
-        :query [params ToolRequestStatusCodeListingParams]
-        :summary "List Tool Request Status Codes"
-        :return schema/ToolRequestStatusCodeListing
-        :description "Tool request status codes are largely arbitrary, but once they've been used once,
-        they're stored in the database so that they can be reused easily. This endpoint allows the
-        caller to list the known status codes."
-        (ok (tool-requests/list-tool-request-status-codes params))))
+       :query [params ToolRequestStatusCodeListingParams]
+       :return schema/ToolRequestStatusCodeListing
+       :summary schema/ToolInstallRequestStatusCodeListingSummary
+       :description schema/ToolInstallRequestStatusCodeListingDocs
+       (ok (tool-requests/list-tool-request-status-codes params))))
 
 (defroutes admin-tools
   (GET "/" []

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -402,7 +402,7 @@
 (defroutes tool-requests
   (GET "/" []
         :query [params ToolRequestListingParams]
-        :return ToolRequestListing
+        :return schema/ToolRequestListing
         :summary "List Tool Requests"
         :description "This endpoint lists high level details about tool requests that have been submitted.
         A user may track their own tool requests with this endpoint."
@@ -410,10 +410,10 @@
 
   (POST "/" []
          :query [params SecuredQueryParams]
-         :body [body (describe ToolRequest
+         :body [body (describe schema/ToolRequest
                        "A tool installation request. One of `source_url` or `source_upload_file`
                         fields are required, but not both.")]
-         :return ToolRequestDetails
+         :return schema/ToolRequestDetails
          :summary "Request Tool Installation"
          :description "This service submits a request for a tool to be installed so that it can be used
          from within the Discovery Environment. The installation request and all status updates
@@ -421,9 +421,9 @@
          (ok (submit-tool-request current-user body)))
 
   (GET "/status-codes" []
-        :query [params StatusCodeListingParams]
+        :query [params ToolRequestStatusCodeListingParams]
         :summary "List Tool Request Status Codes"
-        :return StatusCodeListing
+        :return schema/ToolRequestStatusCodeListing
         :description "Tool request status codes are largely arbitrary, but once they've been used once,
         they're stored in the database so that they can be reused easily. This endpoint allows the
         caller to list the known status codes."


### PR DESCRIPTION
This PR will replace the schemas and docs in `apps.routes.tool` and `apps.routes.schemas.tool` with those added by cyverse-de/common-swagger-api#31.