### PR TITLE
CORE-324 Update app publish endpoint to only notify community admins.

### DIFF
--- a/src/apps/clients/notifications.clj
+++ b/src/apps/clients/notifications.clj
@@ -199,18 +199,20 @@
        dorun))
 
 (defn- format-community-admin-notification
-  [app-name {:keys [id email]} community-names]
+  [integrator-name app-name {:keys [id email]} community-names]
   {:type           "apps"
    :user           id
-   :subject        (str "App " app-name " added to one or more communities")
+   :subject        (str "Community Add Request for app: " app-name)
    :email          true
-   :email_template "app_added_to_communities"
+   :email_template "app_community_request"
    :payload        {:email_address  email
                     :app_name       app-name
+                    :app_integrator integrator-name
                     :community_list (string/join "\n" community-names)}})
 
 (defn send-community-admin-notification
-  [username app-name admin community-names]
-  (guarded-send-notification (format-community-admin-notification app-name
+  [username integrator-name app-name admin community-names]
+  (guarded-send-notification (format-community-admin-notification integrator-name
+                                                                  app-name
                                                                   (groups-client/lookup-subject username admin)
                                                                   community-names)))


### PR DESCRIPTION
The app publish endpoint will no longer auto-tag apps with communities.

Instead, community admins will now receive notifications that the integrator wishes to tag their public app with those communities.

All other metadata, including ontology tags, are still added to the app.