### PR TITLE
CORE-1489: be smarter about fetching docker registry authentication information

### DIFF
--- a/src/apps/containers.clj
+++ b/src/apps/containers.clj
@@ -9,7 +9,7 @@
                                           ports
                                           data-containers
                                           interapps-proxy-settings]]
-        [apps.persistence.docker-registries :only [get-registry]]
+        [apps.persistence.docker-registries :only [get-registry-from-image]]
         [apps.persistence.tools :only [update-tool]]
         [apps.util.assertions :only [assert-not-nil]]
         [apps.util.conversions :only [remove-nil-vals remove-empty-vals]]
@@ -32,8 +32,7 @@
                     (json/encode (select-keys registry [:username :password])))))
 
 (defn- auth-info [image-name]
-  (let [registry-name (string/replace image-name #"/?(?!.*/).*$" "")
-        registry (get-registry registry-name)]
+  (let [registry (get-registry-from-image image-name)]
     (when registry
       (encode-auth registry))))
 

--- a/src/apps/persistence/docker_registries.clj
+++ b/src/apps/persistence/docker_registries.clj
@@ -2,7 +2,8 @@
   (:use [apps.persistence.entities :only [docker-registries]]
         [apps.util.db :only [transaction]]
         [korma.core :exclude [update]])
-  (:require [korma.core :as sql]))
+  (:require [korma.core :as sql]
+            [clojure.string :as string]))
 
 (defn get-registries
   []
@@ -12,6 +13,14 @@
   [name]
   (first (select docker-registries
                  (where {:name name}))))
+
+(defn get-registry-from-image
+  [image-name]
+  (let [parts (string/split image-name #"/")]
+    (loop [n (count parts)]
+      (if-let [reg (get-registry (string/join "/" (take n parts)))]
+        reg
+        (recur (- n 1))))))
 
 (defn add-registry
   [name username password]

--- a/src/apps/persistence/docker_registries.clj
+++ b/src/apps/persistence/docker_registries.clj
@@ -18,9 +18,10 @@
   [image-name]
   (let [parts (string/split image-name #"/")]
     (loop [n (count parts)]
-      (if-let [reg (get-registry (string/join "/" (take n parts)))]
-        reg
-        (recur (- n 1))))))
+      (when-not (= n 0)
+        (if-let [reg (get-registry (string/join "/" (take n parts)))]
+          reg
+          (recur (- n 1)))))))
 
 (defn add-registry
   [name username password]


### PR DESCRIPTION
Instead of taking everything up to the last slash, split on slashes, then repeatedly check for registry information starting with the full name, then removing slash-separated parts starting from the end. This way, it should work for any slash-separated prefix match.

Would appreciate some extra eyes on this since I'm feeling like I missed something in the logic, but anyway.