### PR TITLE
CORE-468 Add coerce-analysis-submission-requirements middleware.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.22"]
+                 [org.cyverse/common-swagger-api "2.11.23"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes/analyses.clj
+++ b/src/apps/routes/analyses.clj
@@ -35,6 +35,7 @@
 
   (POST "/" []
     :query [params SecuredQueryParamsEmailRequired]
+    :middleware [schema/coerce-analysis-submission-requirements]
     :body [body schema/AnalysisSubmission]
     :return schema/AnalysisResponse
     :summary listing-schema/AnalysisSubmitSummary


### PR DESCRIPTION
This PR will update the `POST /analyses` endpoint with the `coerce-analysis-submission-requirements` middleware added by cyverse-de/common-swagger-api#51.