### PR TITLE
CORE-1875: fixed the application ofthe ownership filter to job listings

### DIFF
--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -135,8 +135,8 @@
   (if ownership-filter
     (condp = (:value ownership-filter)
       "all"    query
-      "mine"   (where query [:= :j.username username])
-      "theirs" (where query [:not= :j.username username])
+      "mine"   (h/where query [:= :j.username username])
+      "theirs" (h/where query [:not= :j.username username])
       (cxu/bad-request (str "invalid ownership filter value: " (:value ownership-filter))))
     query))
 


### PR DESCRIPTION
This was causing a PostgreSQL error when the ownership filter was included with any of the standard filters in a job listing request. The error no longer occurs after making the change:

![image](https://user-images.githubusercontent.com/415143/220790923-3c2a7d6f-1571-4efe-9d5a-19266936257e.png)
