### PR TITLE
CORE-971: added an endpoint to list a single app in the DE

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.1-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.0.1"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.26"]
+                 [org.cyverse/common-swagger-api "3.0.1-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -392,6 +392,13 @@
       ((partial query-spy "get-apps-for-admin::search_query:"))
       select))
 
+(defn get-single-app
+  "Fetches a listing for a single app."
+  [{workspace-id :id :as workspace} favorites-group-index app-id]
+  (as-> (get-app-listing-base-query workspace favorites-group-index {:app-ids [app-id]}) q
+    (query-spy "get-single-app::search-query:" q)
+    (select q)))
+
 (defn- add-deleted-and-orphaned-where-clause
   [query public-app-ids]
   (where query

--- a/src/apps/protocols.clj
+++ b/src/apps/protocols.clj
@@ -14,6 +14,7 @@
   (listAppsInCommunity [_ community-id params])
   (adminListAppsInCommunity [_ community-id params])
   (searchApps [_ search-term params])
+  (listSingleApp [_ system-id app-id])
   (adminSearchApps [_ search-term params])
   (canEditApps [_])
   (addApp [_ system-id app])

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -126,6 +126,14 @@
         :description schema/AppCopyDocs
         (ok (apps/copy-app current-user system-id app-id)))
 
+      (GET "/listing" []
+        :query [params SecuredQueryParams]
+        :summary schema/SingleAppListingSummary
+        :return schema/AppListing
+        :description schema/SingleAppListingDocs
+        (ok (coerce! schema/AppListing
+                     (apps/list-single-app current-user system-id app-id))))
+
       (GET "/details" []
         :query [params SecuredQueryParams]
         :return schema/AppDetails

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -104,6 +104,10 @@
   [user {:keys [search] :as params}]
   (.searchApps (get-apps-client user) search params))
 
+(defn list-single-app
+  [user system-id app-id]
+  (.listSingleApp (get-apps-client user) system-id app-id))
+
 (defn admin-search-apps
   [user {:keys [search] :as params}]
   (.adminSearchApps (get-apps-client user) search params))

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -113,6 +113,10 @@
         (listings/search-apps agave search-term params false)
         (.emptyAppListing agave))))
 
+  (listSingleApp [_ system-id app-id]
+    (validate-system-id system-id)
+    (listings/list-app agave app-id))
+
   (adminSearchApps [self search-term params]
     (when (user-has-access-token?)
       (if (apps-util/app-type-qualifies? self params)

--- a/src/apps/service/apps/agave/listings.clj
+++ b/src/apps/service/apps/agave/listings.clj
@@ -62,6 +62,12 @@
       (apply-limit params)
       (format-app-listing-job-stats false)))
 
+(defn list-app
+  [agave app-id]
+  (-> (.listApps agave [app-id] {})
+      add-app-integrator-info
+      (select-keys [:total :apps])))
+
 (defn list-apps-with-ontology
   [agave term params admin?]
   (try+

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -68,6 +68,9 @@
          (remove nil?)
          (util/combine-app-listings params)))
 
+  (listSingleApp [_ system-id app-id]
+    (.listSingleApp (util/get-apps-client clients system-id) system-id app-id))
+
   (adminSearchApps [_ search-term params]
     (let [known-params [:search :app-subset :start_date :end_date :app-type]]
       (->> (map #(.adminSearchApps % search-term (select-keys params known-params)) clients)

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -69,6 +69,9 @@
   (searchApps [_ _ params]
     (listings/list-apps user params false))
 
+  (listSingleApp [_ _ app-id]
+    (listings/list-app user (uuidify app-id)))
+
   (adminSearchApps [_ _ params]
     (listings/list-apps user params true))
 

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -458,6 +458,20 @@
     {:total total
      :apps  apps}))
 
+(defn list-app
+  "This service retrieves app listing information for a single app."
+  [{:keys [username shortUsername]} app-id]
+  (perms/check-app-permissions shortUsername "read" [app-id])
+  (let [workspace      (get-workspace username)
+        perms          (perms-client/load-app-permissions shortUsername)
+        total          (count-apps-for-user nil (:id workspace) {:app-ids [app-id]})
+        apps           (get-single-app workspace (workspace-favorites-app-category-index) app-id)
+        beta-ids-set   (app-ids->beta-ids-set shortUsername [app-id])
+        public-app-ids (perms-client/get-public-app-ids)
+        apps           (map (partial format-app-listing false perms beta-ids-set public-app-ids) apps)]
+    {:total total
+     :apps  apps}))
+
 (defn- load-app-details
   "Retrieves the details for a single app."
   [app-id]


### PR DESCRIPTION
The changes in this PR add a new endpoint that can be used to obtain app listing information for a single app.

The purpose of adding a separate endpoint for listing a single app in the DE is also to add clarity. Adapting the existing app search endpoint to work for listing a specified app ID seems potentially confusing. For example, what happens if the app-id and search parameters are both specified and they conflict (that is the app ID matches an app, but the search string would exclude the app)? I can imagine a valid argument for excluding the app because it doesn't match the search string. After all, maybe the caller only wants to list that specific app if it also matches the search string. I can also imagine a valid argument for including the app because the app-id parameter should override the search string. Given the confusion inherent in interactions between the app-id and search parameters (or the lack thereof), I decided it would probably be best to create a separate endpoint.
