### PR TITLE
CORE-1416: improve analysis listing performance

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-swagger-api "3.1.0"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
-                 [org.cyverse/permissions-client "2.8.1"]
+                 [org.cyverse/permissions-client "2.8.2"]
                  [org.cyverse/service-logging "2.8.2"]
                  [org.cyverse/event-messages "0.0.1"]
                  [org.flatland/ordered "1.5.9"]

--- a/src/apps/clients/data_info.clj
+++ b/src/apps/clients/data_info.clj
@@ -63,7 +63,8 @@
   (->> (slurp (get-file-contents user path))
        (string/split-lines)
        (remove empty?)
-       (drop 1)))
+       (drop 1)
+       (mapv string/trim)))
 
 (defn create-directory
   [user path]

--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -181,9 +181,10 @@
 (def unshare-tool (partial unshare-resource (rt-tool)))
 
 (defn- get-public-resource-ids [resource-type]
-  (->> (pc/get-subject-permissions-for-resource-type (client) "group" (ipg/grouper-user-group-id) resource-type false)
+  (->> (pc/get-abbreviated-subject-permissions-for-resource-type
+        (client) "group" (ipg/grouper-user-group-id) resource-type false)
        :permissions
-       (map (comp uuidify :name :resource))
+       (map (comp uuidify :resource_name))
        set))
 
 (def get-public-app-ids (partial get-public-resource-ids "app"))

--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -31,6 +31,11 @@
   [perms]
   (into {} (map (juxt (comp uuidify :name :resource) :permission_level) perms)))
 
+(defn- group-abbreviated-permissions
+  "Groups abbreviated permissions by resource ID. The resource ID must be a UUID."
+  [perms]
+  (into {} (map (juxt (comp uuidify :resource_name) :permission_level) perms)))
+
 (defn extract-error-message
   [body]
   ((some-fn :reason :message) (service/parse-json body)))
@@ -43,18 +48,18 @@
 (def register-private-analysis (partial register-private-resource (rt-analysis)))
 (def register-private-tool (partial register-private-resource (rt-tool)))
 
-(defn- filter-perms-response
+(defn- filter-abbreviated-perms-response
   [response filter-fn]
-  (group-permissions (filter filter-fn (:permissions response))))
+  (group-abbreviated-permissions (filter filter-fn (:permissions response))))
 
 (defn- load-resource-permissions*
   ([resource-type user filter-fn]
-   (filter-perms-response
-    (pc/get-subject-permissions-for-resource-type (client) "user" user resource-type true)
+   (filter-abbreviated-perms-response
+    (pc/get-abbreviated-subject-permissions-for-resource-type (client) "user" user resource-type true)
     filter-fn))
   ([resource-type user min-level filter-fn]
-   (filter-perms-response
-    (pc/get-subject-permissions-for-resource-type (client) "user" user resource-type true min-level)
+   (filter-abbreviated-perms-response
+    (pc/get-abbreviated-subject-permissions-for-resource-type (client) "user" user resource-type true min-level)
     filter-fn)))
 
 (defn- resource-id-filter

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -673,7 +673,7 @@
                             (h/where [:= :p.id :c.parent_id]))])))
 
 (defn- representative-job-ids-query
-  "Returns a query that obtains the ID, parent ID, and representative job ID of every job in the related_job_ids query,
+  "Returns a query that obtains the ID, parent ID, and representative job ID of every job in the related-job-ids-alias query,
   which should be available as a CTE. The representative job ID is the job ID whose steps represent the steps of every
   job in a batch. For individual jobs, the representative job ID is the job ID itself. For batch jobs, the
   representative job ID is the ID of any of the child jobs in the batch."

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -688,8 +688,8 @@
                        (h/where [:= :c.parent_id :p.id])
                        (h/limit 1))
                    :representative_id])
-        (h/from [:related_job_ids :p])
-        (h/where [:in :id (-> (h/select :id) (h/from :batch_parent_job_ids))]))]})
+        (h/from [related-job-ids-alias :p])
+        (h/where [:in :id (-> (h/select :id) (h/from batch-parent-job-ids-alias))]))]})
 
 (defn list-representative-job-steps-query
   [job-ids]

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -650,24 +650,6 @@
           (where {:job_id job-id})
           (order :step_number)))
 
-(defn- child-job-subselect
-  [job-ids]
-  (subselect :jobs
-             (fields :id)
-             (where {:parent_id [in job-ids]})
-             (limit 1)))
-
-(defn list-representative-job-steps
-  "Lists all of the job steps in a standalone job or all of the steps of one of the jobs in an HT batch. The purpose
-   of this function is to ensure that steps of every job type that are used in a job are listed. The analysis listing
-   code uses this function to determine whether or not a job can be shared."
-  [job-ids]
-  (select (job-step-base-query)
-          (join :inner [:jobs :j] {:s.job_id :j.id})
-          (fields :j.parent_id)
-          (where (or {:job_id [in job-ids]}
-                     {:job_id [in (child-job-subselect job-ids)]}))))
-
 (defn- leaf-job-ids
   [job-ids]
   (let [job-ids (db/sql-array "uuid" job-ids)]
@@ -694,7 +676,10 @@
               [:job_types :t] [:= :s.job_type_id :t.id])
       hsql/format))
 
-(defn list-representative-job-steps*
+(defn list-representative-job-steps
+  "Lists all of the job steps in a standalone job or all of the steps of one of the jobs in an HT batch. The purpose
+   of this function is to ensure that steps of every job type that are used in a job are listed. The analysis listing
+   code uses this function to determine whether or not a job can be shared."
   [job-ids]
   (db/with-transaction [tx]
     (jdbc/query tx (list-representative-job-steps-query job-ids))))


### PR DESCRIPTION
This PR improves the performance of two components of analysis listing:

- listing permissions for all analyses that a user may access.
- listing representative job steps for the analyses in the listing

For the time being, the permissions listing improvement is achieved by eliminating some of the unnecessary data from the permission listing. In one case where the timeout was occurring, the user had access to more than 15000 analyses. Serializing and deserializing that many permissions was taking a significant amount of time, so a new endpoint was created for an abbreviated permission listing that omits some of the data that wasn't being used in this case. This change shortened the response time by a little more than a second in most cases.

After the database merge is complete, we're probably going to want to refactor this code yet again in order to combine the analysis listing with the permission lookup. That should save a significant amount of time as well.

The improvement to the representative job steps listing was achieved by refactoring the database query. The new database query has the potential to return more rows than we actually need, but this won't do any harm because this query is never used to determine which analyses (or steps) a user sees.

There is still some room for improvement. For example, the code to obtain the status information for each batch takes about a tenth of a second for each batch in the listing, which can slow things down quite a bit. Combining this into the query itself is likely to help a little bit. I think that we've made a big enough improvement to prevent most response timeouts for analysis listings for the time being, though. We should be able to safely wait until we have more time to implement additional improvements.