### PR TITLE
CORE-1461 Users unable to delete multiple analyses

### DIFF
--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -64,7 +64,7 @@
 
 (defn- resource-id-filter
   [resource-ids]
-  (comp (set resource-ids) uuidify :name :resource))
+  (comp (set resource-ids) uuidify :resource_name))
 
 (defn- load-resource-permissions
   ([resource-type user]


### PR DESCRIPTION
For CORE-1416, the abbreviated permissions by subject and resource type endpoint was added for performance improvements.  This resulted in the response body from the permissions service changing to a shorter, flatter JSON object.  The resource name is no longer nested in `resource.name`, it's in `resource_name`.  The `resource-id-filter` function just needed to be updated to match this new model.

I tested deleting multiple analyses and that's now working.  The CORE-1416 change was mostly for speeding up the analysis listing performance so I checked that as well and it seems to still work.