### PR TITLE
CORE-1558: fix some SQL syntax errors

### DIFF
--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -74,7 +74,7 @@
   (if (seq app-ids)
     (if (and orphans (seq public-app-ids))
       (where query (or {:id [in app-ids]}
-                       (and {:id [not-in (seq public-app-ids)]}
+                       (and {:id [not-in (sequence public-app-ids)]}
                             (get-app-listing-orphaned-condition))))
       (where query {:id [in app-ids]}))
     query))
@@ -115,7 +115,7 @@
       (where (or {:app_category_app.app_category_id
                   [in (get-all-group-ids-subselect app-group-id)]}
                  {:integrator_username username
-                  :id                  [in (seq public-app-ids)]}))))
+                  :id                  [in (sequence public-app-ids)]}))))
 
 (defn- add-public-apps-by-user-where-clause
   "Adds a where clause to an analysis listing query to restrict app results to
@@ -416,9 +416,9 @@
   [query public-app-ids]
   (where query
          (or {:deleted true
-              :id      [in (seq public-app-ids)]}
+              :id      [in (sequence public-app-ids)]}
              (and (get-app-listing-orphaned-condition)
-                  {:id [not-in (seq public-app-ids)]}))))
+                  {:id [not-in (sequence public-app-ids)]}))))
 
 (defn count-deleted-and-orphaned-apps
   "Counts the number of deleted, public apps, plus apps that are not listed under any category."


### PR DESCRIPTION
This problem was occurring because we were passing `nil` to Korma for some SQL `in`
expressions. This causes Korma to produce a statement that says something like
`WHERE some_value IN NULL`, which isn't valid SQL syntax. We had been using Clojure
expressions such as `[in (seq some-array)]` I believe that the intent was to ensure
that the value passed was a sequence, so the expressions should be changed to
something like `[in (sequence some-array)]`.