### PR TITLE
CORE-1106: more app listing improvements

### DIFF
--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -537,6 +537,11 @@
   (when-not (empty? app-ids)
     (select (get-app-listing-base-query workspace favorites-group-index (assoc params :app-ids app-ids)))))
 
+(defn new-list-apps-by-id
+  "Lists all apps with an ID in the the given app-ids list."
+  [workspace favorites-group-index app-ids params]
+  (new-get-apps-for-user nil workspace favorites-group-index (assoc params :app-ids app-ids)))
+
 (defn admin-list-apps-by-id
   "Lists all apps with an ID in the the given app-ids list,
    including job_count, job_count_failed, job_count_completed, last_used timestamp, and
@@ -546,6 +551,19 @@
     (-> (get-app-listing-base-query workspace favorites-group-index (assoc params :app-ids app-ids))
         (get-job-stats-fields params)
         (get-admin-job-stats-fields params)
+        select)))
+
+(defn new-admin-list-apps-by-id
+  "Lists all apps with an ID in the the given app-ids list,
+   including job_count, job_count_failed, job_count_completed, last_used timestamp, and
+   job_last_completed timestamp fields for each result."
+  [workspace favorites-group-index app-ids params]
+  (let [app-ids (find-matching-app-ids nil (assoc params :app-ids app-ids))]
+    (-> (get-base-app-listing-base-query workspace favorites-group-index params)
+        (get-job-stats-fields params)
+        (get-admin-job-stats-fields params)
+        (where {:id [in app-ids]})
+        ((partial query-spy "admin-list-apps-by-id::search_query:"))
         select)))
 
 (defn get-all-app-ids

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -59,17 +59,15 @@
       (->> (map #(future (.adminListAppsInCommunity % community-id unpaged-params)) clients)
            (util/combine-app-listings params))))
 
-  ;; Note: the :new parameter can go away when the performance improvement changes are done.
   (searchApps [_ search-term params]
-    (->> (map #(future (.searchApps % search-term (select-keys params [:search :app-type :new]))) clients)
+    (->> (map #(future (.searchApps % search-term (select-keys params [:search :app-type]))) clients)
          (util/combine-app-listings params)))
 
   (listSingleApp [_ system-id app-id]
     (.listSingleApp (util/get-apps-client clients system-id) system-id app-id))
 
-  ;; Note: the :new parameter can go away when the performance improvement changes are done.
   (adminSearchApps [_ search-term params]
-    (let [known-params [:search :app-subset :start_date :end_date :app-type :new]]
+    (let [known-params [:search :app-subset :start_date :end_date :app-type]]
       (->> (map #(future (.adminSearchApps % search-term (select-keys params known-params))) clients)
            (util/combine-app-listings params))))
 

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -331,13 +331,9 @@
         faves-index    (workspace-favorites-app-category-index)
         beta-ids-set   (app-ids->beta-ids-set shortUsername app-ids)
         public-app-ids (perms-client/get-public-app-ids)
-        count-apps-fn  (if (:new params true)
-                         (if admin? new-count-apps-for-admin new-count-apps-for-user)
-                         (if admin? count-apps-for-admin count-apps-for-user))
+        count-apps-fn  (if admin? count-apps-for-admin count-apps-for-user)
         total          (if (empty? app-ids) 0 (count-apps-fn nil (:id workspace) (assoc params :app-ids app-ids)))
-        app-listing-fn (if (:new params true)
-                         (if admin? new-admin-list-apps-by-id new-list-apps-by-id)
-                         (if admin? admin-list-apps-by-id list-apps-by-id))
+        app-listing-fn (if admin? admin-list-apps-by-id list-apps-by-id)
         app-listing    (app-listing-fn workspace faves-index app-ids (fix-sort-params params))]
     {:total total
      :apps  (map (partial format-app-listing admin? perms beta-ids-set public-app-ids) app-listing)}))
@@ -442,11 +438,7 @@
 
 (defn list-apps
   "This service fetches a paged list of apps in the user's workspace and all public app groups,
-   further filtering results by a search term if the `search` parameter is present.
-
-   Note: the :new parameter is intended to be used for debugging. I'll remove it when the performance
-   improvements are done. In the meantime, I want to be able to easily switch back to the old search
-   queries in case any bugs are identified."
+   further filtering results by a search term if the `search` parameter is present."
   [{:keys [username shortUsername]} params admin?]
   (let [search_term    (curl/url-decode (:search params))
         workspace      (get-workspace username)
@@ -456,13 +448,9 @@
                            (assoc :orphans admin?)
                            fix-sort-params)
         params         (augment-search-params search_term params shortUsername admin?)
-        count-apps-fn  (if (:new params true)
-                         (if admin? new-count-apps-for-admin new-count-apps-for-user)
-                         (if admin? count-apps-for-admin count-apps-for-user))
+        count-apps-fn  (if admin? count-apps-for-admin count-apps-for-user)
         total          (count-apps-fn search_term (:id workspace) params)
-        app-listing-fn (if (:new params true)
-                         (if admin? new-get-apps-for-admin new-get-apps-for-user)
-                         (if admin? get-apps-for-admin get-apps-for-user))
+        app-listing-fn (if admin? get-apps-for-admin get-apps-for-user)
         apps           (app-listing-fn search_term
                                        workspace
                                        (workspace-favorites-app-category-index)

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -51,9 +51,6 @@
       public-app-ids)
     accessible-app-ids))
 
-(defn- admin-search-app-ids
-  [public-app-ids])
-
 (defn- augment-search-params
   [search_term {:keys [app-ids public-app-ids app-subset] :as params} short-username admin?]
   (let [category-attrs (set (workspace-metadata-category-attrs))

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -334,9 +334,13 @@
         faves-index    (workspace-favorites-app-category-index)
         beta-ids-set   (app-ids->beta-ids-set shortUsername app-ids)
         public-app-ids (perms-client/get-public-app-ids)
-        count-apps-fn  (if admin? count-apps-for-admin count-apps-for-user)
+        count-apps-fn  (if (:new params true)
+                         (if admin? new-count-apps-for-admin new-count-apps-for-user)
+                         (if admin? count-apps-for-admin count-apps-for-user))
         total          (if (empty? app-ids) 0 (count-apps-fn nil (:id workspace) (assoc params :app-ids app-ids)))
-        app-listing-fn (if admin? admin-list-apps-by-id list-apps-by-id)
+        app-listing-fn (if (:new params true)
+                         (if admin? new-admin-list-apps-by-id new-list-apps-by-id)
+                         (if admin? admin-list-apps-by-id list-apps-by-id))
         app-listing    (app-listing-fn workspace faves-index app-ids (fix-sort-params params))]
     {:total total
      :apps  (map (partial format-app-listing admin? perms beta-ids-set public-app-ids) app-listing)}))


### PR DESCRIPTION
After doing some more testing, I think that this PR and the previous one combined make all of the changes that will be useful to make at this time. We could migrate other endpoints to the new listing queries, but that's going to require more effort than it's worth at the moment.

This PR updates the endpoints to list apps under an ontology hierarchy, and it removes the `:new` parameter that I had been using to switch between the old and new queries.
