### PR TITLE
CORE-11 Migrate schemas and docs for /admin/apps endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.8"]
+                 [org.cyverse/common-swagger-api "2.11.9-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes.clj
+++ b/src/apps/routes.clj
@@ -9,6 +9,7 @@
         [ring.util.response :only [redirect]])
   (:require [compojure.route :as route]
             [apps.routes.admin :as admin-routes]
+            [apps.routes.admin.apps :as admin-apps-routes]
             [apps.routes.analyses :as analysis-routes]
             [apps.routes.apps :as app-routes]
             [apps.routes.apps.categories :as app-category-routes]
@@ -165,7 +166,7 @@
       metadata-routes/admin-app-metadata)
     (context "/admin/apps" []
       :tags ["admin-apps"]
-      admin-routes/admin-apps)
+      admin-apps-routes/admin-apps)
     (context "/admin/ontologies" []
       :tags ["admin-ontologies"]
       admin-routes/admin-ontologies)

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -16,7 +16,10 @@
         [common-swagger-api.schema.apps.reference-genomes
          :only [ReferenceGenome
                 ReferenceGenomeIdParam]]
-        [common-swagger-api.schema.integration-data :only [IntegrationData]]
+        [common-swagger-api.schema.apps.admin.categories :only [AppCategorizationRequest]]
+        [common-swagger-api.schema.integration-data
+         :only [IntegrationData
+                IntegrationDataIdPathParam]]
         [common-swagger-api.schema.ontologies
          :only [OntologyClassIRIParam
                 OntologyHierarchy
@@ -31,9 +34,7 @@
                 delete-reference-genome
                 update-reference-genome]]
         [apps.metadata.tool-requests]
-        [apps.routes.params
-         :only [IntegrationDataIdPathParam
-                SecuredQueryParams]]
+        [apps.routes.params :only [SecuredQueryParams]]
         [apps.routes.schemas.analysis.listing]
         [apps.routes.schemas.app]
         [apps.routes.schemas.app.category]
@@ -47,7 +48,8 @@
             [apps.service.apps.de.admin :as admin]
             [apps.service.apps.de.listings :as listings]
             [apps.service.workspace :as workspace]
-            [apps.util.config :as config]))
+            [apps.util.config :as config]
+            [common-swagger-api.schema.apps.admin.apps :as schema]))
 
 (defroutes admin-tool-requests
   (GET "/" []
@@ -119,7 +121,7 @@
   (GET "/" []
     :query [params AdminAppSearchParams]
     :summary "List Apps"
-    :return AdminAppListing
+    :return schema/AdminAppListing
     :description
     (str
 "This service allows admins to list all public apps, including apps listed under the `Trash` category:
@@ -132,7 +134,7 @@
 (get-endpoint-delegate-block
   "metadata"
   "POST /ontologies/{ontology-version}/filter-targets"))
-    (ok (coerce! AdminAppListing
+    (ok (coerce! schema/AdminAppListing
                  (apps/admin-search-apps current-user params))))
 
   (POST "/" []
@@ -165,8 +167,8 @@
 
     (PATCH "/" []
       :query [params SecuredQueryParams]
-      :body [body (describe AdminAppPatchRequest "The App to update.")]
-      :return AdminAppDetails
+      :body [body (describe schema/AdminAppPatchRequest "The App to update.")]
+      :return schema/AdminAppDetails
       :summary "Update App Details and Labels"
       :description (str
 "This service is capable of updating high-level information of an App,
@@ -188,12 +190,12 @@
   "metadata"
   "POST /ontologies/{ontology-version}/filter")
 "Please see the metadata service documentation for information about the `hierarchies` response field.")
-      (ok (coerce! AdminAppDetails
+      (ok (coerce! schema/AdminAppDetails
                    (apps/admin-update-app current-user system-id (assoc body :id app-id)))))
 
     (GET "/details" []
       :query [params SecuredQueryParams]
-      :return AdminAppDetails
+      :return schema/AdminAppDetails
       :summary "Get App Details"
       :description (str
 "This service allows administrative users to view detailed informaiton about private apps."
@@ -201,7 +203,7 @@
   "metadata"
   "POST /ontologies/{ontology-version}/filter")
 "Please see the metadata service documentation for information about the `hierarchies` response field.")
-      (ok (coerce! AdminAppDetails
+      (ok (coerce! schema/AdminAppDetails
                    (apps/admin-get-app-details current-user system-id app-id))))
 
     (PATCH "/documentation" []
@@ -284,13 +286,13 @@
   (GET "/:community-id/apps" []
        :path-params [community-id :- AppCommunityGroupNameParam]
        :query [params AdminAppListingPagingParams]
-       :return AdminAppListing
+       :return schema/AdminAppListing
        :summary "List Apps in a Community"
        :description (str "Lists all of the apps under an App Community that are visible to an admin."
                          (get-endpoint-delegate-block
                            "metadata"
                            "POST /avus/filter-targets"))
-       (ok (coerce! AdminAppListing (apps/admin-list-apps-in-community current-user community-id params)))))
+       (ok (coerce! schema/AdminAppListing (apps/admin-list-apps-in-community current-user community-id params)))))
 
 (defroutes admin-ontologies
 
@@ -346,7 +348,7 @@
     :path-params [ontology-version :- OntologyVersionParam
                   root-iri :- OntologyClassIRIParam]
     :query [{:keys [attr] :as params} AdminOntologyAppListingPagingParams]
-    :return AdminAppListing
+    :return schema/AdminAppListing
     :summary "List Apps in a Category"
     :description (str
 "Lists all of the apps under an app category hierarchy, for the given `ontology-version`,
@@ -354,14 +356,14 @@
 (get-endpoint-delegate-block
   "metadata"
   "POST /ontologies/{ontology-version}/{root-iri}/filter-targets"))
-    (ok (coerce! AdminAppListing
+    (ok (coerce! schema/AdminAppListing
                  (apps/admin-list-apps-under-hierarchy current-user ontology-version root-iri attr params))))
 
   (GET "/:ontology-version/:root-iri/unclassified" [root-iri]
     :path-params [ontology-version :- OntologyVersionParam
                   root-iri :- OntologyClassIRIParam]
     :query [{:keys [attr] :as params} AdminOntologyAppListingPagingParams]
-    :return AdminAppListing
+    :return schema/AdminAppListing
     :summary "List Unclassified Apps"
     :description (str
 "Lists all of the apps that are visible to the user that are not under the given `root-iri`, or any of
@@ -369,7 +371,7 @@
 (get-endpoint-delegate-block
   "metadata"
   "POST /ontologies/{ontology-version}/{root-iri}/filter-unclassified"))
-    (ok (coerce! AdminAppListing
+    (ok (coerce! schema/AdminAppListing
                  (listings/get-unclassified-app-listing current-user ontology-version root-iri attr params true)))))
 
 (defroutes reference-genomes

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -4,15 +4,6 @@
         [common-swagger-api.schema.analyses.listing :only [ExternalId]]
         [common-swagger-api.schema.apps
          :only [AppCategoryIdPathParam
-                AppDeleteSummary
-                AppDeletionRequest
-                AppDetailsSummary
-                AppDocumentation
-                AppDocumentationAddSummary
-                AppDocumentationRequest
-                AppDocumentationUpdateSummary
-                AppListingSummary
-                StringAppIdParam
                 SystemId]]
         [common-swagger-api.schema.apps.categories
          :only [AppCategoryListing
@@ -21,13 +12,6 @@
         [common-swagger-api.schema.apps.reference-genomes
          :only [ReferenceGenome
                 ReferenceGenomeIdParam]]
-        [common-swagger-api.schema.apps.admin.categories
-         :only [AppCategorizationDocs
-                AppCategorizationRequest
-                AppCategorizationSummary]]
-        [common-swagger-api.schema.integration-data
-         :only [IntegrationData
-                IntegrationDataIdPathParam]]
         [common-swagger-api.schema.ontologies
          :only [OntologyClassIRIParam
                 OntologyHierarchy
@@ -124,82 +108,6 @@
       :summary "Look Up an Analysis by External ID"
       :description "This endpoint is used to retrieve information about an analysis with a given external identifier."
       (ok (apps/admin-list-jobs-with-external-ids current-user [external-id])))))
-
-(defroutes admin-apps
-  (GET "/" []
-    :query [params AdminAppSearchParams]
-    :summary AppListingSummary
-    :return schema/AdminAppListing
-    :description schema/AppListingDocs
-    (ok (coerce! schema/AdminAppListing
-                 (apps/admin-search-apps current-user params))))
-
-  (POST "/" []
-    :query [params SecuredQueryParams]
-    :body [body AppCategorizationRequest]
-    :summary AppCategorizationSummary
-    :description AppCategorizationDocs
-    (ok (apps/categorize-apps current-user body)))
-
-  (POST "/shredder" []
-    :query [params SecuredQueryParams]
-    :body [body AppDeletionRequest]
-    :summary schema/AppShredderSummary
-    :description schema/AppShredderDocs
-    (ok (apps/permanently-delete-apps current-user body)))
-
-  (context "/:system-id/:app-id" []
-    :path-params [system-id :- SystemId
-                  app-id    :- StringAppIdParam]
-
-    (DELETE "/" []
-      :query [params SecuredQueryParams]
-      :summary AppDeleteSummary
-      :description schema/AppDeleteDocs
-      (ok (apps/admin-delete-app current-user system-id app-id)))
-
-    (PATCH "/" []
-      :query [params SecuredQueryParams]
-      :body [body schema/AdminAppPatchRequest]
-      :return schema/AdminAppDetails
-      :summary schema/AdminAppPatchSummary
-      :description-file "docs/apps/admin/app-label-update.md"
-      (ok (coerce! schema/AdminAppDetails
-                   (apps/admin-update-app current-user system-id (assoc body :id app-id)))))
-
-    (GET "/details" []
-      :query [params SecuredQueryParams]
-      :return schema/AdminAppDetails
-      :summary AppDetailsSummary
-      :description schema/AppDetailsDocs
-      (ok (coerce! schema/AdminAppDetails
-                   (apps/admin-get-app-details current-user system-id app-id))))
-
-    (PATCH "/documentation" []
-      :query [params SecuredQueryParams]
-      :body [body AppDocumentationRequest]
-      :return AppDocumentation
-      :summary AppDocumentationUpdateSummary
-      :description schema/AppDocumentationUpdateDocs
-      (ok (coerce! AppDocumentation
-                   (apps/admin-edit-app-docs current-user system-id app-id body))))
-
-    (POST "/documentation" []
-      :query [params SecuredQueryParams]
-      :body [body AppDocumentationRequest]
-      :return AppDocumentation
-      :summary AppDocumentationAddSummary
-      :description schema/AppDocumentationAddDocs
-      (ok (coerce! AppDocumentation
-                   (apps/admin-add-app-docs current-user system-id app-id body))))
-
-    (PUT "/integration-data/:integration-data-id" []
-      :path-params [integration-data-id :- IntegrationDataIdPathParam]
-      :query [params SecuredQueryParams]
-      :return IntegrationData
-      :summary schema/AppIntegrationDataUpdateSummary
-      :description schema/AppIntegrationDataUpdateDocs
-      (ok (apps/update-app-integration-data current-user system-id app-id integration-data-id)))))
 
 (defroutes admin-categories
   (GET "/" []

--- a/src/apps/routes/admin/apps.clj
+++ b/src/apps/routes/admin/apps.clj
@@ -1,0 +1,94 @@
+(ns apps.routes.admin.apps
+  (:use [apps.routes.params :only [SecuredQueryParams]]
+        [apps.routes.schemas.app :only [AdminAppSearchParams]]
+        [apps.user :only [current-user]]
+        [apps.util.coercions :only [coerce!]]
+        [common-swagger-api.schema]
+        [common-swagger-api.schema.apps.admin.categories
+         :only [AppCategorizationDocs
+                AppCategorizationRequest
+                AppCategorizationSummary]]
+        [common-swagger-api.schema.integration-data
+         :only [IntegrationData
+                IntegrationDataIdPathParam]]
+        [ring.util.http-response :only [ok]])
+  (:require [apps.service.apps :as apps]
+            [common-swagger-api.routes]                     ;; for :description-file
+            [common-swagger-api.schema.apps :as apps-schema]
+            [common-swagger-api.schema.apps.admin.apps :as schema]))
+
+(defroutes admin-apps
+  (GET "/" []
+       :query [params AdminAppSearchParams]
+       :summary apps-schema/AppListingSummary
+       :return schema/AdminAppListing
+       :description schema/AppListingDocs
+       (ok (coerce! schema/AdminAppListing
+                    (apps/admin-search-apps current-user params))))
+
+  (POST "/" []
+        :query [params SecuredQueryParams]
+        :body [body AppCategorizationRequest]
+        :summary AppCategorizationSummary
+        :description AppCategorizationDocs
+        (ok (apps/categorize-apps current-user body)))
+
+  (POST "/shredder" []
+        :query [params SecuredQueryParams]
+        :body [body apps-schema/AppDeletionRequest]
+        :summary schema/AppShredderSummary
+        :description schema/AppShredderDocs
+        (ok (apps/permanently-delete-apps current-user body)))
+
+  (context "/:system-id/:app-id" []
+    :path-params [system-id :- apps-schema/SystemId
+                  app-id :- apps-schema/StringAppIdParam]
+
+    (DELETE "/" []
+            :query [params SecuredQueryParams]
+            :summary apps-schema/AppDeleteSummary
+            :description schema/AppDeleteDocs
+            (ok (apps/admin-delete-app current-user system-id app-id)))
+
+    (PATCH "/" []
+           :query [params SecuredQueryParams]
+           :body [body schema/AdminAppPatchRequest]
+           :return schema/AdminAppDetails
+           :summary schema/AdminAppPatchSummary
+           :description-file "docs/apps/admin/app-label-update.md"
+           (ok (coerce! schema/AdminAppDetails
+                        (apps/admin-update-app current-user system-id (assoc body :id app-id)))))
+
+    (GET "/details" []
+         :query [params SecuredQueryParams]
+         :return schema/AdminAppDetails
+         :summary apps-schema/AppDetailsSummary
+         :description schema/AppDetailsDocs
+         (ok (coerce! schema/AdminAppDetails
+                      (apps/admin-get-app-details current-user system-id app-id))))
+
+    (PATCH "/documentation" []
+           :query [params SecuredQueryParams]
+           :body [body apps-schema/AppDocumentationRequest]
+           :return apps-schema/AppDocumentation
+           :summary apps-schema/AppDocumentationUpdateSummary
+           :description schema/AppDocumentationUpdateDocs
+           (ok (coerce! apps-schema/AppDocumentation
+                        (apps/admin-edit-app-docs current-user system-id app-id body))))
+
+    (POST "/documentation" []
+          :query [params SecuredQueryParams]
+          :body [body apps-schema/AppDocumentationRequest]
+          :return apps-schema/AppDocumentation
+          :summary apps-schema/AppDocumentationAddSummary
+          :description schema/AppDocumentationAddDocs
+          (ok (coerce! apps-schema/AppDocumentation
+                       (apps/admin-add-app-docs current-user system-id app-id body))))
+
+    (PUT "/integration-data/:integration-data-id" []
+         :path-params [integration-data-id :- IntegrationDataIdPathParam]
+         :query [params SecuredQueryParams]
+         :return IntegrationData
+         :summary schema/AppIntegrationDataUpdateSummary
+         :description schema/AppIntegrationDataUpdateDocs
+         (ok (apps/update-app-integration-data current-user system-id app-id integration-data-id)))))

--- a/src/apps/routes/analyses.clj
+++ b/src/apps/routes/analyses.clj
@@ -6,7 +6,6 @@
                 SecuredQueryParamsEmailRequired]]
         [apps.routes.schemas.analysis]
         [apps.routes.schemas.analysis.listing]
-        [apps.routes.schemas.app]
         [apps.user :only [current-user]]
         [apps.util.coercions :only [coerce!]]
         [common-swagger-api.schema]

--- a/src/apps/routes/integration_data.clj
+++ b/src/apps/routes/integration_data.clj
@@ -1,6 +1,6 @@
 (ns apps.routes.integration-data
   (:use [common-swagger-api.schema]
-        [apps.routes.params :only [IntegrationDataIdPathParam IntegrationDataSearchParams SecuredQueryParams]]
+        [apps.routes.params :only [IntegrationDataSearchParams SecuredQueryParams]]
         [apps.user :only [current-user]]
         [ring.util.http-response :only [ok]])
   (:require [common-swagger-api.schema.integration-data :as schema]
@@ -25,7 +25,7 @@
     (ok (integration-data/add-integration-data current-user body)))
 
   (GET "/:integration-data-id" []
-    :path-params [integration-data-id :- IntegrationDataIdPathParam]
+    :path-params [integration-data-id :- schema/IntegrationDataIdPathParam]
     :query [params SecuredQueryParams]
     :summary "Get an Integration Data Record"
     :return schema/IntegrationData
@@ -33,7 +33,7 @@
     (ok (integration-data/get-integration-data current-user integration-data-id)))
 
   (PUT "/:integration-data-id" []
-    :path-params [integration-data-id :- IntegrationDataIdPathParam]
+    :path-params [integration-data-id :- schema/IntegrationDataIdPathParam]
     :query [params SecuredQueryParams]
     :summary "Update an Integration Data Record"
     :body [body (describe schema/IntegrationDataUpdate "The updated integration data information.")]
@@ -42,7 +42,7 @@
     (ok (integration-data/update-integration-data current-user integration-data-id body)))
 
   (DELETE "/:integration-data-id" []
-    :path-params [integration-data-id :- IntegrationDataIdPathParam]
+    :path-params [integration-data-id :- schema/IntegrationDataIdPathParam]
     :query [params SecuredQueryParams]
     :summary "Delete an Integration Data Record"
     :description "This service allows administrators to delete individual integration data records."

--- a/src/apps/routes/params.clj
+++ b/src/apps/routes/params.clj
@@ -14,8 +14,6 @@
             [schema.core :as s])
   (:import [java.util UUID]))
 
-(def IntegrationDataIdPathParam (describe UUID "A UUID that is used to identify the integration data record"))
-
 (def ApiName (describe String "The name of the external API"))
 
 (def SubmissionIdPathParam (describe UUID "The Submission UUID"))

--- a/src/apps/routes/schemas/app.clj
+++ b/src/apps/routes/schemas/app.clj
@@ -1,93 +1,22 @@
 (ns apps.routes.schemas.app
   (:use [apps.routes.params :only [SecuredQueryParams SecuredQueryParamsEmailRequired]]
-        [common-swagger-api.schema
-         :only [->optional-param
-                optional-key->keyword
-                describe
-                PagingParams
-                SortFieldDocs
-                SortFieldOptionalKey]]
-        [common-swagger-api.schema.apps
-         :only [AppBase
-                AppDeletedParam
-                AppDetails
-                AppDisabledParam
-                AppDocUrlParam
-                AppListing
-                AppListingDetail
-                AppListingJobStats
-                AppListingJobStatsDocs
-                AppListingValidSortFields
-                AppGroup
-                AppReferencesParam
-                AppSearchValidSortFields
-                GroupListDocs
-                OptionalGroupsKey]]
-        [schema.core :only [defschema enum optional-key]])
+        [schema.core :only [defschema]])
   (:require [clojure.set :as sets]
-            [common-swagger-api.schema.apps :as app-schema])
-  (:import [java.util Date]))
-
-(defschema AdminAppListingJobStats
-  (merge AppListingJobStats
-         {:job_count
-          (describe Long "The number of times this app has run")
-
-          :job_count_failed
-          (describe Long "The number of times this app has run to `Failed` status")
-
-          (optional-key :last_used)
-          (describe Date "The start date this app was last run")}))
-
-(defschema AdminAppListingDetail
-  (merge AppListingDetail
-         {(optional-key :job_stats)
-          (describe AdminAppListingJobStats AppListingJobStatsDocs)}))
-
-(defschema AdminAppListing
-  (merge AppListing
-         {:apps (describe [AdminAppListingDetail] "A listing of App details")}))
-
-(def AdminAppListingJobStatsKeys (->> AdminAppListingJobStats
-                                      keys
-                                      (map optional-key->keyword)
-                                      set))
+            [common-swagger-api.schema.apps :as app-schema]
+            [common-swagger-api.schema.apps.admin.apps :as admin-schema]))
 
 (def AdminAppListingValidSortFields
-  (sets/union AppListingValidSortFields AdminAppListingJobStatsKeys))
+  (sets/union app-schema/AppListingValidSortFields
+              admin-schema/AdminAppListingJobStatsKeys))
 
 (defschema AppListingPagingParams
   (merge SecuredQueryParamsEmailRequired
          app-schema/AppListingPagingParams))
 
-(def AdminAppSearchValidSortFields
-  (sets/union AppSearchValidSortFields AdminAppListingJobStatsKeys))
-
 (defschema AppSearchParams
-  (merge SecuredQueryParams app-schema/AppSearchParams))
-
-(def AppSubsets (enum :public :private :all))
+  (merge SecuredQueryParams
+         app-schema/AppSearchParams))
 
 (defschema AdminAppSearchParams
-  (merge AppSearchParams
-         {SortFieldOptionalKey
-          (describe (apply enum AdminAppSearchValidSortFields) SortFieldDocs)
-
-          (optional-key :app-subset)
-          (describe AppSubsets "The subset of apps to search." :default :public)}))
-
-(defschema AdminAppDetails
-  (merge AppDetails
-         {(optional-key :job_stats)
-          (describe AdminAppListingJobStats AppListingJobStatsDocs)}))
-
-(defschema AdminAppPatchRequest
-  (-> AppBase
-    (->optional-param :id)
-    (->optional-param :name)
-    (->optional-param :description)
-    (assoc (optional-key :wiki_url)   AppDocUrlParam
-           (optional-key :references) AppReferencesParam
-           (optional-key :deleted)    AppDeletedParam
-           (optional-key :disabled)   AppDisabledParam
-           OptionalGroupsKey          (describe [AppGroup] GroupListDocs))))
+  (merge SecuredQueryParams
+         admin-schema/AdminAppSearchParams))

--- a/src/apps/routes/schemas/app/category.clj
+++ b/src/apps/routes/schemas/app/category.clj
@@ -5,7 +5,6 @@
                 NonBlankString
                 SortFieldDocs
                 SortFieldOptionalKey]]
-        [common-swagger-api.schema.apps :only [SystemId]]
         [apps.routes.params
          :only [SecuredQueryParams
                 SecuredQueryParamsEmailRequired]]
@@ -38,17 +37,6 @@
 
 (defschema AppCategorySearchResults
   {:categories (describe [AppCategoryInfo] "The list of matching app categories.")})
-
-(defschema AppCategoryIdList
-  {:category_ids (describe [categories-schema/AppCategoryId] "A List of App Category identifiers")})
-
-(defschema AppCategorization
-  (merge AppCategoryIdList
-         {:system_id SystemId
-          :app_id    (describe String "The ID of the App to be Categorized")}))
-
-(defschema AppCategorizationRequest
-  {:categories (describe [AppCategorization] "Apps and the Categories they should be listed under")})
 
 (defschema AppCategoryRequest
   {:name      categories-schema/AppCategoryNameParam

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -1,18 +1,20 @@
 (ns apps.routes.tools
   (:use [common-swagger-api.schema]
         [common-swagger-api.schema.apps :only [AppListing ToolAppListingResponses]]
+        [common-swagger-api.schema.apps.admin.apps :only [AdminAppListing]]
         [common-swagger-api.schema.containers
          :only [DataContainer
                 Device
                 Image
                 Volume
                 VolumesFrom]]
-        [common-swagger-api.schema.integration-data :only [IntegrationData]]
+        [common-swagger-api.schema.integration-data
+         :only [IntegrationData
+                IntegrationDataIdPathParam]]
         [apps.constants :only [de-system-id]]
         [apps.containers]
         [apps.routes.params]
         [apps.routes.schemas.containers]
-        [apps.routes.schemas.app :only [AdminAppListing]]
         [apps.routes.schemas.tool]
         [apps.tools
          :only [admin-add-tools

--- a/src/apps/service/util.clj
+++ b/src/apps/service/util.clj
@@ -1,7 +1,7 @@
 (ns apps.service.util
-  (:use [apps.routes.schemas.app :only [AdminAppListingJobStatsKeys]]
-        [apps.transformers :only [param->long]]
-        [apps.util.conversions :only [remove-nil-vals]])
+  (:use [apps.transformers :only [param->long]]
+        [apps.util.conversions :only [remove-nil-vals]]
+        [common-swagger-api.schema.apps.admin.apps :only [AdminAppListingJobStatsKeys]])
   (:require [clojure.string :as string]
             [clojure-commons.exception-util :as cxu]
             [kameleon.uuids :as uuids])


### PR DESCRIPTION
This PR will replace the schemas and docs for `/admin/apps` endpoints with those added by cyverse-de/common-swagger-api#33.

It will also refactor the `/admin/apps` endpoints into a new `apps.routes.admin.apps` namespace.