### PR TITLE
Update kameleon version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "3.0.6"]
                  [org.cyverse/debug-utils "2.8.1"]
-                 [org.cyverse/kameleon "3.0.4"]
+                 [org.cyverse/kameleon "3.0.6"]
                  [org.cyverse/mescal "3.1.5"]
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.cyverse/authy "2.8.0"]
                  [org.cyverse/clojure-commons "3.0.6"]
                  [org.cyverse/debug-utils "2.8.1"]
-                 [org.cyverse/kameleon "3.0.6"]
+                 [org.cyverse/kameleon "3.0.5"]
                  [org.cyverse/mescal "3.1.5"]
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]


### PR DESCRIPTION
Updated from 3.0.4 to 3.0.6.
it was 3.0.5 in [project.clj](https://github.com/cyverse-de/kameleon/compare/10d0dc6cfc7a...0e740123fa39). Does that mean it wasn't updated before?