### PR TITLE
CORE-11 Migrate schemas and docs for /admin/tool-requests endpoints

### DIFF
--- a/src/apps/routes.clj
+++ b/src/apps/routes.clj
@@ -11,6 +11,7 @@
             [apps.routes.admin :as admin-routes]
             [apps.routes.admin.apps :as admin-apps-routes]
             [apps.routes.admin.reference-genomes :as admin-reference-genomes-routes]
+            [apps.routes.admin.tool-requests :as admin-tool-request-routes]
             [apps.routes.analyses :as analysis-routes]
             [apps.routes.apps :as app-routes]
             [apps.routes.apps.categories :as app-category-routes]
@@ -185,7 +186,7 @@
       tool-routes/admin-tools)
     (context "/admin/tool-requests" []
       :tags ["admin-tool-requests"]
-      admin-routes/admin-tool-requests)
+      admin-tool-request-routes/admin-tool-requests)
     (context "/admin/oauth" []
       :tags ["admin-oauth"]
       oauth-routes/admin-oauth)

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -33,7 +33,8 @@
             [apps.service.apps.de.listings :as listings]
             [apps.service.workspace :as workspace]
             [apps.util.config :as config]
-            [common-swagger-api.schema.apps.admin.apps :as schema]))
+            [common-swagger-api.schema.apps.admin.apps :as schema]
+            [common-swagger-api.schema.tools.admin :as tools-admin-schema]))
 
 (defroutes admin-tool-requests
   (GET "/" []
@@ -74,7 +75,7 @@
   (POST "/:request-id/status" []
     :path-params [request-id :- ToolRequestIdParam]
     :query [params SecuredQueryParams]
-    :body [body (describe ToolRequestStatusUpdate "A Tool Request status update.")]
+    :body [body (describe tools-admin-schema/ToolRequestStatusUpdate "A Tool Request status update.")]
     :return ToolRequestDetails
     :summary "Update the Status of a Tool Request"
     :description "This endpoint is used by Discovery Environment administrators to update the status

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -13,18 +13,10 @@
          :only [OntologyClassIRIParam
                 OntologyHierarchy
                 OntologyVersionParam]]
-        [common-swagger-api.schema.tools
-         :only [ToolRequestStatusCodeId
-                ToolRequestDetails
-                ToolRequestIdParam
-                ToolRequestListing
-                ToolInstallRequestListingSummary]]
-        [apps.metadata.tool-requests]
         [apps.routes.params :only [SecuredQueryParams]]
         [apps.routes.schemas.analysis.listing]
         [apps.routes.schemas.app]
         [apps.routes.schemas.app.category]
-        [apps.routes.schemas.tool]
         [apps.routes.schemas.workspace]
         [apps.user :only [current-user]]
         [apps.util.coercions :only [coerce!]]
@@ -33,50 +25,7 @@
             [apps.service.apps.de.admin :as admin]
             [apps.service.apps.de.listings :as listings]
             [apps.service.workspace :as workspace]
-            [apps.util.config :as config]
-            [common-swagger-api.schema.apps.admin.apps :as schema]
-            [common-swagger-api.schema.tools.admin :as tools-admin-schema]))
-
-(defroutes admin-tool-requests
-  (GET "/" []
-    :query [params ToolRequestListingParams]
-    :return ToolRequestListing
-    :summary ToolInstallRequestListingSummary
-    :description tools-admin-schema/ToolInstallRequestListingDocs
-    (ok (list-tool-requests params)))
-
-  (DELETE "/status-codes/:status-code-id" []
-    :path-params [status-code-id :- ToolRequestStatusCodeId]
-    :query [params SecuredQueryParams]
-    :summary tools-admin-schema/ToolInstallRequestStatusCodeDeleteSummary
-    :description tools-admin-schema/ToolInstallRequestStatusCodeDeleteDocs
-    (delete-tool-request-status-code status-code-id)
-    (ok))
-
-  (DELETE "/:request-id" []
-    :path-params [request-id :- ToolRequestIdParam]
-    :query [params SecuredQueryParams]
-    :summary tools-admin-schema/ToolInstallRequestDeleteSummary
-    :description tools-admin-schema/ToolInstallRequestDeleteDocs
-    (delete-tool-request request-id)
-    (ok))
-
-  (GET "/:request-id" []
-    :path-params [request-id :- ToolRequestIdParam]
-    :query [params SecuredQueryParams]
-    :return ToolRequestDetails
-    :summary tools-admin-schema/ToolInstallRequestDetailsSummary
-    :description tools-admin-schema/ToolInstallRequestDetailsDocs
-    (ok (get-tool-request request-id)))
-
-  (POST "/:request-id/status" []
-    :path-params [request-id :- ToolRequestIdParam]
-    :query [params SecuredQueryParams]
-    :body [body tools-admin-schema/ToolRequestStatusUpdate]
-    :return ToolRequestDetails
-    :summary tools-admin-schema/ToolInstallRequestStatusUpdateSummary
-    :description tools-admin-schema/ToolInstallRequestStatusUpdateDocs
-    (ok (update-tool-request request-id (config/uid-domain) current-user body))))
+            [common-swagger-api.schema.apps.admin.apps :as schema]))
 
 (defroutes admin-analyses
   (context "/by-external-id" []

--- a/src/apps/routes/admin.clj
+++ b/src/apps/routes/admin.clj
@@ -17,7 +17,8 @@
          :only [ToolRequestStatusCodeId
                 ToolRequestDetails
                 ToolRequestIdParam
-                ToolRequestListing]]
+                ToolRequestListing
+                ToolInstallRequestListingSummary]]
         [apps.metadata.tool-requests]
         [apps.routes.params :only [SecuredQueryParams]]
         [apps.routes.schemas.analysis.listing]
@@ -40,26 +41,23 @@
   (GET "/" []
     :query [params ToolRequestListingParams]
     :return ToolRequestListing
-    :summary "List Tool Requests"
-    :description "This endpoint lists high level details about tool requests that have been submitted.
-    Administrators may use this endpoint to track tool requests for all users."
+    :summary ToolInstallRequestListingSummary
+    :description tools-admin-schema/ToolInstallRequestListingDocs
     (ok (list-tool-requests params)))
 
   (DELETE "/status-codes/:status-code-id" []
     :path-params [status-code-id :- ToolRequestStatusCodeId]
     :query [params SecuredQueryParams]
-    :summary "Delete a Tool Request Status Code"
-    :description "This service allows administrators to delete a tool request status code provided that
-    the status code isn't in use in a tool request."
+    :summary tools-admin-schema/ToolInstallRequestStatusCodeDeleteSummary
+    :description tools-admin-schema/ToolInstallRequestStatusCodeDeleteDocs
     (delete-tool-request-status-code status-code-id)
     (ok))
 
   (DELETE "/:request-id" []
     :path-params [request-id :- ToolRequestIdParam]
     :query [params SecuredQueryParams]
-    :summary "Delete a Tool Request"
-    :description "This service allows administrators to delete a tool request. This endpoint is primarily
-    intended for use in the QA cleanup suite."
+    :summary tools-admin-schema/ToolInstallRequestDeleteSummary
+    :description tools-admin-schema/ToolInstallRequestDeleteDocs
     (delete-tool-request request-id)
     (ok))
 
@@ -67,19 +65,17 @@
     :path-params [request-id :- ToolRequestIdParam]
     :query [params SecuredQueryParams]
     :return ToolRequestDetails
-    :summary "Obtain Tool Request Details"
-    :description "This service obtains detailed information about a tool request. This is the service
-    that the DE support team uses to obtain the request details."
+    :summary tools-admin-schema/ToolInstallRequestDetailsSummary
+    :description tools-admin-schema/ToolInstallRequestDetailsDocs
     (ok (get-tool-request request-id)))
 
   (POST "/:request-id/status" []
     :path-params [request-id :- ToolRequestIdParam]
     :query [params SecuredQueryParams]
-    :body [body (describe tools-admin-schema/ToolRequestStatusUpdate "A Tool Request status update.")]
+    :body [body tools-admin-schema/ToolRequestStatusUpdate]
     :return ToolRequestDetails
-    :summary "Update the Status of a Tool Request"
-    :description "This endpoint is used by Discovery Environment administrators to update the status
-    of a tool request."
+    :summary tools-admin-schema/ToolInstallRequestStatusUpdateSummary
+    :description tools-admin-schema/ToolInstallRequestStatusUpdateDocs
     (ok (update-tool-request request-id (config/uid-domain) current-user body))))
 
 (defroutes admin-analyses

--- a/src/apps/routes/admin/tool_requests.clj
+++ b/src/apps/routes/admin/tool_requests.clj
@@ -1,0 +1,51 @@
+(ns apps.routes.admin.tool-requests
+  (:use [apps.metadata.tool-requests]
+        [apps.routes.params :only [SecuredQueryParams]]
+        [apps.routes.schemas.tool :only [ToolRequestListingParams]]
+        [apps.user :only [current-user]]
+        [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]])
+  (:require [apps.util.config :as config]
+            [common-swagger-api.schema.tools :as schema]
+            [common-swagger-api.schema.tools.admin :as admin-schema]))
+
+(defroutes admin-tool-requests
+  (GET "/" []
+       :query [params ToolRequestListingParams]
+       :return schema/ToolRequestListing
+       :summary schema/ToolInstallRequestListingSummary
+       :description admin-schema/ToolInstallRequestListingDocs
+       (ok (list-tool-requests params)))
+
+  (DELETE "/status-codes/:status-code-id" []
+          :path-params [status-code-id :- schema/ToolRequestStatusCodeId]
+          :query [params SecuredQueryParams]
+          :summary admin-schema/ToolInstallRequestStatusCodeDeleteSummary
+          :description admin-schema/ToolInstallRequestStatusCodeDeleteDocs
+          (delete-tool-request-status-code status-code-id)
+          (ok))
+
+  (context "/:request-id" []
+    :path-params [request-id :- schema/ToolRequestIdParam]
+
+    (DELETE "/" []
+            :query [params SecuredQueryParams]
+            :summary admin-schema/ToolInstallRequestDeleteSummary
+            :description admin-schema/ToolInstallRequestDeleteDocs
+            (delete-tool-request request-id)
+            (ok))
+
+    (GET "/" []
+         :query [params SecuredQueryParams]
+         :return schema/ToolRequestDetails
+         :summary admin-schema/ToolInstallRequestDetailsSummary
+         :description admin-schema/ToolInstallRequestDetailsDocs
+         (ok (get-tool-request request-id)))
+
+    (POST "/status" []
+          :query [params SecuredQueryParams]
+          :body [body admin-schema/ToolRequestStatusUpdate]
+          :return schema/ToolRequestDetails
+          :summary admin-schema/ToolInstallRequestStatusUpdateSummary
+          :description admin-schema/ToolInstallRequestStatusUpdateDocs
+          (ok (update-tool-request request-id (config/uid-domain) current-user body)))))

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -13,9 +13,6 @@
   (merge SecuredQueryParams
          admin-schema/ToolUpdateParams))
 
-(defschema ToolRequestStatusUpdate
-  (dissoc schema/ToolRequestStatus :updated_by :status_date))
-
 (defschema ToolRequestListingParams
   (merge SecuredQueryParams
          schema/ToolRequestListingParams))


### PR DESCRIPTION
This PR will replace the `/admin/tool-requests` endpoint schemas and docs with those added by cyverse-de/common-swagger-api#40, and refactor `/admin/tool-requests` endpoints into their own `apps.routes.admin.tool-requests` namespace.