### PR TITLE
Update common-swagger-api to 3.2.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.2.2"]
+                 [org.cyverse/common-swagger-api "3.2.3"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/permissions-client "2.8.2"]
                  [org.cyverse/service-logging "2.8.2"]


### PR DESCRIPTION
Updates the version of common-swagger-api. This should enable analysis submissions to include the max_cpu_cores field. That doesn't mean the service does anything with the field yet, that's still being looked at.