### PR TITLE
CORE-1164: added the `type` and `path` members to parameters sent in …

### DIFF
--- a/src/apps/service/apps/de/jobs/params.clj
+++ b/src/apps/service/apps/de/jobs/params.clj
@@ -119,7 +119,8 @@
      {:id    (:id param)
       :name  opt-arg
       :order (:order param 0)
-      :value (stringify opt-val)}))
+      :value (stringify opt-val)
+      :type  (:type param)}))
   ([param param-value]
    (build-arg param (or (:name param) "") param-value)))
 
@@ -169,9 +170,10 @@
 (defn- build-input-arg
   [{:keys [repeat_option_flag name] :as param} preprocessor index value]
   (let [name (if (and (pos? index) (not repeat_option_flag)) "" name)]
-    (build-arg
-     (assoc param :name name)
-     ((fnil preprocessor "") value))))
+    (-> (build-arg
+         (assoc param :name name)
+         ((fnil preprocessor "") value))
+        (assoc :path value))))
 
 (defn input-args
   [{:keys [is_implicit omit_if_blank] :as param} param-value preprocessor]


### PR DESCRIPTION
…outgoing job submissions

The purpose of this PR is to facilitate jobs using the iRODS CSI driver. Adding the full path to each input file will allow us to bind a directory to a FUSE mount pointing to `/iplant` or `/iplant/home` into the container and adjust the input file or folder paths accordingly. In the case of a pipeline, the paths don't need to be modified (because they refer to paths relative to the current working directory). Because of this, relative paths should not be adjusted when building the command line.

The `type` parameter currently isn't used, but I added it in case it became necessary in the future. (There was a period of time when I thought it was going to be necessary for this change, but we found an alternate solution.)
