### PR TITLE
CORE-1745 Add default_max_cpu_cores to relaunch-info responses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.3.2"]
+                 [org.cyverse/common-swagger-api "3.3.3"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/otel "0.2.5"]
                  [org.cyverse/permissions-client "2.8.2"]

--- a/src/apps/service/apps/jobs/params.clj
+++ b/src/apps/service/apps/jobs/params.clj
@@ -155,11 +155,13 @@
                                       first)]
     (merge step-reqs
            (-> requested-step-reqs
-               (select-keys [:min_memory_limit
+               (select-keys [:max_cpu_cores
                              :min_cpu_cores
+                             :min_memory_limit
                              :min_disk_space])
-               (sets/rename-keys {:min_memory_limit :default_memory
+               (sets/rename-keys {:max_cpu_cores    :default_max_cpu_cores
                                   :min_cpu_cores    :default_cpu_cores
+                                  :min_memory_limit :default_memory
                                   :min_disk_space   :default_disk_space})))))
 
 (defn- update-resources-reqs


### PR DESCRIPTION
This PR will add a `default_max_cpu_cores` field to `relaunch-info` endpoint responses, populated from the user's original `max_cpu_cores` request.