### PR TITLE
CORE-1506 Update app details endpoint to use latest app version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.2.2"]
+                 [org.cyverse/common-swagger-api "3.2.3-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/permissions-client "2.8.2"]
                  [org.cyverse/service-logging "2.8.2"]

--- a/src/apps/persistence/app_documentation.clj
+++ b/src/apps/persistence/app_documentation.clj
@@ -18,6 +18,7 @@
            (join [:users :editors]
                  {:editors.id :modified_by})
            (fields :app_id
+                   [:app_version_id :version_id]
                    [:value :documentation]
                    :created_on
                    :modified_on

--- a/src/apps/persistence/app_documentation.clj
+++ b/src/apps/persistence/app_documentation.clj
@@ -5,12 +5,12 @@
 
 (defn get-app-references
   "Retrieves references for the given app ID."
-  [app-id]
-  (select app_references (where {:app_id app-id})))
+  [app-version-id]
+  (select app_references (where {:app_version_id app-version-id})))
 
 (defn get-documentation
   "Retrieves documentation details for the given app ID."
-  [app-id]
+  [app-version-id]
   (first
    (select :app_documentation
            (join [:users :creators]
@@ -23,7 +23,7 @@
                    :modified_on
                    [:creators.username :created_by]
                    [:editors.username :modified_by])
-           (where {:app_id app-id}))))
+           (where {:app_version_id app-version-id}))))
 
 (defn add-documentation
   "Inserts an App's documentation into the database."

--- a/src/apps/persistence/app_groups.clj
+++ b/src/apps/persistence/app_groups.clj
@@ -19,12 +19,6 @@
   [workspace-id]
   (select workspace (where (or {:is_public true} {:id workspace-id}))))
 
-(defn get-visible-root-app-group-ids
-  "Gets the list of internal root app group identifiers that are visible to the
-   user with the given workspace identifier."
-  [workspace-id]
-  (map :root_category_id (get-visible-workspaces workspace-id)))
-
 (defn get-app-category
   "Retrieves an App category by its ID."
   [app_group_id]

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -350,17 +350,6 @@
                  {:id [in pre-matched-app-ids]}
                  (get-deployed-component-search-subselect search_term))))))
 
-(defn- add-app-category-where-clause
-  "Adds a where clause to a base App listing query to restrict results to apps
-   in all public groups and groups under the given workspace_id, only if `app-ids` is empty."
-  [base-listing-query workspace_id {:keys [app-ids]}]
-  (if (empty? app-ids)
-    (-> base-listing-query
-        (join :app_category_app {:app_category_app.app_id :app_listing.id})
-        (where {:app_category_app.app_category_id
-                [in (get-public-group-ids-subselect workspace_id)]}))
-    base-listing-query))
-
 (defn count-apps-for-user
   "Counts Apps in all public groups and groups under the given workspace_id.
    If search_term is not empty, results are limited to apps that contain search_term in their name,

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -131,7 +131,7 @@
   (subselect [:app_steps :s]
              (join [:tasks :t] {:s.task_id :t.id})
              (join [:job_types :jt] {:t.job_type_id :jt.id})
-             (where {:s.app_id :app_listing.id
+             (where {:s.app_version_id :app_listing.version_id
                      :jt.name  app-type})))
 
 (defn- add-app-type-where-clause

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -189,7 +189,6 @@
           :wiki_url
           :average_rating
           :total_ratings
-          :is_public
           :step_count
           :tool_count
           :external_app_count

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -179,6 +179,7 @@
           :id
           :name
           :version
+          :version_id
           :lower_case_name
           :description
           :integrator_name

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -179,6 +179,7 @@
   (fields listing-query
           :id
           :name
+          :version
           :lower_case_name
           :description
           :integrator_name

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -105,6 +105,13 @@
   [app-id]
   (assert-not-nil [:app-id app-id] (app-listing/get-app-listing (uuidify app-id))))
 
+(defn get-app-latest-version
+  "Retrieves the latest version field from the app listing view in the database."
+  [app-id]
+  (-> app-id
+      get-app
+      :version_id))
+
 (defn- user-id-subselect [username]
   (subselect :users
              (fields :id)
@@ -260,14 +267,17 @@
 
 (defn get-app-tools
   "Loads information about the tools associated with an app."
-  [app-id]
+  ([app-id]
+   (get-app-tools app-id (get-app-latest-version app-id)))
+  ([app-id version-id]
   (select (get-tool-listing-base-query)
           (join :container_images {:tool_listing.container_images_id :container_images.id})
           (fields [:container_images.name       :image_name]
                   [:container_images.tag        :image_tag]
                   [:container_images.url        :image_url]
                   [:container_images.deprecated :deprecated])
-          (where {:app_id app-id})))
+          (where {:app_id         app-id
+                  :app_version_id version-id}))))
 
 (defn get-app-notification-types
   "Loads information about the notification types to use for an app."

--- a/src/apps/persistence/app_search.clj
+++ b/src/apps/persistence/app_search.clj
@@ -32,8 +32,8 @@
 (defn- external-step-subselect
   []
   (subselect [:app_steps :es]
-             (where {:es.app_id  :a.id
-                     :es.task_id nil})))
+             (where {:es.app_version_id :v.id
+                     :es.task_id        nil})))
 
 (defn- add-agave-pipeline-where-clause
   [q {agave-enabled? :agave-enabled :or {agave-enaled? "false"}}]
@@ -71,7 +71,7 @@
    non-administrative app listings."
   [q {admin? :admin}]
   (if-not admin?
-    (where q {:a.deleted         false
+    (where q {:v.deleted         false
               :i.integrator_name [not= c/internal-app-integrator]})
     q))
 
@@ -79,8 +79,9 @@
   "Gets an app search select query. This function returns only a list of matching app IDs."
   [search-term query-opts]
   (as-> (select* [:apps :a]) q
-    (join q [:integration_data :i] {:a.integration_data_id :i.id})
-    (join q [:app_steps :s] {:a.id :s.app_id})
+    (join q [:app_versions :v] {:a.id :v.app_id})
+    (join q [:integration_data :i] {:v.integration_data_id :i.id})
+    (join q [:app_steps :s] {:v.id :s.app_version_id})
     (join q [:tasks :t] {:s.task_id :t.id})
     (join q [:tools :tool] {:t.tool_id :tool.id})
     (join q [:job_types :jt] {:t.job_type_id :jt.id})

--- a/src/apps/persistence/entities.clj
+++ b/src/apps/persistence/entities.clj
@@ -1,7 +1,7 @@
 (ns apps.persistence.entities
   (:use [korma.core :exclude [update]]))
 
-(declare users collaborator requestor workspace app_categories apps app_references integration_data
+(declare users collaborator requestor workspace app_categories apps app_versions app_steps app_references integration_data
          tools tool_test_data_files output_mapping input_mapping tasks job_types inputs outputs
          task_parameters info_type data_formats multiplicity parameter_groups parameters
          parameter_values parameter_types value_type validation_rules validation_rule_arguments
@@ -37,15 +37,19 @@
 
 ;; An app.
 (defentity apps
-  (belongs-to integration_data)
+  (has-many app_versions {:fk :app_id})
   (many-to-many app_categories :app_category_app
                 {:lfk :app_id
                  :rfk :app_category_id})
-  (many-to-many tasks :app_steps
-                {:lfk :app_id
-                 :rfk :task_id})
-  (has-many app_references {:fk :app_id})
   (has-many ratings {:fk :app_id}))
+
+;; Versions of an app.
+(defentity app_versions
+  (belongs-to integration_data)
+  (has-many app_references {:fk :app_version_id})
+  (many-to-many tasks :app_steps
+                {:lfk :app_version_id
+                 :rfk :task_id}))
 
 ;; References associated with an app.
 (defentity app_references)
@@ -55,7 +59,7 @@
 
 ;; Information about who integrated an app or a deployed component.
 (defentity integration_data
-  (has-many apps)
+  (has-many app_versions)
   (has-many tools))
 
 (defentity data-containers
@@ -236,11 +240,6 @@
 (defentity ratings
   (belongs-to users {:fk :user_id})
   (belongs-to apps {:fk :app_id}))
-
-;; A view for listing rating information.
-(defentity rating_listing
-  (belongs-to apps {:fk :app_id})
-  (belongs-to users {:fk :user_id}))
 
 ;; Database version entries.
 (defentity version

--- a/src/apps/service/apps/de/job_view.clj
+++ b/src/apps/service/apps/de/job_view.clj
@@ -91,11 +91,11 @@
   (mapv (partial format-group user name-prefix include-hidden-params? step) (get-groups (:id step))))
 
 (defn- get-steps
-  [app-id]
+  [app-version-id]
   (select [:app_steps :s]
           (join :inner [:tasks :t] {:s.task_id :t.id})
           (fields :s.id [:s.step :step_number] :s.task_id [:t.name :task_name])
-          (where {:app_id app-id})
+          (where {:app_version_id app-version-id})
           (order :step)))
 
 (defn- format-steps
@@ -105,8 +105,8 @@
     (doall (mapcat (fn [step] (format-groups user (group-name-prefix step) include-hidden-params? step)) app-steps))))
 
 (defn- format-app
-  [user {app-id :id name :name :as app} include-hidden-params?]
-  (let [app-steps           (get-steps app-id)
+  [user {:keys [name version_id] :as app} include-hidden-params?]
+  (let [app-steps           (get-steps version_id)
         limit-check-results (limits/load-limit-check-results user)]
     (-> (select-keys app [:id :name :description :disabled :deleted])
         (assoc :label name

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -1,6 +1,5 @@
 (ns apps.service.apps.de.listings
   (:use [apps.constants :only [de-system-id executable-tool-type]]
-        [apps.persistence.app-documentation :only [get-documentation]]
         [apps.persistence.app-groups]
         [apps.persistence.app-listing]
         [apps.persistence.entities]
@@ -518,17 +517,19 @@
 
 (defn- load-app-details
   "Retrieves the details for a single app."
-  [app-id]
+  [app-id app-version-id]
   (assert-not-nil [:app-id app-id]
                   (first (select apps
-                                 (with app_references)
-                                 (with integration_data)
+                                 (with app_versions
+                                       (with app_references)
+                                       (with integration_data)
+                                       (where {:app_versions.id app-version-id}))
                                  (where {:id app-id})))))
 
 (defn- format-wiki-url
   "CORE-6510: Remove the wiki_url from app details responses if the App has documentation saved."
   [{:keys [id wiki_url] :as app}]
-  (assoc app :wiki_url (if (get-documentation id) nil wiki_url)))
+  (assoc app :wiki_url (if (docs/has-docs? id) nil wiki_url)))
 
 (defn- format-app-hierarchies
   [{app-id :id :as app} username]
@@ -574,13 +575,25 @@
 (defn- format-app-details
   "Formats information for the get-app-details service."
   [username details tools admin?]
-  (let [app-id (:id details)]
+  (let [app-id                       (:id details)
+        {version-id :id
+         :keys      [app_references]
+         :as        version-details} (-> details :app_versions first)]
     (-> details
-        (select-keys [:id :integration_date :edited_date :deleted :disabled :wiki_url
-                      :integrator_name :integrator_email])
+        (select-keys [:id :wiki_url])
+        (merge (select-keys
+                 version-details
+                 [:version
+                  :deleted
+                  :disabled
+                  :edited_date
+                  :integration_date
+                  :integrator_name
+                  :integrator_email]))
         (assoc :name                 (:name details "")
                :description          (:description details "")
-               :references           (map :reference_text (:app_references details))
+               :version_id           version-id
+               :references           (map :reference_text app_references)
                :tools                (map format-app-tool tools)
                :job_stats            (format-app-details-job-stats (str app-id) nil admin?)
                :extra                (format-app-extra-info app-id admin?)
@@ -594,11 +607,13 @@
 ;; This function was split from `get-app-details` to provide a way for administrative endopints to skip permission
 ;; checks without including the app stat information.
 (defn- get-app-details*
-  [username app-id admin?]
-  (let [details (load-app-details app-id)
-        tools   (get-app-tools app-id)]
-    (->> (format-app-details username details tools admin?)
-         (remove-nil-vals))))
+  ([username app-id admin?]
+   (get-app-details* username app-id (amp/get-app-latest-version app-id) admin?))
+  ([username app-id app-version-id admin?]
+   (let [details (load-app-details app-id app-version-id)
+         tools   (get-app-tools app-id app-version-id)]
+     (->> (format-app-details username details tools admin?)
+          (remove-nil-vals)))))
 
 ;; FIXME: remove the code to bypass the permission checks for admin users when we have a better
 ;; way to implement this.


### PR DESCRIPTION
This PR will update the app details endpoint to use info from the latest app version, which includes updates to allow the `GET /apps/{system-id}/{app-id}/documentation` endpoint to use docs from the latest app version.

This PR is on top of #237, so only the last 2 commits need to be reviewed for this one.

Summary of changes:

* Added `app_versions` table references to `apps.persistence.entities` and removed an unused `rating_listing` entity.
* Added `apps.persistence.app-metadata/get-app-latest-version`
* Refactored a few functions to use `apps.service.apps.de.docs/has-docs?` so that it can check for docs in the latest app version.
* Removed unused `apps.service.apps.de.docs/upsert-app-docs` function.
* Updated functions for getting app docs and references to use an app version ID.
* Added latest app version ID to app documentation responses.