### PR TITLE
Parallelize creation of virtual categories

### DIFF
--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -8,6 +8,7 @@
         [service-logging.thread-context :only [with-logging-context]])
   (:require [clojure.tools.logging :as log]
             [clojure-commons.exception-util :as cxu]
+            [clojure.walk :as walk]
             [mescal.de :as agave]
             [apps.clients.notifications :as cn]
             [apps.persistence.jobs :as jp]
@@ -76,7 +77,9 @@
 (defn get-app-categories
   [user params]
   (let [client (get-apps-client user "type=apps")]
-    {:categories (transaction (.listAppCategories client params))}))
+    {:categories (transaction
+                   (walk/prewalk (fn [x] (if (or (future? x) (delay? x)) (deref x) x))
+                     (.listAppCategories client params)))}))
 
 (defn list-apps-in-category
   [user system-id category-id params]

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -364,7 +364,8 @@
 
 (defn get-admin-app-categories
   [user params]
-  {:categories (.getAdminAppCategories (get-apps-client user) params)})
+  (walk/prewalk (fn [x] (if (or (future? x) (delay? x)) (deref x) x))
+    {:categories (.getAdminAppCategories (get-apps-client user) params)}))
 
 (defn search-admin-app-categories
   [user params]

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -388,10 +388,10 @@
   [{:keys [shortUsername] :as user} workspace group-id perms {:keys [public-app-ids] :as params}]
   (when-let [format-fns (virtual-group-fns group-id)]
     (-> ((:format-group format-fns) user workspace params)
-        (realize-virtual-group)
         (assoc :apps (let [app-listing  ((:format-listing format-fns) user workspace params)
                            beta-ids-set (app-ids->beta-ids-set shortUsername (map :id app-listing))]
-                       (map (partial format-app-listing false perms beta-ids-set public-app-ids) app-listing))))))
+                       (map (partial format-app-listing false perms beta-ids-set public-app-ids) app-listing)))
+        (realize-virtual-group))))
 
 (defn- count-apps-in-group
   "Counts the number of apps in an app group, including virtual app groups that may be included."

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -97,7 +97,7 @@
    :id         trash-category-id
    :name       "Trash"
    :is_public  true
-   :total      (count-deleted-and-orphaned-apps params)})
+   :total      (future (count-deleted-and-orphaned-apps params))})
 
 (defn list-trashed-apps
   "Lists the public, deleted apps and orphaned apps."
@@ -111,7 +111,7 @@
    :id        my-public-apps-id
    :name      "My public apps"
    :is_public false
-   :total     (count-public-apps-by-user username params)})
+   :total     (future (count-public-apps-by-user username params))})
 
 (defn list-my-public-apps
   "Lists the public apps belonging to the user with the given workspace."
@@ -129,7 +129,7 @@
    :id        shared-with-me-id
    :name      "Shared with me"
    :is_public false
-   :total     (count-shared-apps workspace (workspace-favorites-app-category-index) params)})
+   :total     (future (count-shared-apps workspace (workspace-favorites-app-category-index) params))})
 
 (defn list-apps-shared-with-me
   [_ workspace params]
@@ -145,11 +145,16 @@
 
 (def ^:private virtual-group-ids (set (keys virtual-group-fns)))
 
+(defn- realize-virtual-group
+  [group]
+  (reduce (fn [group k] (if (future? (group k)) (update group k deref) group)) group (keys group)))
+
 (defn- format-private-virtual-groups
   "Formats any virtual groups that should appear in a user's workspace."
   [user workspace params]
-  (remove :is_public
-          (map (fn [[_ {f :format-group}]] (f user workspace params)) virtual-group-fns)))
+  (doall (map realize-virtual-group ;; resolve immediately to start futures executing
+    (remove :is_public
+      (map (fn [[_ {f :format-group}]] (f user workspace params)) virtual-group-fns)))))
 
 (defn- add-private-virtual-groups
   [user group workspace params]
@@ -383,6 +388,7 @@
   [{:keys [shortUsername] :as user} workspace group-id perms {:keys [public-app-ids] :as params}]
   (when-let [format-fns (virtual-group-fns group-id)]
     (-> ((:format-group format-fns) user workspace params)
+        (realize-virtual-group)
         (assoc :apps (let [app-listing  ((:format-listing format-fns) user workspace params)
                            beta-ids-set (app-ids->beta-ids-set shortUsername (map :id app-listing))]
                        (map (partial format-app-listing false perms beta-ids-set public-app-ids) app-listing))))))


### PR DESCRIPTION
also, remove non-public categories faster with futures and doall

fairly small PR, but improves performance of the main categories endpoint substantially. apps was doing some significant work it didn't need to, plus this parallelizes some of what's left. Here's what's going on:

`count-deleted-and-orphaned-apps` is pretty slow (about 5s from here, though it's probably at least a little better not over VPN). But, it's only used for the Trash category, which has `:is_public` set to true. `format-private-virtual-groups` removes things with `:is_public` true, but only after they've been calculated out, so we were just calculating that all out to immediately toss it. Instead, I've changed it to use a future for all the counts, and then deref the futures after the `remove` call. Also, I added in a `doall` so it would start the whole process before leaving `format-private-virtual-groups` (before, it was calculating it much later, during response coercion, due to the lazy sequences).

I think that it'll still calculate out the future with `count-deleted-and-orphaned-apps`, but now it does it in another thread and never derefs it, which at least means the endpoint returns without it needing to have calculated that count.