### PR TITLE
CORE-1534 Add admin app version endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.4.0"]
+                 [org.cyverse/common-swagger-api "3.4.1-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/otel "0.2.5"]
                  [org.cyverse/permissions-client "2.8.2"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.4.1-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.4.1"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/otel "0.2.5"]
                  [org.cyverse/permissions-client "2.8.2"]

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -357,6 +357,38 @@
       (where {:app_version_id version-id})
       select))
 
+(defn task-ids-for-app-version
+  "Get the list of task IDs associated with an app version."
+  [app-version-id]
+  (map :task_id
+       (select [:app_steps :step]
+               (fields :step.task_id)
+               (where {:step.app_version_id app-version-id}))))
+
+(defn task-ids-for-app
+  "Get the list of task IDs associated with an app."
+  [app-id]
+  (map :task_id
+       (select [:app_steps :step]
+               (fields :step.task_id)
+               (where {:step.app_version_id
+                       [in (subselect app_versions
+                                      (fields :id)
+                                      (where {:app_id app-id}))]}))))
+
+(defn get-task-tools
+  "Loads information about the tools associated with tasks with the given IDs."
+  [task-ids]
+  (-> (get-tool-listing-base-query)
+      (join :container_images {:tool_listing.container_images_id :container_images.id})
+      (fields [:container_images.name :image_name]
+              [:container_images.tag :image_tag]
+              [:container_images.url :image_url]
+              [:container_images.deprecated :deprecated])
+      (join :tasks {:tasks.tool_id :tool_listing.tool_id})
+      (where {:tasks.id [in task-ids]})
+      select))
+
 (defn get-app-notification-types
   "Loads information about the notification types to use for an app version."
   [app-version-id]

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -341,6 +341,15 @@
                                                      :deleted false}))]})
       select))
 
+(defn get-all-app-tools
+  "Loads information about the tools associated with all versions of an app."
+  [app-id]
+  (-> (get-app-tools-base-query app-id)
+      (where {:app_version_id [in (subselect app_versions
+                                             (fields :id)
+                                             (where {:app_id app-id}))]})
+      select))
+
 (defn get-app-version-tools
   "Loads information about the tools associated with a specific app version."
   [app-id version-id]

--- a/src/apps/routes/admin/apps.clj
+++ b/src/apps/routes/admin/apps.clj
@@ -132,6 +132,17 @@
     (context "/versions/:version-id" []
              :path-params [version-id :- apps-schema/AppVersionIdParam]
 
+             (GET "/details" []
+                  :query [params SecuredQueryParams]
+                  :return schema/AdminAppDetails
+                  :summary schema/AppVersionDetailsSummary
+                  :description schema/AppVersionDetailsDocs
+                  (ok (coerce! schema/AdminAppDetails
+                               (apps/admin-get-app-version-details current-user
+                                                                   system-id
+                                                                   app-id
+                                                                   version-id))))
+
              (PATCH "/documentation" []
                     :query [params SecuredQueryParams]
                     :body [body apps-schema/AppDocumentationRequest]

--- a/src/apps/routes/admin/apps.clj
+++ b/src/apps/routes/admin/apps.clj
@@ -132,6 +132,18 @@
     (context "/versions/:version-id" []
              :path-params [version-id :- apps-schema/AppVersionIdParam]
 
+             (PATCH "/" []
+                    :query [params SecuredQueryParams]
+                    :body [body schema/AdminAppPatchRequest]
+                    :return schema/AdminAppDetails
+                    :summary schema/AdminAppVersionPatchSummary
+                    :description-file "docs/apps/admin/app-label-update.md"
+                    (ok (coerce! schema/AdminAppDetails
+                                 (apps/admin-update-app current-user
+                                                        system-id
+                                                        (assoc body :id         app-id
+                                                                    :version_id version-id)))))
+
              (GET "/details" []
                   :query [params SecuredQueryParams]
                   :return schema/AdminAppDetails

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -326,10 +326,12 @@
   (.adminDeleteApp (get-apps-client user) system-id app-id))
 
 (defn admin-update-app
-  [user system-id body]
+  [user system-id {app-id :id app-version-id :version_id :as body}]
   (let [apps-client (get-apps-client user)]
     (.adminUpdateApp apps-client system-id body)
-    (.getAppDetails apps-client system-id (:id body) true)))
+    (if app-version-id
+      (.getAppVersionDetails apps-client system-id app-id app-version-id true)
+      (.getAppDetails apps-client system-id app-id true))))
 
 (defn admin-bless-app
   [user system-id app-id]

--- a/src/apps/service/apps/de/admin.clj
+++ b/src/apps/service/apps/de/admin.clj
@@ -92,9 +92,9 @@
 (defn- update-app-details
   "Updates high-level details and labels in an App, including deleted and disabled flags in the
    database."
-  [{app-id :id :keys [references groups extra] :as app}]
+  [{app-id :id :keys [version_id references groups extra] :as app}]
   (persistence/update-app app)
-  (let [version-id (persistence/get-app-latest-version app-id)
+  (let [version-id (or version_id (persistence/get-app-latest-version app-id))
         app (assoc app :version_id version-id)]
     (persistence/update-app-version app)
     (when-not (empty? references)

--- a/src/apps/service/apps/de/edit.clj
+++ b/src/apps/service/apps/de/edit.clj
@@ -231,7 +231,7 @@
          (assoc :version_id version-id
                 :versions   (persistence/list-app-versions app-id)
                 :references (map :reference_text app_references)
-                :tools      (map format-app-tool (persistence/get-app-tools (:id app) version-id))
+                :tools      (map format-app-tool (persistence/get-app-version-tools (:id app) version-id))
                 :groups     (map format-group (:parameter_groups task))
                 :system_id  c/system-id)
          (dissoc :app_versions)))))

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -603,7 +603,7 @@
                       :is_favorite])
         (assoc :name                 (:name details "")
                :description          (:description details "")
-               :versions             (amp/list-app-versions app-id)
+               :versions             (amp/list-app-versions app-id admin?)
                :references           (map :reference_text app-references)
                :tools                (map format-app-tool tools)
                :job_stats            (format-app-details-job-stats (str app-id) nil admin?)

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -627,7 +627,7 @@
                                                  (workspace-favorites-app-category-index)
                                                  app-id
                                                  app-version-id)
-         tools          (get-app-tools app-id app-version-id)
+         tools          (amp/get-app-version-tools app-id app-version-id)
          app-references (app-docs-db/get-app-references app-version-id)
          perms          (perms-client/load-app-permissions shortUsername)
          public-app-ids (perms-client/get-public-app-ids)

--- a/src/apps/service/apps/de/metadata.clj
+++ b/src/apps/service/apps/de/metadata.clj
@@ -7,8 +7,7 @@
                                             decategorize-app
                                             get-app-subcategory-id
                                             remove-app-from-category]]
-        [apps.service.apps.de.validation :only [app-publishable?
-                                                validate-app-existence
+        [apps.service.apps.de.validation :only [validate-app-existence
                                                 validate-app-version-existence
                                                 verify-app-permission]]
         [apps.util.db :only [transaction]]

--- a/src/apps/service/apps/de/validation.clj
+++ b/src/apps/service/apps/de/validation.clj
@@ -1,6 +1,7 @@
 (ns apps.service.apps.de.validation
   (:use [apps.persistence.app-metadata :only [get-app
                                               get-app-tools
+                                              get-app-version-tools
                                               get-app-version
                                               list-duplicate-apps
                                               list-duplicate-apps-by-id
@@ -30,7 +31,8 @@
   (map :id
        (select :app_versions
                (fields :id)
-               (where {:app_id app-id}))))
+               (where {:app_id  app-id
+                       :deleted false}))))
 
 (defn- task-ids-for-app-version
   "Get the list of task IDs associated with an app version."
@@ -83,7 +85,7 @@
   [username admin? public-app-ids app-id app-version-id]
   (let [task-ids            (task-ids-for-app-version app-version-id)
         unrunnable-tasks    (list-unrunnable-tasks task-ids)
-        tools               (get-app-tools app-id app-version-id)
+        tools               (get-app-version-tools app-id app-version-id)
         unpublishable-tools (when-not admin? (get-unpublishable-tools username tools))
         deprecated-tools    (filter :deprecated tools)
         private-apps        (private-apps-for task-ids public-app-ids)]

--- a/src/apps/service/apps/de/validation.clj
+++ b/src/apps/service/apps/de/validation.clj
@@ -5,7 +5,8 @@
                                               get-app-version
                                               list-duplicate-apps
                                               list-duplicate-apps-by-id
-                                              parameter-types-for-tool-type]]
+                                              parameter-types-for-tool-type
+                                              task-ids-for-app-version]]
         [apps.persistence.entities :only [tools tool_types]]
         [clojure-commons.exception-util :only [forbidden exists]]
         [korma.core :exclude [update]]
@@ -13,6 +14,7 @@
   (:require [apps.clients.permissions :as perms-client]
             [apps.service.apps.de.permissions :as perms]
             [apps.util.config :as config]
+            [clojure-commons.exception-util :as ex-util]
             [clojure.string :as string]))
 
 (defn validate-app-existence
@@ -33,14 +35,6 @@
                (fields :id)
                (where {:app_id  app-id
                        :deleted false}))))
-
-(defn- task-ids-for-app-version
-  "Get the list of task IDs associated with an app version."
-  [app-version-id]
-  (map :task_id
-       (select [:app_steps :step]
-               (fields :step.task_id)
-               (where {:step.app_version_id app-version-id}))))
 
 (defn- private-apps-for
   "Finds private single-step apps for a list of task IDs."
@@ -78,14 +72,12 @@
     (->> (remove (comp public-tool-ids :id) tools)
          (remove-publishable-tools username))))
 
-(defn- app-version-publishable?
-  "Determines whether or not an app version can be published.
+(defn app-tasks-and-tools-publishable?
+  "Determines whether an app's tools and tasks can be published.
    Returns a flag indicating whether the app version is publishable
    along with the reason the app version isn't publishable if it's not."
-  [username admin? public-app-ids app-id app-version-id]
-  (let [task-ids            (task-ids-for-app-version app-version-id)
-        unrunnable-tasks    (list-unrunnable-tasks task-ids)
-        tools               (get-app-version-tools app-id app-version-id)
+  [username admin? public-app-ids task-ids tools]
+  (let [unrunnable-tasks    (list-unrunnable-tasks task-ids)
         unpublishable-tools (when-not admin? (get-unpublishable-tools username tools))
         deprecated-tools    (filter :deprecated tools)
         private-apps        (private-apps-for task-ids public-app-ids)]
@@ -96,6 +88,15 @@
           (= 1 (count task-ids))    [true]
           (seq private-apps)        [false "contains private apps" private-apps]
           :else                     [true])))
+
+(defn- app-version-publishable?
+  "Determines whether an app version can be published.
+   Returns a flag indicating whether the app version is publishable
+   along with the reason the app version isn't publishable if it's not."
+  [username admin? public-app-ids app-id app-version-id]
+  (let [task-ids            (task-ids-for-app-version app-version-id)
+        tools               (get-app-version-tools app-id app-version-id)]
+    (app-tasks-and-tools-publishable? username admin? public-app-ids task-ids tools)))
 
 (defn app-publishable?
   "Determines whether or not an app can be published.
@@ -130,6 +131,14 @@
         get-registry           (comp first #(string/split % #"/" 2) :image_name)
         in-untrusted-registry? #(not (contains? trusted-registries (get-registry %)))]
     (some (every-pred in-untrusted-registry? private-tool?) (get-app-tools app-id))))
+
+(defn verify-tools-for-public-app
+  "Verifies that a public app will not use the given private or missing tools."
+  [tools err-msg]
+  (let [public-tool-ids (perms-client/get-public-tool-ids)
+        private-tools   (remove (comp public-tool-ids :id) tools)]
+    (when (or (empty? tools) (not-empty private-tools))
+      (throw+ (ex-util/bad-request err-msg :tools private-tools)))))
 
 (defn- verify-app-not-public
   "Verifies that an app has not been made public."


### PR DESCRIPTION
This PR will add admin app version details and update endpoints.

It will also update the sharing endpoint to only share tools in undeleted versions, and the publish endpoints to only validate and publish tools in undeleted versions.

This change now requires admin undelete actions for app versions to ensure tools are not private or missing, and also ensures workflows are using tasks from public apps; and these validation checks are also now in the create version endpoints for public apps and pipelines.