### PR TITLE
Comment out status-count query for performance

### DIFF
--- a/src/apps/service/apps/job_listings.clj
+++ b/src/apps/service/apps/job_listings.clj
@@ -110,7 +110,7 @@
         types            (.getJobTypes apps-client)
         jobs             (list-jobs* user search-params types analysis-ids)
         rep-steps        (group-by :job_id (jp/list-representative-job-steps (mapv :id jobs)))
-        status-count     (future (count-job-statuses user params types analysis-ids))]
+        status-count     (future (comment (count-job-statuses user params types analysis-ids)))]
     {:analyses     (mapv (partial format-job apps-client perms rep-steps) jobs)
      :timestamp    (str (System/currentTimeMillis))
      :status-count @status-count


### PR DESCRIPTION
This addition seems to push users with 3k+ analyses over the 20s timeout.  Removing it drops the resp time to roughly 17s.