### PR TITLE
CORE-63: Add handling for htcondor extra requirements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.9"]
+                 [org.cyverse/common-swagger-api "2.11.10-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -15,6 +15,14 @@
   [app-id]
   (first (select app_listing (where {:id app-id}))))
 
+(defn get-app-extra-info
+  [app-id]
+  (when-let [htcondor (first
+                   (select apps_htcondor_extra
+                           (fields [:extra_requirements])
+                           (where {:apps_id app-id})))]
+    {:htcondor htcondor}))
+
 (defn- get-all-group-ids-subselect
   "Gets a subselect that fetches the app_categories and its subgroup IDs with
    the stored procedure app_category_hierarchy_ids."

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -405,6 +405,12 @@
    (delete app_references (where {:app_id app-id}))
    (dorun (map (partial add-app-reference app-id) references))))
 
+(defn set-htcondor-extra
+  [app-id extra-requirements]
+  (transaction
+    (delete apps_htcondor_extra (where {:apps_id app-id}))
+    (insert apps_htcondor_extra (values {:apps_id app-id, :extra_requirements extra-requirements}))))
+
 (defn- get-job-type-id-for-system* [system-id]
   (:id (first (select :job_types (fields :id) (where {:system_id system-id})))))
 

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -17,6 +17,7 @@
             [apps.persistence.app-metadata.delete :as delete]
             [apps.persistence.app-metadata.relabel :as relabel]
             [clojure.set :as set]
+            [clojure.string :as string]
             [clojure-commons.exception-util :as cxu]
             [korma.core :as sql]))
 
@@ -409,7 +410,8 @@
   [app-id extra-requirements]
   (transaction
     (delete apps_htcondor_extra (where {:apps_id app-id}))
-    (insert apps_htcondor_extra (values {:apps_id app-id, :extra_requirements extra-requirements}))))
+    (if-not (or (nil? extra-requirements) (empty? (string/trim extra-requirements)))
+      (insert apps_htcondor_extra (values {:apps_id app-id, :extra_requirements extra-requirements})))))
 
 (defn- get-job-type-id-for-system* [system-id]
   (:id (first (select :job_types (fields :id) (where {:system_id system-id})))))

--- a/src/apps/persistence/entities.clj
+++ b/src/apps/persistence/entities.clj
@@ -7,7 +7,7 @@
          parameter_values parameter_types value_type validation_rules validation_rule_arguments
          rule_type rule_subtype app_category_listing app_listing tool_listing ratings collaborators
          genome_reference created_by last_modified_by data_source tool_types
-         tool_request_status_codes tool_architectures tool_requests
+         tool_request_status_codes tool_architectures tool_requests apps_htcondor_extra
          tool_request_statuses container-images container-settings container-devices container-volumes container-volumes-from)
 
 ;; Users who have logged into the DE.  Multiple entities are associated with
@@ -49,6 +49,9 @@
 
 ;; References associated with an app.
 (defentity app_references)
+
+;; Extra info for HTCondor
+(defentity apps_htcondor_extra)
 
 ;; Information about who integrated an app or a deployed component.
 (defentity integration_data

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -488,6 +488,12 @@
     (if admin? (jobs-db/get-job-stats app-id params)
                (jobs-db/get-public-job-stats app-id params))))
 
+(defn- format-app-extra-info
+  [app-id admin?]
+  (if admin?
+    (get-app-extra-info app-id)
+    nil))
+
 (defn- format-tool-image [{:keys [image_name image_tag image_url deprecated]}]
   (remove-nil-vals
     {:name       image_name
@@ -511,6 +517,7 @@
              :references           (map :reference_text (:app_references details))
              :tools                (map format-app-tool tools)
              :job_stats            (format-app-details-job-stats (str app-id) nil admin?)
+             :extra                (format-app-extra-info app-id admin?)
              :categories           (get-groups-for-app app-id)
              :suggested_categories (get-suggested-groups-for-app app-id)
              :system_id            c/system-id)


### PR DESCRIPTION
This allows the field to be added in the administrative app PATCH endpoint, and returns it in the administrative app details endpoint.

Depends on cyverse-de/common-swagger-api#36 and cyverse-de/common-swagger-api#37 but the relevant snapshot version was already what was in project.clj of this project, so the changes are only to the functionality of the endpoints themselves.

It may also be useful to add documentation information into the app details endpoint, as we discussed at one point. That hasn't happened yet, but could get added to this PR or go into a new one.

We'll also need to pull the new common-swagger-api version into terrain, but I don't see much need to make a PR for just that :)