### PR TITLE
CORE-1217: switched to a newer version of org.cyverse/mescal

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.cyverse/clojure-commons "3.0.4"]
                  [org.cyverse/debug-utils "2.8.0"]
                  [org.cyverse/kameleon "3.0.4"]
-                 [org.cyverse/mescal "3.1.3"]
+                 [org.cyverse/mescal "3.1.4"]
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]


### PR DESCRIPTION
This is just a dependency update. I'm going to merge it immediately.