### PR TITLE
CORE-600 Add job status counts as an endpoint and to job listings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.1"]
+                 [org.cyverse/common-swagger-api "3.0.3-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.3-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.0.3"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/protocols.clj
+++ b/src/apps/protocols.clj
@@ -46,6 +46,7 @@
   (copyPipeline [_ app-id])
   (editPipeline [_ app-id])
   (listJobs [_ params])
+  (listJobStats [_ params])
   (adminListJobsWithExternalIds [_ external-ids])
   (loadAppTables [_ qualified-app-ids])
   (submitJob [_ submission])

--- a/src/apps/routes/analyses.clj
+++ b/src/apps/routes/analyses.clj
@@ -1,6 +1,7 @@
 (ns apps.routes.analyses
   (:use [apps.routes.params
          :only [AnalysisListingParams
+                AnalysisStatParams
                 FilterParams
                 SecuredQueryParams
                 SecuredQueryParamsEmailRequired]]
@@ -33,6 +34,18 @@
                                  (coercions/coerce!
                                   (assoc AnalysisListingParams listing-schema/OptionalKeyFilter [FilterParams])
                                   (assoc params :filter (json/from-json filter)))))))
+  (GET "/stats" []
+      :query [{:keys [filter] :as params} AnalysisStatParams]
+      :return schema/AnalysisStats
+      :summary schema/AnalysisStatSummary
+      :description schema/AnalysisStatDescription
+      ;; JSON query params are not currently supported by compojure-api,
+      ;; so we have to decode the String filter param and validate it here.
+      (ok (coerce! schema/AnalysisStats
+                   (apps/list-job-stats current-user
+                                   (coercions/coerce!
+                                     (assoc AnalysisStatParams listing-schema/OptionalKeyFilter [FilterParams])
+                                     (assoc params :filter (json/from-json filter)))))))
 
   (POST "/" []
     :query [params SecuredQueryParamsEmailRequired]

--- a/src/apps/routes/params.clj
+++ b/src/apps/routes/params.clj
@@ -8,7 +8,8 @@
                 SortFieldOptionalKey
                 StandardUserQueryParams]]
         [common-swagger-api.schema.common :only [IncludeHiddenParams]])
-  (:require [common-swagger-api.schema.analyses.listing :as analyses-schema]
+  (:require [common-swagger-api.schema.analyses :as analysis-schema]
+            [common-swagger-api.schema.analyses.listing :as listing-schema]
             [common-swagger-api.schema.apps.elements :as elements-schema]
             [common-swagger-api.schema.tools :as tools-schema]
             [schema.core :as s])
@@ -56,7 +57,10 @@
       case-insensitive, in the corresponding field.")})
 
 (s/defschema AnalysisListingParams
-  (merge SecuredQueryParams analyses-schema/AnalysisListingParams))
+  (merge SecuredQueryParams listing-schema/AnalysisListingParams))
+
+(s/defschema AnalysisStatParams
+  (merge SecuredQueryParams analysis-schema/AnalysisStatParams))
 
 (s/defschema ToolSearchParams
   (merge SecuredQueryParams tools-schema/ToolSearchParams))

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -226,6 +226,10 @@
   [user params]
   (.listJobs (get-apps-client user) params))
 
+(defn list-job-stats
+  [user params]
+  (.listJobStats (get-apps-client user) params))
+
 (defn- format-job-submission-response
   [job-info]
   (-> job-info

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -223,6 +223,9 @@
   (listJobs [self params]
     (job-listings/list-jobs self user params))
 
+  (listJobStats [self params]
+    (job-listings/list-job-stats self user params))
+
   (adminListJobsWithExternalIds [_ external-ids]
     (job-listings/admin-list-jobs-with-external-ids external-ids))
 

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -177,6 +177,9 @@
   (listJobs [self params]
     (job-listings/list-jobs self user params))
 
+  (listJobStats [self params]
+    (job-listings/list-job-stats self user params))
+
   (adminListJobsWithExternalIds [_ external-ids]
     (job-listings/admin-list-jobs-with-external-ids external-ids))
 

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -189,6 +189,9 @@
   (listJobs [self params]
     (job-listings/list-jobs self user params))
 
+  (listJobStats [self params]
+    (job-listings/list-job-stats self user params))
+
   (adminListJobsWithExternalIds [_ external-ids]
     (job-listings/admin-list-jobs-with-external-ids external-ids))
 

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -102,6 +102,10 @@
   [{:keys [username]} {:keys [filter include-hidden]} types analysis-ids]
   (jp/count-jobs-of-types username filter include-hidden types analysis-ids))
 
+(defn- count-job-statuses
+  [{:keys [username]} {:keys [filter include-hidden]} types analysis-ids]
+  (jp/count-jobs-of-statuses username filter include-hidden types analysis-ids))
+
 (defn list-jobs
   [apps-client user {:keys [sort-field] :as params}]
   (let [perms            (perms-client/load-analysis-permissions (:shortUsername user))
@@ -112,9 +116,10 @@
         jobs             (list-jobs* user search-params types analysis-ids)
         rep-steps        (group-by (some-fn :parent_id :job_id) (jp/list-representative-job-steps (mapv :id jobs)))
         app-tables       (.loadAppTables apps-client jobs)]
-    {:analyses  (mapv (partial format-job apps-client perms app-tables rep-steps) jobs)
-     :timestamp (str (System/currentTimeMillis))
-     :total     (count-jobs user params types analysis-ids)}))
+    {:analyses     (mapv (partial format-job apps-client perms app-tables rep-steps) jobs)
+     :timestamp    (str (System/currentTimeMillis))
+     :status-count (count-job-statuses user params types analysis-ids)
+     :total        (count-jobs user params types analysis-ids)}))
 
 (defn admin-list-jobs-with-external-ids [external-ids]
   (let [jobs      (jp/list-jobs-by-external-id external-ids)

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -115,10 +115,11 @@
         types            (.getJobTypes apps-client)
         jobs             (list-jobs* user search-params types analysis-ids)
         rep-steps        (group-by (some-fn :parent_id :job_id) (jp/list-representative-job-steps (mapv :id jobs)))
-        app-tables       (.loadAppTables apps-client jobs)]
+        app-tables       (.loadAppTables apps-client jobs)
+        status-count     (future (count-job-statuses user params types analysis-ids))]
     {:analyses     (mapv (partial format-job apps-client perms app-tables rep-steps) jobs)
      :timestamp    (str (System/currentTimeMillis))
-     :status-count (count-job-statuses user params types analysis-ids)
+     :status-count @status-count
      :total        (count-jobs user params types analysis-ids)}))
 
 (defn admin-list-jobs-with-external-ids [external-ids]

--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -122,6 +122,13 @@
      :status-count @status-count
      :total        (count-jobs user params types analysis-ids)}))
 
+(defn list-job-stats
+  [apps-client user params]
+  (let [perms            (perms-client/load-analysis-permissions (:shortUsername user))
+        analysis-ids     (set (keys perms))
+        types            (.getJobTypes apps-client)]
+    {:status-count (count-job-statuses user params types analysis-ids)}))
+
 (defn admin-list-jobs-with-external-ids [external-ids]
   (let [jobs      (jp/list-jobs-by-external-id external-ids)
         rep-steps (group-by :job_id (jp/list-representative-job-steps (mapv :id jobs)))]


### PR DESCRIPTION
In case we did want to switch to having the totals be grouped by job type (so, for example, an interactive section with all those status totals, and then an agave section with all those status totals, etc.), instead of showing the totals for whatever type filter is set, I've been looking into how to do that as well (if only for my own practice). It's taking me longer than I anticipated to figure that out, so I'm putting this up now in case we want to stick with this format anyway. So the end result is still looking like:
```
{
  "analyses": [ ... ],
  "timestamp": "1591988105298",
  "status-count": [
    {
      "count": 23,
      "status": "Submitted"
    },
    {
      "count": 3,
      "status": "Canceled"
    },
    {
      "count": 4,
      "status": "Completed"
    }
  ],
  "total": 30
}
```