### PR TITLE
CORE-1955 Add endpoint for reordering app versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [org.cyverse/metadata-client "3.1.2"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-cfg "2.8.3"]
-                 [org.cyverse/common-swagger-api "3.4.6"]
+                 [org.cyverse/common-swagger-api "3.4.7"]
                  [org.cyverse/cyverse-groups-client "0.1.9"]
                  [org.cyverse/permissions-client "2.8.4"]
                  [org.cyverse/service-logging "2.8.4"]

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -528,6 +528,12 @@
                           (remove-nil-vals))]
      (sql/update app_versions (set-fields version-info) (where {:id version-id})))))
 
+(defn set-app-versions-order
+  [app-id versions]
+  (transaction
+    (doseq [[index id] (map-indexed (fn [i v] [i (:version_id v)]) (rseq versions))]
+      (sql/update app_versions (set-fields {:version_order index}) (where {:app_id app-id :id id})))))
+
 (defn- get-app-publication-status-code-id
   [status-code]
   (-> (select* :app_publication_request_status_codes)

--- a/src/apps/protocols.clj
+++ b/src/apps/protocols.clj
@@ -29,6 +29,7 @@
   (deleteAppVersion [_ system-id app-id app-version-id])
   (relabelApp [_ system-id app])
   (updateApp [_ system-id app])
+  (setAppVersionsOrder [_ system-id app-id versions])
   (copyApp [_ system-id app-id])
   (copyAppVersion [_ system-id app-id version-id])
   (getAppDetails [_ system-id app-id admin?])

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -119,6 +119,14 @@
         :description schema/AppUpdateDocs
         (ok (apps/update-app current-user system-id (assoc body :id app-id))))
 
+      (POST "/versions" []
+        :query [params SecuredQueryParamsRequired]
+        :body [{:keys [versions]} schema/AppVersionOrderRequest]
+        :return schema/App
+        :summary schema/AppVersionOrderSummary
+        :description schema/AppVersionOrderDocs
+        (ok (apps/set-app-versions-order current-user system-id app-id versions)))
+
       (POST "/copy" []
         :query [params SecuredQueryParamsRequired]
         :return schema/App

--- a/src/apps/routes/apps.clj
+++ b/src/apps/routes/apps.clj
@@ -119,14 +119,6 @@
         :description schema/AppUpdateDocs
         (ok (apps/update-app current-user system-id (assoc body :id app-id))))
 
-      (POST "/versions" []
-        :query [params SecuredQueryParamsRequired]
-        :body [{:keys [versions]} schema/AppVersionOrderRequest]
-        :return schema/App
-        :summary schema/AppVersionOrderSummary
-        :description schema/AppVersionOrderDocs
-        (ok (apps/set-app-versions-order current-user system-id app-id versions)))
-
       (POST "/copy" []
         :query [params SecuredQueryParamsRequired]
         :return schema/App

--- a/src/apps/routes/apps/versions.clj
+++ b/src/apps/routes/apps/versions.clj
@@ -27,6 +27,14 @@
                                                     (assoc app :id app-id)
                                                     false)))
 
+                    (PUT "/" []
+                         :query [params SecuredQueryParamsRequired]
+                         :body [{:keys [versions]} schema/AppVersionOrderRequest]
+                         :return schema/App
+                         :summary schema/AppVersionOrderSummary
+                         :description schema/AppVersionOrderDocs
+                         (ok (apps/set-app-versions-order current-user system-id app-id versions)))
+
                     (context "/:version-id" []
                              :path-params [version-id :- schema/AppVersionIdParam]
 

--- a/src/apps/service/apps.clj
+++ b/src/apps/service/apps.clj
@@ -93,6 +93,10 @@
   [user system-id app]
   (.updateApp (get-apps-client user) system-id app))
 
+(defn set-app-versions-order
+  [user system-id app-id versions]
+  (.setAppVersionsOrder (get-apps-client user) system-id app-id versions))
+
 (defn copy-app
   [user system-id app-id]
   (.copyApp (get-apps-client user) system-id app-id))

--- a/src/apps/service/apps/agave.clj
+++ b/src/apps/service/apps/agave.clj
@@ -176,6 +176,10 @@
     (validate-system-id system-id)
     (reject-app-integration-request))
 
+  (setAppVersionsOrder [_ system-id app-id versions]
+    (validate-system-id system-id)
+    (reject-app-integration-request))
+
   (copyApp [_ system-id app-id]
     (validate-system-id system-id)
     (reject-app-integration-request))

--- a/src/apps/service/apps/combined.clj
+++ b/src/apps/service/apps/combined.clj
@@ -118,6 +118,9 @@
   (updateApp [_ system-id app]
     (.updateApp (util/get-apps-client clients system-id) system-id app))
 
+  (setAppVersionsOrder [_ system-id app-id versions]
+    (.setAppVersionsOrder (util/get-apps-client clients system-id) system-id app-id versions))
+
   (copyApp [_ system-id app-id]
     (.copyApp (util/get-apps-client clients system-id) system-id app-id))
 

--- a/src/apps/service/apps/de.clj
+++ b/src/apps/service/apps/de.clj
@@ -127,6 +127,10 @@
     (validate-system-id system-id)
     (edit/update-app user (update app :id uuidify)))
 
+  (setAppVersionsOrder [_ system-id app-id versions]
+    (validate-system-id system-id)
+    (edit/set-app-versions-order user (uuidify app-id) versions))
+
   (copyApp [_ system-id app-id]
     (validate-system-id system-id)
     (edit/copy-app user (uuidify app-id)))

--- a/src/apps/service/apps/de/edit.clj
+++ b/src/apps/service/apps/de/edit.clj
@@ -473,6 +473,12 @@
      (update-app-groups task-id groups)
      (get-app-ui user app-id version-id))))
 
+(defn set-app-versions-order
+  [user app-id versions]
+  (verify-app-editable user (persistence/get-app app-id))
+  (persistence/set-app-versions-order app-id versions)
+  (get-app-ui user app-id))
+
 (defn get-user-subcategory
   [username index]
   (-> (get-workspace username)


### PR DESCRIPTION
Added `PUT /apps/:system/:id/versions` for reordering app versions.

This endpoint expects the app versions to be in descending order, with the newest (or latest) first, since that is also the way they are listed in the app details and listing endpoints.