### PR TITLE
CORE-1106: switched the endpoints for listing apps under a hierarchy …

### DIFF
--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -537,6 +537,11 @@
   (when-not (empty? app-ids)
     (select (get-app-listing-base-query workspace favorites-group-index (assoc params :app-ids app-ids)))))
 
+(defn new-list-apps-by-id
+  "Lists all apps with an ID in the the given app-ids list."
+  [workspace favorites-group-index app-ids params]
+  (new-get-apps-for-user nil workspace favorites-group-index (assoc params :app-ids app-ids)))
+
 (defn admin-list-apps-by-id
   "Lists all apps with an ID in the the given app-ids list,
    including job_count, job_count_failed, job_count_completed, last_used timestamp, and
@@ -546,6 +551,19 @@
     (-> (get-app-listing-base-query workspace favorites-group-index (assoc params :app-ids app-ids))
         (get-job-stats-fields params)
         (get-admin-job-stats-fields params)
+        select)))
+
+(defn new-admin-list-apps-by-id
+  "Lists all apps with an ID in the the given app-ids list,
+   including job_count, job_count_failed, job_count_completed, last_used timestamp, and
+   job_last_completed timestamp fields for each result."
+  [workspace favorites-group-index app-ids params]
+  (let [app-ids (find-matching-app-ids nil (assoc params :app-ids app-ids))]
+    (-> (get-base-app-listing-base-query workspace favorites-group-index params)
+        (get-job-stats-fields params)
+        (get-admin-job-stats-fields params)
+        (where {:id [in app-ids]})
+        ((partial query-spy "admin-list-apps-by-id::search_query:"))
         select)))
 
 (defn get-all-app-ids

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -51,9 +51,6 @@
       public-app-ids)
     accessible-app-ids))
 
-(defn- admin-search-app-ids
-  [public-app-ids])
-
 (defn- augment-search-params
   [search_term {:keys [app-ids public-app-ids app-subset] :as params} short-username admin?]
   (let [category-attrs (set (workspace-metadata-category-attrs))

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -334,9 +334,13 @@
         faves-index    (workspace-favorites-app-category-index)
         beta-ids-set   (app-ids->beta-ids-set shortUsername app-ids)
         public-app-ids (perms-client/get-public-app-ids)
-        count-apps-fn  (if admin? count-apps-for-admin count-apps-for-user)
+        count-apps-fn  (if (:new params true)
+                         (if admin? new-count-apps-for-admin new-count-apps-for-user)
+                         (if admin? count-apps-for-admin count-apps-for-user))
         total          (if (empty? app-ids) 0 (count-apps-fn nil (:id workspace) (assoc params :app-ids app-ids)))
-        app-listing-fn (if admin? admin-list-apps-by-id list-apps-by-id)
+        app-listing-fn (if (:new params true)
+                         (if admin? new-admin-list-apps-by-id new-list-apps-by-id)
+                         (if admin? admin-list-apps-by-id list-apps-by-id))
         app-listing    (app-listing-fn workspace faves-index app-ids (fix-sort-params params))]
     {:total total
      :apps  (map (partial format-app-listing admin? perms beta-ids-set public-app-ids) app-listing)}))


### PR DESCRIPTION
…to use the new queries

This change updates the app listing by ID endpoints to use the new queries. There isn't much of a performance improvement in this case, but I would eventually like to update all app listing code to use the same queries just to avoid potential confusion. There will be more PRs related to this coming up, but I wanted to get this one submitted because I'm going to be adding a couple of new features to the apps service over the next few days. I'm hoping to return to this task after I finish adding the new features.
