### PR TITLE
CORE-1750 Fix admin integration-data delete endpoint for app versions

### DIFF
--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -247,10 +247,12 @@
                 select)))
 
 (defn get-app-ids-by-integration-data-id [integration-data-id]
-  (mapv :id (-> (select* :apps)
-                (fields :id)
-                (where {:integration_data_id integration-data-id})
-                select)))
+  (mapv :app_id
+        (-> (select* :app_versions)
+            (modifier "DISTINCT")
+            (fields :app_id)
+            (where {:integration_data_id integration-data-id})
+            select)))
 
 (defn delete-integration-data [integration-data-id]
   (-> (delete* :integration_data)


### PR DESCRIPTION
This PR will fix the `DELETE /admin/integration-data/:integration-data-id` endpoint so that it will check the `app_versions` table for integration data in use by apps.

This should have been part of the changes for #246.