### PR TITLE
CORE-1216: update analysis listings in order to deprecate the `app_di…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.5"]
+                 [org.cyverse/common-swagger-api "3.0.6"]
                  [org.cyverse/cyverse-groups-client "0.1.5"]
                  [org.cyverse/permissions-client "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]

--- a/src/apps/service/apps/jobs.clj
+++ b/src/apps/service/apps/jobs.clj
@@ -42,10 +42,9 @@
 (defn- format-job-for-status-update
   [apps-client {job-id :id user-id :user_id}]
   (let [job        (jp/get-job-by-id job-id)
-        app-tables (.loadAppTables apps-client [job])
         rep-steps  (jp/list-representative-job-steps [job-id])
         rep-steps  (group-by (some-fn :parent_id :job_id) rep-steps)]
-    (assoc (listings/format-job apps-client nil app-tables rep-steps job) :user_id user-id)))
+    (assoc (listings/format-job apps-client nil rep-steps job) :user_id user-id)))
 
 (defn- send-job-status-update
   [apps-client {prev-status :status :as original-job} {step-type :job_type :as job-step}]


### PR DESCRIPTION
…sabled` field

Obtaining the value of the `app_disabled` field for analysis that run in Tapis requires users to authenticate to Tapis. This produces some inconsistent behavior because authentication is required only if one of the analyses in the current page of the listing happens to be a Tapis analysis. We're deprecating this field and updating the endpoints to always return `false` in this field.
