### PR TITLE
Handle username suffix better

### DIFF
--- a/src/apps/metadata/tool_requests.clj
+++ b/src/apps/metadata/tool_requests.clj
@@ -142,7 +142,7 @@
          status      (:status update prev-status)
          status-id   (:id (load-status-code status))
          username    (required-field update :username)
-         username    (if (re-find #"@" username) username (str username "@" uid-domain))
+         username    (str (string/replace username #"@.*$" "") "@" uid-domain)
          user-id     (users/get-user-id username)
          comments    (:comments update)
          comments    (when-not (string/blank? comments) comments)]

--- a/src/apps/service/integration_data.clj
+++ b/src/apps/service/integration_data.clj
@@ -4,7 +4,7 @@
   (:require [apps.persistence.app-metadata :as amp]
             [apps.persistence.tools :as tools-db]
             [apps.service.apps.de.validation :as app-validation]
-            [apps.util.config :as cfg]
+            [apps.users :refer [append-username-suffix]]
             [clojure.string :as string]
             [clojure-commons.exception-util :as cxu]))
 
@@ -45,7 +45,7 @@
 (def ^:private used-by-apps (partial integration-data-record-used "apps"))
 
 (defn add-integration-data [_ {:keys [username name email]}]
-  (let [qualified-username (when username (str username "@" (cfg/uid-domain)))]
+  (let [qualified-username (when username (append-username-suffix username))]
     (cond
       (and username (amp/get-integration-data-by-username qualified-username))
       (duplicate-username username)

--- a/src/apps/service/integration_data.clj
+++ b/src/apps/service/integration_data.clj
@@ -4,7 +4,7 @@
   (:require [apps.persistence.app-metadata :as amp]
             [apps.persistence.tools :as tools-db]
             [apps.service.apps.de.validation :as app-validation]
-            [apps.users :refer [append-username-suffix]]
+            [apps.user :refer [append-username-suffix]]
             [clojure.string :as string]
             [clojure-commons.exception-util :as cxu]))
 

--- a/src/apps/user.clj
+++ b/src/apps/user.clj
@@ -11,10 +11,9 @@
   current-user nil)
 
 (defn append-username-suffix [username]
-  (let [suffix (str "@" (uid-domain))]
-    (if (string/ends-with? username suffix)
-      username
-      (str username suffix))))
+  (let [suffix (str "@" (uid-domain))
+        unsuffixed (string/replace username #"@.*$" "")]
+    (str unsuffixed suffix)))
 
 (defn user-from-attributes
   [user-attributes]

--- a/src/apps/webhooks.clj
+++ b/src/apps/webhooks.clj
@@ -4,7 +4,7 @@
         [apps.persistence.users :only [get-user-id]])
   (:require [clojure.tools.logging :as log]
             [clojure-commons.exception-util :as cxu]
-            [apps.util.config :as config]
+            [apps.users :refer [append-username-suffix]]
             [korma.core :as sql]))
 
 (defn- get-webhook-topics [webhook-id]
@@ -54,7 +54,7 @@
       (add-topic-subscription id topic_name))))
 
 (defn add-webhooks [user {:keys [webhooks]}]
-  (let [user_id (get-user-id (str user "@" (config/uid-domain)))]
+  (let [user_id (get-user-id (append-username-suffix user))]
     (transaction
      (delete :webhooks (where {:user_id user_id}))
      (doseq [{:keys [url type topics]} webhooks]

--- a/src/apps/webhooks.clj
+++ b/src/apps/webhooks.clj
@@ -4,7 +4,7 @@
         [apps.persistence.users :only [get-user-id]])
   (:require [clojure.tools.logging :as log]
             [clojure-commons.exception-util :as cxu]
-            [apps.users :refer [append-username-suffix]]
+            [apps.user :refer [append-username-suffix]]
             [korma.core :as sql]))
 
 (defn- get-webhook-topics [webhook-id]


### PR DESCRIPTION
This tries to centralize the logic for username suffix handling to all use a regex-type approach like I used in the analyses service (remove everything starting from the first `@`, then add the suffix after that). This moves most places that cared about the configuration property to use the same function within apps.user, with one exception that was set up to pass the uid domain in. That could maybe go away too, but thought I'd get this much up at least.