### PR TITLE
CORE-2139: ensure that jobs for which downstream submissions fail are…

### DIFF
--- a/.clj-kondo/imports/clj-kondo/slingshot/clj_kondo/slingshot/try_plus.clj
+++ b/.clj-kondo/imports/clj-kondo/slingshot/clj_kondo/slingshot/try_plus.clj
@@ -41,3 +41,4 @@
                      (meta node))])]
     ;; (prn (api/sexpr new-node))
     {:node new-node}))
+

--- a/src/apps/service/apps/combined/jobs.clj
+++ b/src/apps/service/apps/combined/jobs.clj
@@ -4,6 +4,7 @@
    [apps.persistence.app-metadata :as ap]
    [apps.persistence.jobs :as jp]
    [apps.service.apps.combined.util :as cu]
+   [apps.util.db :refer [transaction]]
    [apps.util.service :as service]
    [cheshire.core :as cheshire]
    [clojure-commons.file-utils :as ft]
@@ -102,10 +103,11 @@
 
 (defn- record-step-submission
   [job-id step-number external-id]
-  (->>  {:external_id external-id
-         :status      jp/submitted-status
-         :start_date  (db/now)}
-        (jp/update-job-step-number job-id step-number)))
+  (transaction
+   (->>  {:external_id external-id
+          :status      jp/submitted-status
+          :start_date  (db/now)}
+         (jp/update-job-step-number job-id step-number))))
 
 (defn- submit-job-step
   [client {:keys [id] :as job-info} job-step submission]
@@ -114,7 +116,7 @@
         (.submitJobStep client id)
         (record-step-submission id (:step_number job-step)))
    (catch Object _
-     (log/error (:throwable (:throwable &throw-context) "job step submission failed"))
+     (log/error (:throwable &throw-context) "job step submission failed")
      (when-not (boolean (:parent_id submission)) (throw+)))))
 
 (defn submit
@@ -126,7 +128,8 @@
         job-info    (build-job-save-info user (ft/build-result-folder-path submission)
                                          job-id system-id version-id app-info submission)
         job-step    (first job-steps)]
-    (jp/save-multistep-job job-info job-steps submission)
+    (transaction
+     (jp/save-multistep-job job-info job-steps submission))
     (submit-job-step (cu/apps-client-for-job-step clients job-step) job-info job-step submission)
     job-id))
 

--- a/src/apps/service/apps/de/jobs.clj
+++ b/src/apps/service/apps/de/jobs.clj
@@ -25,12 +25,13 @@
    interfering with the caller."
   [job-id external-id error-message]
   (try
-    (let [end-date (db/now)]
-      (jp/update-job job-id jp/failed-status end-date)
-      (jp/update-job-step job-id external-id jp/failed-status end-date)
-      (jp/add-job-status-update external-id
-                                (or error-message "Job submission failed")
-                                jp/failed-status))
+    (transaction
+     (let [end-date (db/now)]
+       (jp/update-job job-id jp/failed-status end-date)
+       (jp/update-job-step job-id external-id jp/failed-status end-date)
+       (jp/add-job-status-update external-id
+                                 (or error-message "Job submission failed")
+                                 jp/failed-status)))
     (catch Exception e
       (log/error e "failed to record submission failure for job" job-id))))
 

--- a/src/apps/service/apps/jobs/submissions/async.clj
+++ b/src/apps/service/apps/jobs/submissions/async.clj
@@ -74,18 +74,17 @@
 
 (defn- batch-job-reducer
   [apps-client user {:keys [parent-id parent-status total submission batch-status] :as results} path-map]
-  (transaction
-    ;; re-check for completed parent status before each submission
-   (let [parent-status (if (jp/completed? parent-status)
-                         parent-status
-                         (jp/get-job-status parent-id))
-         job-status    (if (jp/completed? parent-status)
-                         jp/canceled-status
-                         (submit-job-in-batch apps-client user submission total path-map))]
-     (assoc results
-            :parent-status parent-status
-            :total         (inc total)
-            :batch-status  (update batch-status job-status (fnil inc 0))))))
+  ;; re-check for completed parent status before each submission
+  (let [parent-status (if (jp/completed? parent-status)
+                        parent-status
+                        (jp/get-job-status parent-id))
+        job-status    (if (jp/completed? parent-status)
+                        jp/canceled-status
+                        (submit-job-in-batch apps-client user submission total path-map))]
+    (assoc results
+           :parent-status parent-status
+           :total         (inc total)
+           :batch-status  (update batch-status job-status (fnil inc 0)))))
 
 (defn- preprocess-batch-submission
   [submission output-dir parent-id]

--- a/src/apps/service/apps/jobs/submissions/submit.clj
+++ b/src/apps/service/apps/jobs/submissions/submit.clj
@@ -1,11 +1,10 @@
 (ns apps.service.apps.jobs.submissions.submit
   (:require
-   [apps.clients.permissions :as perms-client]
-   [apps.util.db :refer [transaction]]))
+   [apps.clients.permissions :as perms-client]))
 
 (defn submit-and-register-private-job
+  "Submits a job for execution and calls the `permissions` service to record permissions."
   [apps-client user submission]
-  (transaction
-   (let [job-info (.submitJob apps-client submission)]
-     (perms-client/register-private-analysis (:shortUsername user) (:id job-info))
-     job-info)))
+  (let [job-info (.submitJob apps-client submission)]
+    (perms-client/register-private-analysis (:shortUsername user) (:id job-info))
+    job-info))

--- a/src/apps/service/apps/tapis/jobs.clj
+++ b/src/apps/service/apps/tapis/jobs.clj
@@ -3,8 +3,10 @@
    [apps.persistence.jobs :as jp]
    [apps.util.config :as config]
    [apps.util.conversions :refer [remove-nil-vals]]
+   [apps.util.db :refer [transaction]]
    [apps.util.json :as json-util]
    [cemerick.url :as curl]
+   [clojure.tools.logging :as log]
    [clojure-commons.file-utils :as ft]
    [kameleon.db :as db]
    [kameleon.uuids :as uuids]
@@ -100,17 +102,25 @@
     :wiki_url        (:wiki_url job)
     :parent_id       (:parent_id submission)}))
 
+(defn- store-job-and-step
+  [user job-id job submission]
+  (transaction
+   (try+
+    (store-tapis-job user job-id job submission)
+    (store-job-step job-id job)
+    (catch Object _
+      (log/errorf (:throwable &throw-context) "failed to record TAPIS job %s" job)
+      (throw+)))))
+
 (defn- handle-successful-submission
   [user job-id job submission]
-  (store-tapis-job user job-id job submission)
-  (store-job-step job-id job)
+  (store-job-and-step user job-id job submission)
   (format-job-submission-response job-id submission job))
 
 (defn- handle-failed-submission
   [user job-id job submission]
   (let [job (assoc job :status jp/failed-status)]
-    (store-tapis-job user job-id job submission)
-    (store-job-step job-id job)
+    (store-job-and-step user job-id job submission)
     (format-job-submission-response job-id submission job)))
 
 (defn- send-submission


### PR DESCRIPTION
… still recorded in the database

This replaces the higher level transactions in `apps.services.apps.jobs.submissions.submit` and `apps.services.apps.jobs.submissions.async` with lower level transactions in order to ensure that the rows are recorded in the database if a submission failure occurs.
