### PR TITLE
Route periodic notification information into the stored job submission

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [org.cyverse/metadata-client "3.1.2"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-cfg "2.8.3"]
-                 [org.cyverse/common-swagger-api "3.4.5"]
+                 [org.cyverse/common-swagger-api "3.4.6-SNAPSHOT"]
                  [org.cyverse/cyverse-groups-client "0.1.9"]
                  [org.cyverse/permissions-client "2.8.4"]
                  [org.cyverse/service-logging "2.8.4"]

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [org.cyverse/metadata-client "3.1.2"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-cfg "2.8.3"]
-                 [org.cyverse/common-swagger-api "3.4.6-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.4.6"]
                  [org.cyverse/cyverse-groups-client "0.1.9"]
                  [org.cyverse/permissions-client "2.8.4"]
                  [org.cyverse/service-logging "2.8.4"]

--- a/src/apps/service/apps/de/jobs/common.clj
+++ b/src/apps/service/apps/de/jobs/common.clj
@@ -191,6 +191,8 @@
          :group                (:group submission "")
          :name                 (:name submission)
          :notify               (:notify submission)
+         :notify_periodic      (:notify_periodic submission nil)
+         :periodic_period      (:periodic_period submission nil)
          :output_dir           (:output_dir submission)
          :request_type         "submit"
          :steps                @steps


### PR DESCRIPTION
Also includes the start of the update for cyverse-de/common-swagger-api#87 which can be updated to a non-snapshot version when that's in properly.