### PR TITLE
CORE-1749 Fix admin integration-data update endpoint for app versions

### DIFF
--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -211,9 +211,9 @@
       get-integration-data-by-app-version-id))
 
 (defn update-app-integration-data [app-id integration-data-id]
-  (-> (update* :apps)
+  (-> (update* :app_versions)
       (set-fields {:integration_data_id integration-data-id})
-      (where {:id app-id})
+      (where {:id (subselect app_listing (fields :version_id) (where {:id app-id}))})
       (sql/update)))
 
 (defn update-tool-integration-data [tool-id integration-data-id]


### PR DESCRIPTION
This PR will update the `PUT /admin/apps/:system-id/:app-id/integration-data/:integration-data-id` endpoint so that it will update an app's latest version.

This should have been part of the changes for #246.