### PR TITLE
CORE-1808 Return overall_job_type field in app listings and details

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.4.1"]
+                 [org.cyverse/common-swagger-api "3.4.2"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/otel "0.2.5"]
                  [org.cyverse/permissions-client "2.8.2"]

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -298,8 +298,7 @@
                                :reason ""}
                               (catch map? {:keys [reason]}
                                 {:is_valid false
-                                 :reason reason}))
-        app (dissoc app :overall_job_type)]
+                                 :reason reason}))]
     (assoc app :pipeline_eligibility pipeline_eligibility)))
 
 (defn- format-app-ratings


### PR DESCRIPTION
Updated the `apps.service.apps.de.listings/format-app-pipeline-eligibility` function to no longer remove the `overall_job_type` field in app listing details.

This will allow the UI to label apps with the `interactive` job type as VICE apps.