### PR TITLE
CORE-11 Migrate schemas and docs for /admin/tools endpoints

### DIFF
--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -1,17 +1,9 @@
 (ns apps.routes.schemas.tool
   (:use [apps.routes.params :only [SecuredQueryParams]]
-        [clojure-commons.error-codes]
-        [common-swagger-api.schema
-         :only [->optional-param
-                describe
-                ErrorResponse
-                PagingParams]]
-        [schema.core :only [defschema enum optional-key]])
-  (:require [common-swagger-api.schema.tools :as schema])
-  (:import [java.util UUID]))
-
-(defschema ToolIdsList
-  {:tool_ids (describe [UUID] "A List of Tool IDs")})
+        [common-swagger-api.schema :only [->optional-param describe]]
+        [schema.core :only [defschema optional-key]])
+  (:require [common-swagger-api.schema.tools :as schema]
+            [common-swagger-api.schema.tools.admin :as admin-schema]))
 
 (defschema PrivateToolDeleteParams
   (merge SecuredQueryParams
@@ -19,19 +11,7 @@
 
 (defschema ToolUpdateParams
   (merge SecuredQueryParams
-    {(optional-key :overwrite-public)
-     (describe Boolean "Flag to force container settings updates of public tools.")}))
-
-(defschema ToolsImportRequest
-  {:tools (describe [schema/ToolImportRequest] "zero or more Tool definitions")})
-
-(defschema ToolUpdateRequest
-  (-> schema/ToolImportRequest
-      (->optional-param :name)
-      (->optional-param :version)
-      (->optional-param :type)
-      (->optional-param :implementation)
-      (->optional-param :container)))
+         admin-schema/ToolUpdateParams))
 
 (defschema ToolRequestStatusUpdate
   (dissoc schema/ToolRequestStatus :updated_by :status_date))

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -42,9 +42,10 @@
             [apps.tools.permissions :as tool-permissions]
             [apps.tools.sharing :as tool-sharing]
             [common-swagger-api.routes]                     ;; for :description-file
-            [common-swagger-api.schema.containers :as containers-schema]
             [common-swagger-api.schema.apps.permission :as perm-schema]
+            [common-swagger-api.schema.containers :as containers-schema]
             [common-swagger-api.schema.tools :as schema]
+            [common-swagger-api.schema.tools.admin :as admin-schema]
             [compojure.api.middleware :as middleware]))
 
 (def entrypoint-warning
@@ -255,9 +256,9 @@
   (POST "/" []
         :query [params SecuredQueryParams]
         :middleware [schema/coerce-tool-list-import-request]
-        :body [body (describe ToolsImportRequest "The Tools to import.")]
+        :body [body (describe admin-schema/ToolsImportRequest "The Tools to import.")]
         :responses (merge CommonResponses
-                          {200 {:schema      ToolIdsList
+                          {200 {:schema      admin-schema/ToolIdsList
                                 :description "A list of the new Tool IDs."}
                            400 {:schema      ErrorResponseExists
                                 :description "A Tool with the given `name` already exists."}})
@@ -297,7 +298,7 @@
          :path-params [tool-id :- schema/ToolIdParam]
          :query [{:keys [user overwrite-public]} ToolUpdateParams]
          :middleware [schema/coerce-tool-import-requests]
-         :body [body (describe ToolUpdateRequest "The Tool to update.")]
+         :body [body (describe admin-schema/ToolUpdateRequest "The Tool to update.")]
          :responses (merge CommonResponses
                            {200 {:schema      schema/ToolDetails
                                  :description "The Tool details."}
@@ -524,7 +525,7 @@ included in it. Any existing settings not included in the request's `container` 
         :path-params [tool-id :- schema/ToolIdParam]
         :query [params SecuredQueryParams]
         :middleware [schema/coerce-tool-import-requests]
-        :body [body (describe ToolUpdateRequest "The Tool to update.")]
+        :body [body (describe admin-schema/ToolUpdateRequest "The Tool to update.")]
         :responses (merge CommonResponses
                           {200 {:schema      schema/ToolDetails
                                 :description "The Tool details."}


### PR DESCRIPTION
This PR will replace schemas and docs for `/admin/tools` endpoints with those added by cyverse-de/common-swagger-api#39.