### PR TITLE
CORE-1102: perform DE an HPC analysis listings concurrently.

### DIFF
--- a/conf/test/logback.xml
+++ b/conf/test/logback.xml
@@ -14,6 +14,9 @@
   <!-- Jargon Logging -->
   <logger name="org.irods.jargon" level="ERROR" />
 
+  <!-- Change level to DEBUG to log database queries. -->
+  <logger name="kameleon.util" level="WARN"/>
+
   <logger name="apps.service.callbacks" level="INFO" />
   <logger name="apps.util.json" level="DEBUG" />
 

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -41,41 +41,41 @@
 
   (listAppsUnderHierarchy [_ root-iri attr params]
     (let [unpaged-params (dissoc params :limit :offset)]
-      (->> (map #(.listAppsUnderHierarchy % root-iri attr unpaged-params) clients)
+      (->> (map #(future (.listAppsUnderHierarchy % root-iri attr unpaged-params)) clients)
            (remove nil?)
-           (util/combine-app-listings params))))
+           (util/combine-concurrent-app-listings params))))
 
   (adminListAppsUnderHierarchy [_ ontology-version root-iri attr params]
     (let [unpaged-params (dissoc params :limit :offset)]
-      (->> (map #(.adminListAppsUnderHierarchy % ontology-version root-iri attr unpaged-params) clients)
+      (->> (map #(future (.adminListAppsUnderHierarchy % ontology-version root-iri attr unpaged-params)) clients)
            (remove nil?)
-           (util/combine-app-listings params))))
+           (util/combine-concurrent-app-listings params))))
 
   (listAppsInCommunity [_ community-id params]
     (let [unpaged-params (dissoc params :limit :offset)]
-      (->> (map #(.listAppsInCommunity % community-id unpaged-params) clients)
+      (->> (map #(future (.listAppsInCommunity % community-id unpaged-params)) clients)
            (remove nil?)
-           (util/combine-app-listings params))))
+           (util/combine-concurrent-app-listings params))))
 
   (adminListAppsInCommunity [_ community-id params]
     (let [unpaged-params (dissoc params :limit :offset)]
-      (->> (map #(.adminListAppsInCommunity % community-id unpaged-params) clients)
+      (->> (map #(future (.adminListAppsInCommunity % community-id unpaged-params)) clients)
            (remove nil?)
-           (util/combine-app-listings params))))
+           (util/combine-concurrent-app-listings params))))
 
   (searchApps [_ search-term params]
-    (->> (map #(.searchApps % search-term (select-keys params [:search :app-type])) clients)
+    (->> (map #(future (.searchApps % search-term (select-keys params [:search :app-type]))) clients)
          (remove nil?)
-         (util/combine-app-listings params)))
+         (util/combine-concurrent-app-listings params)))
 
   (listSingleApp [_ system-id app-id]
     (.listSingleApp (util/get-apps-client clients system-id) system-id app-id))
 
   (adminSearchApps [_ search-term params]
     (let [known-params [:search :app-subset :start_date :end_date :app-type]]
-      (->> (map #(.adminSearchApps % search-term (select-keys params known-params)) clients)
+      (->> (map #(future (.adminSearchApps % search-term (select-keys params known-params))) clients)
            (remove nil?)
-           (util/combine-app-listings params))))
+           (util/combine-concurrent-app-listings params))))
 
   (canEditApps [_]
     (some #(.canEditApps %) clients))

--- a/src/apps/service/apps/combined/util.clj
+++ b/src/apps/service/apps/combined/util.clj
@@ -22,6 +22,12 @@
         (apply-offset params)
         (apply-limit params))))
 
+(defn combine-concurrent-app-listings
+  "Expects results to be a list of futures that can be dereferenced to return a map in a format like
+   {:total int, :apps []}"
+  [params results]
+  (combine-app-listings params (mapv deref results)))
+
 (defn get-apps-client
   ([clients]
    (or (first (filter #(.supportsSystemId % jp/de-client-name) clients))


### PR DESCRIPTION
I tested these changes locally in the REPL using these functions:

``` clojure
(defn test-search
  [term]
  (binding [current-user user]
    (apps/search-apps user {:search term})
    nil))

(defn test-admin-search
  [term]
  (binding [current-user user]
    (apps/admin-search-apps user {:search term})
    nil))

(def ontology-version "http://edamontology.org/1.16/2016/12/19/15-54-46.2")
(def root-iri "http://edamontology.org/operation_2928")
(def attr "rdf:type")
(def sort-field "name")
(def sort-dir "ASC")

(defn test-list-apps-under-hierarchy
  []
  (binding [current-user user]
    (apps/list-apps-under-hierarchy
     user
     root-iri
     attr
     {:type       attr
      :sort-field sort-field
      :sort-dir   sort-dir})
    nil))

(defn test-admin-list-apps-under-hierarchy
  []
  (binding [current-user user]
    (apps/admin-list-apps-under-hierarchy
     user
     ontology-version
     root-iri
     attr
     {:type       attr
      :sort-field sort-field
      :sort-dir   sort-dir})
    nil))

(def community-id "iplant:de:qa:communities:Metalheads")

(defn test-list-apps-in-community
  []
  (binding [current-user user]
    (apps/list-apps-in-community
     user
     community-id
     {:sort-field sort-field
      :sort-dir   sort-dir})
    nil))

(defn test-admin-list-apps-in-community
  []
  (binding [current-user user]
    (apps/admin-list-apps-in-community
     user
     community-id
     {:sort-field sort-field
      :sort-dir   sort-dir})
    nil))
```

I removed the `nil` return value to do some cursory checks on the results that were being returned.
