### PR TITLE
CORE-1221: removed a now unnecessary call to org.postgresql.jdbc.PgAr…

### DIFF
--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -76,7 +76,7 @@
   [rep-steps job]
   (remove-nil-vals
    (assoc (format-base-job job)
-          :external_ids     (vec (.getArray (:external_ids job)))
+          :external_ids     (:external_ids job)
           :interactive_urls (interactive-urls job rep-steps))))
 
 ;; The `:app_disabled` field is now deprecated and always returns `false`.


### PR DESCRIPTION
…ray.getArray

There was a lingering call to `org.postgresql.jdbc.PgArray.getArray` that I missed after I added the `extend-protocol` statement in `apps.persistence.app-listings`, and it was causing an error.