### PR TITLE
CORE-661 Add `POST /analyses/relauncher` endpoint

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.25"]
+                 [org.cyverse/common-swagger-api "2.11.26"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/routes/analyses.clj
+++ b/src/apps/routes/analyses.clj
@@ -8,6 +8,7 @@
         [apps.routes.schemas.analysis.listing]
         [apps.user :only [current-user]]
         [apps.util.coercions :only [coerce!]]
+        [common-swagger-api.routes]                         ;; for :description-file
         [common-swagger-api.schema]
         [common-swagger-api.schema.apps :only [AppJobView]]
         [ring.util.http-response :only [ok]])
@@ -50,6 +51,13 @@
     :summary perms-schema/AnalysisPermissionListingSummary
     :description perms-schema/AnalysisPermissionListingDocs
     (ok (apps/list-job-permissions current-user (:analyses body) params)))
+
+  (POST "/relauncher" []
+    :query [params SecuredQueryParams]
+    :body [{:keys [analyses]} schema/AnalysesRelauncherRequest]
+    :summary schema/AnalysesRelauncherSummary
+    :description-file "docs/analyses/relauncher.md"
+    (ok (apps/relaunch-jobs current-user analyses)))
 
   (POST "/sharing" []
     :query [params SecuredQueryParams]

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -319,6 +319,10 @@
   [user submission-id]
   (jobs/get-submission-launch-info (get-apps-client user) user submission-id))
 
+(defn relaunch-jobs
+  [user job-ids]
+  (jobs/relaunch-jobs (get-apps-client user) user job-ids))
+
 (defn stop-job
   [user job-id params]
   (let [status (:job_status params jp/canceled-status)]

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -12,6 +12,7 @@
             [apps.service.apps.jobs.params :as job-params]
             [apps.service.apps.jobs.permissions :as job-permissions]
             [apps.service.apps.jobs.sharing :as job-sharing]
+            [apps.service.apps.jobs.resubmit :as resubmit]
             [apps.service.apps.jobs.submissions :as submissions]
             [apps.service.apps.jobs.util :as ju]
             [apps.util.service :as service]))
@@ -164,6 +165,12 @@
   (if-let [submission (sp/get-submission-by-id submission-id)]
     (job-params/get-submission-launch-info apps-client user submission)
     (cxu/not-found "submission information not found")))
+
+(defn relaunch-jobs
+  [apps-client user job-ids]
+  (validate-jobs-for-user user job-ids "read")
+  (resubmit/resubmit-jobs apps-client user (map jp/get-job-by-id job-ids))
+  nil)
 
 (defn- stop-job-steps
   "Stops an individual step in a job."

--- a/src/apps/service/apps/jobs/resubmit.clj
+++ b/src/apps/service/apps/jobs/resubmit.clj
@@ -1,0 +1,52 @@
+(ns apps.service.apps.jobs.resubmit
+  (:require [apps.service.apps.jobs.submissions :as submissions]
+            [apps.service.apps.jobs.submissions.async :as async]
+            [cheshire.core :as cheshire]
+            [clojure.string :as string]
+            [clojure-commons.exception-util :as exception-util]
+            [kameleon.uuids :as uuids]))
+
+(defn- decode-job-submission
+  [{:keys [id submission] :as job}]
+  (when-not submission (exception-util/not-found (str "Job submission values could not be found for " id)))
+  (update job :submission #(-> % .getValue (cheshire/decode true))))
+
+(defn- format-redo-name
+  "Returns a string by appending `-redo-1` to `original-name`.
+   If `original-name` already ends with `-redo-###` (where `###` is any digit),
+   then returns `original-name-redo-###` where `###` is a number 1 larger than the original trailing digit."
+  [original-name]
+  (let [regex          #"(.*-redo-)(\d+)$"
+        format-matches #(str %1 (-> %2 Integer/parseInt inc))]
+    (if (re-matches regex original-name)
+      (string/replace original-name regex #(format-matches (%1 1) (%1 2)))
+      (str original-name "-redo-1"))))
+
+(defn- format-resubmission-output-dir
+  [{:keys [submission] :as job}]
+  (if (:create_output_subdir submission true)
+    job
+    (update-in job [:submission :output_dir] format-redo-name)))
+
+(defn- format-resubmission-name
+  [{:keys [parent_id] :as job}]
+  (if parent_id
+    (-> job
+        (update-in [:submission :parent_id] uuids/uuidify)
+        (update-in [:submission :name] format-redo-name))
+    job))
+
+(defn- format-resubmission
+  [job]
+  (-> job
+      format-resubmission-output-dir
+      format-resubmission-name))
+
+(defn resubmit-jobs
+  [apps-client user jobs]
+  (let [jobs                  (map (comp format-resubmission decode-job-submission) jobs)
+        [ht-jobs single-jobs] ((juxt filter remove) :is_batch jobs)]
+    (when-not (empty? single-jobs)
+      (async/resubmit-jobs apps-client user single-jobs))
+    (doseq [ht-job ht-jobs]
+      (submissions/submit apps-client user (:submission ht-job)))))

--- a/src/apps/service/apps/jobs/submissions.clj
+++ b/src/apps/service/apps/jobs/submissions.clj
@@ -5,11 +5,8 @@
         [korma.db :only [transaction]])
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
-            [clojure-commons.error-codes :as ce]
-            [clojure-commons.file-utils :as ft]
             [kameleon.db :as db]
             [apps.clients.data-info :as data-info]
-            [apps.clients.notifications :as notifications]
             [apps.clients.permissions :as perms-client]
             [apps.persistence.app-metadata :as ap]
             [apps.persistence.jobs :as jp]
@@ -17,7 +14,6 @@
             [apps.service.apps.jobs.submissions.async :as async]
             [apps.service.apps.jobs.submissions.submit :as submit]
             [apps.util.config :as config]
-            [apps.util.service :as service]
             [apps.service.apps.jobs.util :as util]))
 
 (defn- get-app-params

--- a/src/apps/service/apps/jobs/submissions/async.clj
+++ b/src/apps/service/apps/jobs/submissions/async.clj
@@ -4,6 +4,7 @@
         [slingshot.slingshot :only [try+ throw+]])
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
+            [clojure-commons.exception-util :as exception-util]
             [clojure-commons.file-utils :as ft]
             [apps.clients.notifications :as notifications]
             [apps.persistence.jobs :as jp]
@@ -14,13 +15,12 @@
 
 (defn- max-batch-paths-exceeded
   [max-paths first-list-path first-list-count]
-  (throw+
-   {:type       :clojure-commons.exception/illegal-argument
-    :error      (str "The HT Analysis Path List exceeds the maximum of "
-                     max-paths
-                     " allowed paths.")
-    :path       first-list-path
-    :path-count first-list-count}))
+  (exception-util/illegal-argument
+   (str "The HT Analysis Path List exceeds the maximum of "
+        max-paths
+        " allowed paths.")
+   :path       first-list-path
+   :path-count first-list-count))
 
 (defn- validate-path-lists
   [path-lists]
@@ -29,8 +29,7 @@
     (when (> first-list-count (config/ht-path-list-max-paths))
       (max-batch-paths-exceeded (config/ht-path-list-max-paths) first-list-path first-list-count))
     (when-not (every? (comp (partial = first-list-count) count second) path-lists)
-      (throw+ {:type  :clojure-commons.exception/illegal-argument
-               :error "All HT Analysis Path Lists must have the same number of paths."}))
+      (exception-util/illegal-argument "All HT Analysis Path Lists must have the same number of paths."))
     path-lists))
 
 (defn- map-slice
@@ -109,7 +108,7 @@
                                 :batch-status  {jp/submitted-status 0}}
                                path-maps)
          total-jobs    (:total job-stats)
-         success-count (get (:batch-status job-stats) jp/submitted-status)
+         success-count (get-in job-stats [:batch-status jp/submitted-status])
          parent-job    (job-listings/list-job apps-client parent-id)
          message       (format "%s %d analyses of %d %s"
                                (:name parent-job)
@@ -135,3 +134,37 @@
   [apps-client user ht-paths submission output-dir parent-id]
   (let [^Runnable target #(submit-batch-jobs-thread apps-client user ht-paths submission output-dir parent-id)]
     (.start (Thread. target (str "batch_submit_" parent-id)))))
+
+(defn- resubmit-job-reducer
+  [apps-client
+   user
+   {:keys [total batch-status] :as results}
+   {:keys [submission]}]
+  (let [job-status (->> submission
+                        (submit/submit-and-register-private-job apps-client user)
+                        :status)]
+    (assoc results
+           :total         (inc total)
+           :batch-status  (update batch-status job-status (fnil inc 0)))))
+
+(defn- resubmit-jobs-thread
+  [apps-client {username :shortUsername email-address :email :as user} jobs]
+  (try+
+   (let [resubmit-stats (reduce (partial resubmit-job-reducer apps-client user)
+                                {:total        0
+                                 :batch-status {jp/submitted-status 0}}
+                                jobs)
+         total-jobs     (:total resubmit-stats)
+         success-count  (get-in resubmit-stats [:batch-status jp/submitted-status])
+         message        (format "%d of %d analyses successfully relaunched" success-count total-jobs)]
+     (if (> success-count 0)
+       (notifications/send-job-status-update username email-address (first jobs) message)
+       (throw+ "all relaunch submissions failed.")))
+   (catch Object _
+     (log/error (:throwable &throw-context) "relaunch job submissions failed.")
+     (notifications/send-job-status-update user (first jobs)))))
+
+(defn resubmit-jobs
+  [apps-client user jobs]
+  (let [^Runnable target #(resubmit-jobs-thread apps-client user jobs)]
+    (.start (Thread. target (str "resubmit_" (:username user) "_" (-> jobs first :id))))))


### PR DESCRIPTION
This PR will add the new `POST /analyses/relauncher` endpoint.

From the endpoint docs added in cyverse-de/common-swagger-api#54:

This service automatically relaunches analyses with the IDs given in the request.

* If a requested analysis was a sub-job of an HT analysis, then the relaunched analysis will also be a sub-job of that parent HT analysis.
* Any of the original analyses that have the `create_output_subdir` flag set to `false` will cause the corresponding relaunched analysis to use an output folder with `-redo-###` appended to the original output folder name, where `###` will be a `1` by default. If the original output folder name also ends with `-redo-###`, then the relaunched folder name will use a number 1 larger than the original. This will always apply to output folders of relaunched sub-jobs of an HT analysis.
  
  For example, if the output folder was `my-analysis`, then the relaunched output folder will use `my-analysis-redo-1`. If that relaunched analysis is in turn relaunched itself, then the next relaunched output folder will be `my-analysis-redo-2`.
* The names of relaunched HT analysis sub-jobs will also be renamed in this manner.

Also, in order to avoid loss of data, this endpoint will return an `EXISTS` error if any job "redo" output dirs already exist.

## Known Issues

If a user relaunches a job with the `create_output_subdir` flag set to `false` (such as in HT analyses sub-jobs), then relaunches that same job before the first relaunch has a chance to start running, then the output folder of the first relaunch won't have a chance to be created before the second relaunch is requested, the second relaunch will not return an `EXISTS` error, and both relaunched jobs will end up sharing the same output directory.