### PR TITLE
WIP CORE-600 Add total count of jobs by status

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.1"]
+                 [org.cyverse/common-swagger-api "3.0.3-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -102,6 +102,10 @@
   [{:keys [username]} {:keys [filter include-hidden]} types analysis-ids]
   (jp/count-jobs-of-types username filter include-hidden types analysis-ids))
 
+(defn- count-job-statuses
+  [{:keys [username]} {:keys [filter include-hidden]} types analysis-ids]
+  (jp/count-jobs-of-statuses username filter include-hidden types analysis-ids))
+
 (defn list-jobs
   [apps-client user {:keys [sort-field] :as params}]
   (let [perms            (perms-client/load-analysis-permissions (:shortUsername user))
@@ -112,9 +116,10 @@
         jobs             (list-jobs* user search-params types analysis-ids)
         rep-steps        (group-by (some-fn :parent_id :job_id) (jp/list-representative-job-steps (mapv :id jobs)))
         app-tables       (.loadAppTables apps-client jobs)]
-    {:analyses  (mapv (partial format-job apps-client perms app-tables rep-steps) jobs)
-     :timestamp (str (System/currentTimeMillis))
-     :total     (count-jobs user params types analysis-ids)}))
+    {:analyses     (mapv (partial format-job apps-client perms app-tables rep-steps) jobs)
+     :timestamp    (str (System/currentTimeMillis))
+     :status-count (count-job-statuses user params types analysis-ids)
+     :total        (count-jobs user params types analysis-ids)}))
 
 (defn admin-list-jobs-with-external-ids [external-ids]
   (let [jobs      (jp/list-jobs-by-external-id external-ids)


### PR DESCRIPTION
Wanted some eyes on this before I try to make other changes.  This produces something like:
```
{
  "analyses": [ ... ],
  "timestamp": "1591988105298",
  "status-count": [
    {
      "count": 23,
      "status": "Submitted"
    },
    {
      "count": 3,
      "status": "Canceled"
    },
    {
      "count": 4,
      "status": "Completed"
    }
  ],
  "total": 30
}
```