### PR TITLE
CORE-1971: manage default memory & CPU limits as configuration values in the apps service instead of hardcoded values in app-exposer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.2"]
-                 [org.cyverse/common-swagger-api "3.4.4-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.4.4"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/otel "0.2.5"]
                  [org.cyverse/permissions-client "2.8.3"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.2"]
-                 [org.cyverse/common-swagger-api "3.4.3"]
+                 [org.cyverse/common-swagger-api "3.4.4-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/otel "0.2.5"]
                  [org.cyverse/permissions-client "2.8.3"]

--- a/src/apps/routes/schemas/tool.clj
+++ b/src/apps/routes/schemas/tool.clj
@@ -9,6 +9,10 @@
   (merge SecuredQueryParams
          schema/PrivateToolDeleteParams))
 
+(defschema ToolDetailsParams
+  (merge SecuredQueryParams
+         schema/ToolDetailsParams))
+
 (defschema ToolUpdateParams
   (merge SecuredQueryParams
          admin-schema/ToolUpdateParams))

--- a/src/apps/routes/tools.clj
+++ b/src/apps/routes/tools.clj
@@ -165,11 +165,11 @@
 
   (GET "/:tool-id" []
     :path-params [tool-id :- schema/ToolIdParam]
-    :query [{:keys [user]} SecuredQueryParams]
+    :query [{:keys [user include-defaults]} ToolDetailsParams]
     :responses schema/ToolDetailsResponses
     :summary schema/ToolDetailsSummary
     :description schema/ToolDetailsDocs
-    (ok (user-get-tool user tool-id)))
+    (ok (user-get-tool user tool-id include-defaults)))
 
   (PATCH "/:tool-id" []
     :path-params [tool-id :- schema/ToolIdParam]
@@ -249,11 +249,11 @@
 
   (GET "/:tool-id" []
     :path-params [tool-id :- schema/ToolIdParam]
-    :query [{:keys [user]} SecuredQueryParams]
+    :query [{:keys [user include-defaults]} ToolDetailsParams]
     :responses admin-schema/ToolDetailsResponses
     :summary schema/ToolDetailsSummary
     :description admin-schema/ToolDetailsDocs
-    (ok (get-tool user tool-id)))
+    (ok (get-tool user tool-id include-defaults)))
 
   (PATCH "/:tool-id" []
     :path-params [tool-id :- schema/ToolIdParam]

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -687,7 +687,7 @@
 (defn- format-task
   [user {:keys [tool_id] :as task}]
   (-> task
-      (assoc :tool (when tool_id (tools/get-tool user tool_id)))
+      (assoc :tool (when tool_id (tools/get-tool user tool_id true)))
       (dissoc :tool_id)
       (update-in [:inputs] (partial map (comp remove-nil-vals format-task-file-param)))
       (update-in [:outputs] (partial map (comp remove-nil-vals format-task-output)))

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -88,10 +88,11 @@
 
 (defn get-tool
   "Obtains a tool by ID."
-  [user tool-id]
+  [user tool-id include-defaults]
   (let [tool           (->> (persistence/get-tool tool-id)
                             (format-tool-listing (perms-client/load-tool-permissions user)
                                                  (perms-client/get-public-tool-ids)))
+        ;; XXX: use include-defaults here
         container      (clojure.set/rename-keys (tool-container-info tool-id) {:ports :container_ports})
         implementation (persistence/get-tool-implementation-details tool-id)]
     (assoc tool
@@ -100,9 +101,9 @@
 
 (defn user-get-tool
   "Obtains tool details for a user."
-  [user tool-id]
+  [user tool-id include-defaults]
   (permissions/check-tool-permissions user "read" [tool-id])
-  (get-tool user tool-id))
+  (get-tool user tool-id include-defaults))
 
 (defn- add-new-tool
   [{:keys [container] :as tool}]
@@ -136,7 +137,7 @@
    (persistence/update-tool tool)
    (when container
      (set-tool-container id overwrite-public container))
-   (get-tool user id)))
+   (get-tool user id false)))
 
 (defn delete-tool
   [tool-id]
@@ -150,7 +151,7 @@
 (defn admin-delete-tool
   "Deletes a tool, as long as it is not in use by any apps."
   [user tool-id]
-  (let [{:keys [name location version]} (get-tool user tool-id)]
+  (let [{:keys [name location version]} (get-tool user tool-id false)]
     (validate-tool-not-used tool-id)
     (log/warn user "deleting tool" tool-id name version "@" location))
   (delete-tool tool-id))
@@ -160,13 +161,13 @@
   (admin-update-tool user false tool)
   (perms-client/make-tool-public id)
   (tool-requests/complete-tool-request id (config/uid-domain) current-user)
-  (get-tool user id))
+  (get-tool user id false))
 
 (defn- validate-tool-for-tool-request
   "Ensures the given tool ID exists, the user has 'own' permission for that tool, the tool is not deprecated,
    and a tool request has not already been submitted for the tool."
   [user tool-id]
-  (let [image (-> (get-tool user tool-id) :container :image)]
+  (let [image (-> (get-tool user tool-id false) :container :image)]
     (permissions/check-tool-permissions user "own" [tool-id])
     (when (:deprecated image)
       (throw+ {:type  :clojure-commons.exception/bad-request-field

--- a/src/apps/tools.clj
+++ b/src/apps/tools.clj
@@ -54,6 +54,14 @@
               :tool_request_status)
       remove-nil-vals))
 
+(defn- format-container-settings
+  [container-settings include-defaults]
+  (if include-defaults
+      (merge {:max_cpu_cores (config/default-cpu-limit)
+              :memory_limit (config/default-memory-limit)}
+             container-settings)
+    container-settings))
+
 (defn- filter-listing-tool-ids
   [all-tool-ids public-tool-ids {:keys [public] :as params}]
   (if (contains? params :public)
@@ -92,8 +100,7 @@
   (let [tool           (->> (persistence/get-tool tool-id)
                             (format-tool-listing (perms-client/load-tool-permissions user)
                                                  (perms-client/get-public-tool-ids)))
-        ;; XXX: use include-defaults here
-        container      (clojure.set/rename-keys (tool-container-info tool-id) {:ports :container_ports})
+        container      (clojure.set/rename-keys (format-container-settings (tool-container-info tool-id) include-defaults) {:ports :container_ports})
         implementation (persistence/get-tool-implementation-details tool-id)]
     (assoc tool
            :container container

--- a/src/apps/tools/private.clj
+++ b/src/apps/tools/private.clj
@@ -91,7 +91,7 @@
      (persistence/update-tool tool)
      (when container
        (containers/set-tool-container tool-id false (restrict-private-tool-container type container)))))
-  (tools/get-tool user tool-id))
+  (tools/get-tool user tool-id false))
 
 (defn delete-private-tool
   "Deletes a private tool if user has `own` permission for the tool.

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -123,6 +123,16 @@
   [props config-valid configs]
   "apps.tools.private.memory-limit" (* 16 1024 1024 1024)) ;; 16GB
 
+(cc/defprop-optint default-cpu-limit
+  "The CPU limit, in millicores, to be used as the default resource limit when one is not set in a tool definition."
+  [props config-valid configs]
+  "apps.tools.default.cpu-limit" "4000")
+
+(cc/defprop-optint default-memory-limit
+  "The momry limit, in bytes, to be used as the default resource limit when one is not set in a tool definition."
+  [props config-valid configs]
+  "apps.tools.default.memory-limit" (* 16 1024 1024 1024)) ;; 16GB
+
 (cc/defprop-optstr workspace-root-app-category
   "The name of the root app category in a user's workspace."
   [props config-valid configs]

--- a/src/apps/util/config.clj
+++ b/src/apps/util/config.clj
@@ -124,12 +124,12 @@
   "apps.tools.private.memory-limit" (* 16 1024 1024 1024)) ;; 16GB
 
 (cc/defprop-optint default-cpu-limit
-  "The CPU limit, in millicores, to be used as the default resource limit when one is not set in a tool definition."
+  "The CPU limit, in cores (matching the database's data type), to be used as the default resource limit when one is not set in a tool definition."
   [props config-valid configs]
-  "apps.tools.default.cpu-limit" "4000")
+  "apps.tools.default.cpu-limit" 4)
 
 (cc/defprop-optint default-memory-limit
-  "The momry limit, in bytes, to be used as the default resource limit when one is not set in a tool definition."
+  "The memory limit, in bytes, to be used as the default resource limit when one is not set in a tool definition."
   [props config-valid configs]
   "apps.tools.default.memory-limit" (* 16 1024 1024 1024)) ;; 16GB
 


### PR DESCRIPTION
Hopefully fairly easily understood. For the UI, we've added an include-defaults parameter (cyverse-de/common-swagger-api#84 and cyverse-de/terrain#277 for the schema and ensuring that reaches this service, resp.) so that when _editing_ tools the configured default isn't listed as though it's the tool-specific configured value. When launching apps, however, the default should show up seamlessly as though it's configured in the tool & passed down to app-exposer.

This still needs testing, but as discussed elsewhere I might do so in the QA environment to ease the cross-service setup process.