### PR TITLE
CORE-633 Add submitted resources reqs as defaults in relaunch response

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.23"]
+                 [org.cyverse/common-swagger-api "2.11.25"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]


### PR DESCRIPTION
This PR will update the `GET /analyses/{analysis-id}/relaunch-info` endpoint to include `default_memory`, `default_cpu_cores`, and `default_disk_space` values in each step's resource `requirements` settings, if the corresponding `min` values were submitted in the original analysis.

Merging requires cyverse-de/common-swagger-api#53 first.