### PR TITLE
CORE-11 Migrate schemas and docs for /reference-genomes endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.8-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "2.11.8"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -13,6 +13,9 @@
          :only [AppCategoryListing
                 AppCategoryAppListing
                 AppCommunityGroupNameParam]]
+        [common-swagger-api.schema.apps.reference-genomes
+         :only [ReferenceGenome
+                ReferenceGenomeIdParam]]
         [common-swagger-api.schema.integration-data :only [IntegrationData]]
         [common-swagger-api.schema.ontologies
          :only [OntologyClassIRIParam

--- a/src/apps/routes/reference_genomes.clj
+++ b/src/apps/routes/reference_genomes.clj
@@ -10,14 +10,14 @@
   (GET "/" []
         :query [params ReferenceGenomeListingParams]
         :return schema/ReferenceGenomesList
-        :summary "List Reference Genomes."
-        :description "This endpoint may be used to obtain lists of all available Reference Genomes."
+        :summary schema/ReferenceGenomeListingSummary
+        :description schema/ReferenceGenomeListingDocs
         (ok (list-reference-genomes params)))
 
   (GET "/:reference-genome-id" []
         :path-params [reference-genome-id :- schema/ReferenceGenomeIdParam]
         :query [params SecuredQueryParams]
         :return schema/ReferenceGenome
-        :summary "Get a Reference Genome."
-        :description "This endpoint may be used to obtain a Reference Genome by its UUID."
+        :summary schema/ReferenceGenomeDetailsSummary
+        :description schema/ReferenceGenomeDetailsDocs
         (ok (get-reference-genome reference-genome-id))))

--- a/src/apps/routes/reference_genomes.clj
+++ b/src/apps/routes/reference_genomes.clj
@@ -1,22 +1,23 @@
 (ns apps.routes.reference-genomes
   (:use [common-swagger-api.schema]
         [apps.metadata.reference-genomes :only [get-reference-genome list-reference-genomes]]
-        [apps.routes.params]
+        [apps.routes.params :only [SecuredQueryParams]]
         [apps.routes.schemas.reference-genome]
-        [ring.util.http-response :only [ok]]))
+        [ring.util.http-response :only [ok]])
+  (:require [common-swagger-api.schema.apps.reference-genomes :as schema]))
 
 (defroutes reference-genomes
   (GET "/" []
         :query [params ReferenceGenomeListingParams]
-        :return ReferenceGenomesList
+        :return schema/ReferenceGenomesList
         :summary "List Reference Genomes."
         :description "This endpoint may be used to obtain lists of all available Reference Genomes."
         (ok (list-reference-genomes params)))
 
   (GET "/:reference-genome-id" []
-        :path-params [reference-genome-id :- ReferenceGenomeIdParam]
+        :path-params [reference-genome-id :- schema/ReferenceGenomeIdParam]
         :query [params SecuredQueryParams]
-        :return ReferenceGenome
+        :return schema/ReferenceGenome
         :summary "Get a Reference Genome."
         :description "This endpoint may be used to obtain a Reference Genome by its UUID."
         (ok (get-reference-genome reference-genome-id))))

--- a/src/apps/routes/schemas/reference_genome.clj
+++ b/src/apps/routes/schemas/reference_genome.clj
@@ -2,59 +2,20 @@
   (:use [common-swagger-api.schema :only [->optional-param describe]]
         [apps.routes.params]
         [schema.core :only [defschema optional-key]])
-  (:import [java.util Date UUID]))
-
-(def ReferenceGenomeIdParam (describe UUID "A UUID that is used to identify the Reference Genome"))
+  (:require [common-swagger-api.schema.apps.reference-genomes :as schema]))
 
 (defschema ReferenceGenomeListingParams
   (merge SecuredQueryParams
-    {(optional-key :deleted)
-     (describe Boolean
-       "Whether or not to include Reference Genomes that have been marked as deleted
-        (false by default).")
-
-     (optional-key :created_by)
-     (describe String "Filters the Reference Genome listing by the user that added them.")}))
+         schema/ReferenceGenomeListingParams))
 
 (defschema ReferenceGenomeDeletionParams
   (assoc SecuredQueryParams
     (optional-key :permanent)
     (describe Boolean "If true, completely remove the reference genome from the database.")))
 
-(defschema ReferenceGenome
-  {:id
-   ReferenceGenomeIdParam
-
-   :name
-   (describe String "The Reference Genome's name")
-
-   :path
-   (describe String "The path of the directory containing the Reference Genome")
-
-   (optional-key :deleted)
-   (describe Boolean "Whether the Reference Genome is marked as deleted")
-
-   :created_by
-   (describe String "The username of the user that added the Reference Genome")
-
-   (optional-key :created_on)
-   (describe Date "The date the Reference Genome was added")
-
-   :last_modified_by
-   (describe String "The username of the user that updated the Reference Genome")
-
-   (optional-key :last_modified_on)
-   (describe Date "The date of last modification to the Reference Genome")})
-
-(defschema ReferenceGenomesList
-  {:genomes (describe [ReferenceGenome] "Listing of Reference Genomes.")})
-
 (defschema ReferenceGenomeSetRequest
-  (-> ReferenceGenome
-    (->optional-param :id)))
-
-(defschema ReferenceGenomesSetRequest
-  {:genomes (describe [ReferenceGenomeSetRequest] "Listing of Reference Genomes.")})
+  (-> schema/ReferenceGenome
+      (->optional-param :id)))
 
 (defschema ReferenceGenomeRequest
   (-> ReferenceGenomeSetRequest


### PR DESCRIPTION
This PR will replace the schemas and docs for `/reference-genomes` endpoints with those added by cyverse-de/common-swagger-api#32.