### PR TITLE
Logins endpoint

### DIFF
--- a/src/apps/persistence/users.clj
+++ b/src/apps/persistence/users.clj
@@ -76,3 +76,8 @@
   (-> (upsert-login-record (get-user-id username) ip-address session-id login-time)
       (:login_time)
       (.getTime)))
+
+(defn list-logins
+  "Lists a number of the most recent logins for a user"
+  [username limit]
+  [])

--- a/src/apps/persistence/users.clj
+++ b/src/apps/persistence/users.clj
@@ -79,5 +79,8 @@
 
 (defn list-logins
   "Lists a number of the most recent logins for a user"
-  [username limit]
-  [])
+  [username query-limit]
+  (->> (select :logins
+               (where {:user_id (get-user-id username)})
+               (limit (or query-limit 5)))
+       (mapv (fn [login] (select-keys login [:ip_address :login_time])))))

--- a/src/apps/routes/schemas/user.clj
+++ b/src/apps/routes/schemas/user.clj
@@ -26,3 +26,11 @@
          {(optional-key :limit)
           (describe (both Long (pred pos? 'positive-integer?))
      "Limits the response to X number of results.")}))
+
+(defschema ListLoginsResponse
+  {:logins
+   [{:login_time
+     (describe Long "Login time as milliseconds since the epoch.")
+     
+     (optional-key :session_id)
+     (describe String "The session ID provided by the auth provider.")}]})

--- a/src/apps/routes/schemas/user.clj
+++ b/src/apps/routes/schemas/user.clj
@@ -27,10 +27,11 @@
           (describe (both Long (pred pos? 'positive-integer?))
      "Limits the response to X number of results.")}))
 
+; NOTE that the IP Address key uses an underscore here. Other schemas are inconsistent about this.
 (defschema ListLoginsResponse
   {:logins
-   [{:login_time
-     (describe Long "Login time as milliseconds since the epoch.")
+   [{(optional-key :ip_address)
+     (describe String "The IP address associated with this login session.")
      
-     (optional-key :session_id)
-     (describe String "The session ID provided by the auth provider.")}]})
+     :login_time
+     (describe Long "Login time as milliseconds since the epoch.")}]})

--- a/src/apps/routes/schemas/user.clj
+++ b/src/apps/routes/schemas/user.clj
@@ -1,7 +1,7 @@
 (ns apps.routes.schemas.user
   (:use [common-swagger-api.schema :only [describe]]
         [apps.routes.params :only [SecuredQueryParams]]
-        [schema.core :only [defschema optional-key]])
+        [schema.core :only [defschema optional-key both pred]])
   (:require [common-swagger-api.schema.sessions :as sessions-schema])
   (:import [java.util UUID]))
 
@@ -20,3 +20,9 @@
          sessions-schema/IPAddrParam
          {(optional-key :session-id) (describe String "The session ID provided by the auth provider.")
           (optional-key :login-time) (describe Long "Login time as milliseconds since the epoch, provided by auth provider.")}))
+
+(defschema ListLoginsParams
+  (merge SecuredQueryParams
+         {(optional-key :limit)
+          (describe (both Long (pred pos? 'positive-integer?))
+     "Limits the response to X number of results.")}))

--- a/src/apps/routes/users.clj
+++ b/src/apps/routes/users.clj
@@ -33,7 +33,7 @@
   
   (GET "/logins" []
     :query [params ListLoginsParams]
-    ;; XXX: :return something
+    :return ListLoginsResponse
     :summary "Login listing"
     :description "Fetch a listing of recent logins"
     (ok (users/list-logins current-user params))))

--- a/src/apps/routes/users.clj
+++ b/src/apps/routes/users.clj
@@ -32,9 +32,8 @@
     (ok (users/login current-user params)))
   
   (GET "/logins" []
-    ;; XXX: limit parameter
-    :query [params SecuredQueryParams]
+    :query [params ListLoginsParams]
     ;; XXX: :return something
     :summary "Login listing"
     :description "Fetch a listing of recent logins"
-    (ok (users/list-logins current-user (assoc params :limit 5)))))
+    (ok (users/list-logins current-user params))))

--- a/src/apps/routes/users.clj
+++ b/src/apps/routes/users.clj
@@ -29,4 +29,12 @@
     :summary "User Login Service"
     :description "Terrain calls this service to record when a user logs in
           and to fetch user session info."
-    (ok (users/login current-user params))))
+    (ok (users/login current-user params)))
+  
+  (GET "/logins" []
+    ;; XXX: limit parameter
+    :query [params SecuredQueryParams]
+    ;; XXX: :return something
+    :summary "Login listing"
+    :description "Fetch a listing of recent logins"
+    (ok {:logins []}))

--- a/src/apps/routes/users.clj
+++ b/src/apps/routes/users.clj
@@ -37,4 +37,4 @@
     ;; XXX: :return something
     :summary "Login listing"
     :description "Fetch a listing of recent logins"
-    (ok {:logins []}))
+    (ok (users/list-logins current-user (assoc params :limit 5)))))

--- a/src/apps/service/users.clj
+++ b/src/apps/service/users.clj
@@ -15,3 +15,7 @@
   [{:keys [username] :as current-user} {:keys [ip-address login-time session-id]}]
   {:login_time (up/record-login username ip-address session-id login-time)
    :auth_redirect (oauth/get-redirect-uris current-user)})
+
+(defn list-logins
+  [{:keys [username] :as current-user} {:keys [limit]}]
+  (up/list-logins username limit))

--- a/src/apps/service/users.clj
+++ b/src/apps/service/users.clj
@@ -17,5 +17,5 @@
    :auth_redirect (oauth/get-redirect-uris current-user)})
 
 (defn list-logins
-  [{:keys [username] :as current-user} {:keys [limit]}]
+  [{:keys [username] :as current-user} {:keys [limit] :or {limit 5}}]
   (up/list-logins username limit))


### PR DESCRIPTION
This adds an endpoint that lists the most recent N (default 5) logins in the database for the logged-in user. After adding here, a passthrough will be added in terrain and a table to display this information in Sonora. As part of putting it in terrain or in advance of that, I may move some of the schemas to common-swagger-api, but it seemed like just doing it here to start was easier & would be easier to review.

Related: https://github.com/cyverse-de/terrain/pull/294