### PR TITLE
Enable sharing analysis inputs and outputs with groups

### DIFF
--- a/src/apps/clients/async_tasks.clj
+++ b/src/apps/clients/async_tasks.clj
@@ -2,6 +2,7 @@
   (:require [apps.util.config :as config]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
+            [otel.otel :as otel]
             [async-tasks-client.core :as async-tasks-client]))
 
 (defn get-by-id
@@ -34,9 +35,13 @@
 
 (defn run-async-thread
   [async-task-id thread-function prefix]
-  (let [^Runnable task-thread (fn [] (thread-function async-task-id))]
-    (.start (Thread. task-thread (str prefix "-" (string/replace async-task-id #".*/tasks/" "")))))
-  async-task-id)
+  (otel/with-span [outer-span ["run-async-thread" {:kind :producer :attributes {"async-task-id" (str async-task-id)}}]]
+    (let [^Runnable task-thread (fn []
+                                  (with-open [_ (otel/span-scope outer-span)]
+                                    (otel/with-span [s ["async thread" {:kind :consumer :attributes {"async-task-id" (str async-task-id)}}]]
+                                      (thread-function async-task-id))))]
+      (.start (Thread. task-thread (str prefix "-" (string/replace async-task-id #".*/tasks/" "")))))
+    async-task-id))
 
 (defn new-task
   [type user data & [{:keys [timeout] :or {timeout "10m"}}]]

--- a/src/apps/service/apps/jobs/sharing.clj
+++ b/src/apps/service/apps/jobs/sharing.clj
@@ -334,7 +334,7 @@
 
 (defn unshare-jobs
   [apps-client {username :shortUsername} sharing-requests]
-  (otel/with-span [s ["share-jobs"]]
+  (otel/with-span [s ["unshare-jobs"]]
     (-> (async-tasks/new-task "analysis-unsharing" username sharing-requests)
         (async-tasks/run-async-thread unshare-jobs-thread "analysis-unsharing")
         (string/replace #".*/tasks/" "")

--- a/src/apps/service/apps/jobs/sharing.clj
+++ b/src/apps/service/apps/jobs/sharing.clj
@@ -109,10 +109,11 @@
 
 (defn- share-app-for-job
   [apps-client sharer sharee job-id {system-id :system_id app-id :app_id}]
-  (when-not (.hasAppPermission apps-client sharee system-id app-id "read")
-    (let [response (.shareAppWithSubject apps-client false {} sharee system-id app-id "read")]
-      (when-not (:success response)
-        (get-in response [:error :reason] "unable to share app")))))
+  (otel/with-span [s ["share-app-for-job"]]
+    (when-not (.hasAppPermission apps-client sharee system-id app-id "read")
+      (let [response (.shareAppWithSubject apps-client false {} sharee system-id app-id "read")]
+        (when-not (:success response)
+          (get-in response [:error :reason] "unable to share app"))))))
 
 (defn- get-user-from-subject
   [subject]
@@ -141,7 +142,8 @@
 
 (defn- process-child-jobs
   [f job-id]
-  (doall (remove nil? (mapcat f (jp/list-child-jobs job-id)))))
+  (otel/with-span [s ["process-child-jobs"]]
+    (doall (remove nil? (mapcat f (jp/list-child-jobs job-id))))))
 
 (defn- list-job-inputs
   [apps-client {system-id :system_id app-id :app_id app-version-id :app_version_id :as job}]
@@ -153,7 +155,8 @@
 
 (defn- process-job-inputs
   [f apps-client job]
-  (doall (remove nil? (map f (list-job-inputs apps-client job)))))
+  (otel/with-span [s ["process-job-inputs"]]
+    (doall (remove nil? (map f (list-job-inputs apps-client job))))))
 
 (defn- share-analysis
   [job-id sharee level]


### PR DESCRIPTION
The `get-user-from-subject` function is copied from terrain, and other than that it's just using it.

I still need to test this, but reviews are welcome as I do.