### PR TITLE
CORE-1871: fix an error that was occurring when DE administrators app…

### DIFF
--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -512,7 +512,8 @@
         app (-> app
                 (select-keys [:name :description :wiki_url])
                 (remove-nil-vals))]
-    (sql/update apps (set-fields app) (where {:id app-id}))))
+    (when-not (empty? app)
+      (sql/update apps (set-fields app) (where {:id app-id})))))
 
 (defn update-app-version
   "Updates top-level app version info in the database."


### PR DESCRIPTION
…rove app publication requests

The DE admin UI sends an empty request body by default when an administrator approves an app publication request. The simplest option at this time is to update the `apps` service so that it doesn't attempt to update the app if none of the relevant fields are included in the request body.
