### PR TITLE
Add apps.util.cache with some simple caches 

### DIFF
--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -1,5 +1,6 @@
 (ns apps.clients.permissions
   (:require [apps.clients.iplant-groups :as ipg]
+            [apps.util.cache :as cache]
             [apps.util.config :as config]
             [apps.util.service :as service]
             [clojure.tools.logging :as log]
@@ -116,6 +117,24 @@
   [tool-id]
   (pc/delete-resource (client) tool-id (rt-tool)))
 
+(defn- get-public-resource-ids [resource-type]
+  (->> (pc/get-abbreviated-subject-permissions-for-resource-type
+        (client) "group" (ipg/grouper-user-group-id) resource-type false)
+       :permissions
+       (map (comp uuidify :resource_name))
+       set))
+
+(def ^:private public-app-ids-cache
+  "60-second TTL cache for the set of public app IDs."
+  (cache/ttl-cache #(get-public-resource-ids "app") 60000))
+
+(def ^:private public-tool-ids-cache
+  "60-second TTL cache for the set of public tool IDs."
+  (cache/ttl-cache #(get-public-resource-ids "tool") 60000))
+
+(def get-public-app-ids (:lookup public-app-ids-cache))
+(def get-public-tool-ids (:lookup public-tool-ids-cache))
+
 (defn- revoke-app-user-permission
   "Revokes a user's permission to access an app, ignoring cases where the user didn't already have access."
   [user app-id]
@@ -126,11 +145,13 @@
 (defn make-app-public
   [user app-id]
   (revoke-app-user-permission user app-id)
-  (pc/grant-permission (client) (rt-app) app-id "group" (ipg/grouper-user-group-id) "read"))
+  (pc/grant-permission (client) (rt-app) app-id "group" (ipg/grouper-user-group-id) "read")
+  ((:invalidate public-app-ids-cache)))
 
 (defn register-public-tool
   [tool-id]
-  (pc/grant-permission (client) (rt-tool) tool-id "group" (ipg/grouper-user-group-id) "read"))
+  (pc/grant-permission (client) (rt-tool) tool-id "group" (ipg/grouper-user-group-id) "read")
+  ((:invalidate public-tool-ids-cache)))
 
 (defn make-tool-public
   [tool-id]
@@ -179,16 +200,6 @@
 (def unshare-analysis (partial unshare-resource (rt-analysis)))
 (def share-tool (partial share-resource (rt-tool)))
 (def unshare-tool (partial unshare-resource (rt-tool)))
-
-(defn- get-public-resource-ids [resource-type]
-  (->> (pc/get-abbreviated-subject-permissions-for-resource-type
-        (client) "group" (ipg/grouper-user-group-id) resource-type false)
-       :permissions
-       (map (comp uuidify :resource_name))
-       set))
-
-(def get-public-app-ids (partial get-public-resource-ids "app"))
-(def get-public-tool-ids (partial get-public-resource-ids "tool"))
 
 (defn- get-resource-users
   "Lists users with any level of access to a resource."

--- a/src/apps/persistence/categories.clj
+++ b/src/apps/persistence/categories.clj
@@ -1,5 +1,6 @@
 (ns apps.persistence.categories
   (:require [apps.persistence.users :refer [get-user-id]]
+            [apps.util.cache :as cache]
             [korma.core :as sql]))
 
 (defn add-hierarchy-version
@@ -8,10 +9,25 @@
               (sql/values {:version version
                            :applied_by (get-user-id username)})))
 
-(defn get-active-hierarchy-version
+(defn- fetch-active-hierarchy-version
   []
   ((comp :version first)
    (sql/select :app_hierarchy_version
                (sql/fields :version)
                (sql/order :applied :DESC)
                (sql/limit 1))))
+
+(def ^:private hierarchy-version-cache
+  "TTL cache for the active hierarchy version. TTL is 60 seconds — short enough
+   to pick up admin changes promptly, long enough to avoid repeated DB hits
+   during request processing."
+  (cache/ttl-cache fetch-active-hierarchy-version 60000))
+
+(defn invalidate-hierarchy-version-cache
+  "Clears the cached hierarchy version. Call after setting a new version."
+  []
+  ((:invalidate hierarchy-version-cache)))
+
+(def get-active-hierarchy-version
+  "Returns the active hierarchy version, served from a 60-second TTL cache."
+  (:lookup hierarchy-version-cache))

--- a/src/apps/service/apps/de/admin.clj
+++ b/src/apps/service/apps/de/admin.clj
@@ -210,6 +210,7 @@
   "Sets the active ontology-version for use in apps hierarchy endpoints."
   [{:keys [username]} ontology-version]
   (let [version-details (db-categories/add-hierarchy-version username ontology-version)]
+    (db-categories/invalidate-hierarchy-version-cache)
     (assoc version-details :applied_by username)))
 
 (defn delete-ontology

--- a/src/apps/util/cache.clj
+++ b/src/apps/util/cache.clj
@@ -1,0 +1,46 @@
+(ns apps.util.cache)
+
+(defn cache-by-key
+  "Creates a cache that stores results of (fetch-fn key) by key.
+   Only non-nil results are cached, so a failed lookup will be retried on the
+   next call. Returns a map with :lookup (fn [key] -> value-or-nil) and
+   :invalidate (fn [key] -> nil) for removing a single entry."
+  [fetch-fn]
+  (let [store (atom {})]
+    {:lookup
+     (fn [key]
+       (if (contains? @store key)
+         (get @store key)
+         (let [value (fetch-fn key)]
+           (when (some? value)
+             (swap! store assoc key value))
+           value)))
+
+     :invalidate
+     (fn [key]
+       (swap! store dissoc key)
+       nil)}))
+
+(defn ttl-cache
+  "Creates a TTL-based cache around a zero-arg fetch function.
+   The cached value expires after ttl-ms milliseconds. Both nil and non-nil
+   results are cached (a nil result means 'no data' which is still valid).
+   Returns a map with :lookup (fn [] -> value-or-nil) and
+   :invalidate (fn [] -> nil) for clearing the cache."
+  [fetch-fn ttl-ms]
+  (let [store (atom {:value nil :fetched-at 0})]
+    {:lookup
+     (fn []
+       (let [{:keys [value fetched-at]} @store
+             now (System/currentTimeMillis)]
+         (if (and (pos? fetched-at)
+                  (< (- now fetched-at) ttl-ms))
+           value
+           (let [v (fetch-fn)]
+             (reset! store {:value v :fetched-at now})
+             v))))
+
+     :invalidate
+     (fn []
+       (reset! store {:value nil :fetched-at 0})
+       nil)}))

--- a/src/apps/workspace.clj
+++ b/src/apps/workspace.clj
@@ -3,14 +3,26 @@
    [apps.persistence.users :refer [get-existing-user-id]]
    [apps.persistence.workspace :refer [fetch-workspace-by-user-id]]
    [apps.user :refer [current-user]]
+   [apps.util.cache :as cache]
    [slingshot.slingshot :refer [throw+]]))
+
+(def ^:private workspace-cache
+  "Cache of username -> workspace. Only non-nil results are stored.
+   Workspaces are immutable once created, so caching indefinitely is safe."
+  (cache/cache-by-key
+   (fn [username]
+     (fetch-workspace-by-user-id (get-existing-user-id username)))))
+
+(def ^:private lookup-workspace
+  "Cached workspace lookup by username."
+  (:lookup workspace-cache))
 
 (defn get-workspace
   "Gets a workspace database entry for the given username or the current user."
   ([]
    (get-workspace (:username current-user)))
   ([username]
-   (if-let [workspace (fetch-workspace-by-user-id (get-existing-user-id username))]
+   (if-let [workspace (lookup-workspace username)]
      workspace
      (throw+ {:type     :clojure-commons.exception/not-found
               :message  "Workspace for user not found."

--- a/test/apps/util/cache_test.clj
+++ b/test/apps/util/cache_test.clj
@@ -1,0 +1,159 @@
+(ns apps.util.cache-test
+  (:require
+   [apps.util.cache :as cache]
+   [clojure.test :refer [deftest is testing]]))
+
+;; ---------------------------------------------------------------------------
+;; cache-by-key tests
+;; ---------------------------------------------------------------------------
+
+(deftest cache-by-key-caches-non-nil-results
+  (testing "A non-nil result is cached and the fetch function is not called again"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [k] (swap! call-count inc) {:id k :name "workspace"})
+          c          (cache/cache-by-key fetch-fn)
+          lookup     (:lookup c)]
+      (is (= {:id "alice" :name "workspace"} (lookup "alice")))
+      (is (= 1 @call-count))
+      ;; Second call should use cache
+      (is (= {:id "alice" :name "workspace"} (lookup "alice")))
+      (is (= 1 @call-count)))))
+
+(deftest cache-by-key-does-not-cache-nil
+  (testing "A nil result is not cached, so subsequent calls retry the fetch"
+    (let [call-count (atom 0)
+          results    (atom {})
+          fetch-fn   (fn [k] (swap! call-count inc) (get @results k))
+          c          (cache/cache-by-key fetch-fn)
+          lookup     (:lookup c)]
+      ;; First call returns nil (user doesn't exist yet)
+      (is (nil? (lookup "bob")))
+      (is (= 1 @call-count))
+      ;; Second call still retries because nil was not cached
+      (is (nil? (lookup "bob")))
+      (is (= 2 @call-count))
+      ;; Now the user exists
+      (swap! results assoc "bob" {:id "bob" :name "workspace"})
+      (is (= {:id "bob" :name "workspace"} (lookup "bob")))
+      (is (= 3 @call-count))
+      ;; Now it's cached
+      (is (= {:id "bob" :name "workspace"} (lookup "bob")))
+      (is (= 3 @call-count)))))
+
+(deftest cache-by-key-caches-per-key
+  (testing "Different keys are cached independently"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [k] (swap! call-count inc) {:id k})
+          c          (cache/cache-by-key fetch-fn)
+          lookup     (:lookup c)]
+      (is (= {:id "alice"} (lookup "alice")))
+      (is (= {:id "bob"} (lookup "bob")))
+      (is (= 2 @call-count))
+      ;; Both cached independently
+      (is (= {:id "alice"} (lookup "alice")))
+      (is (= {:id "bob"} (lookup "bob")))
+      (is (= 2 @call-count)))))
+
+(deftest cache-by-key-invalidate-removes-entry
+  (testing "Invalidating a key causes the next lookup to re-fetch"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [k] (swap! call-count inc) {:id k :v @call-count})
+          c          (cache/cache-by-key fetch-fn)
+          lookup     (:lookup c)
+          invalidate (:invalidate c)]
+      (is (= {:id "alice" :v 1} (lookup "alice")))
+      (is (= 1 @call-count))
+      ;; Invalidate
+      (invalidate "alice")
+      ;; Next lookup re-fetches
+      (is (= {:id "alice" :v 2} (lookup "alice")))
+      (is (= 2 @call-count)))))
+
+(deftest cache-by-key-propagates-exceptions
+  (testing "Exceptions from fetch-fn propagate without caching"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [k]
+                       (swap! call-count inc)
+                       (throw (ex-info "DB error" {:key k})))
+          c          (cache/cache-by-key fetch-fn)
+          lookup     (:lookup c)]
+      ;; First call throws
+      (is (thrown-with-msg? Exception #"DB error" (lookup "alice")))
+      (is (= 1 @call-count))
+      ;; Second call retries (nothing was cached)
+      (is (thrown-with-msg? Exception #"DB error" (lookup "alice")))
+      (is (= 2 @call-count)))))
+
+(deftest cache-by-key-caches-falsey-values
+  (testing "A non-nil falsey value (false) is cached correctly"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [_k] (swap! call-count inc) false)
+          c          (cache/cache-by-key fetch-fn)
+          lookup     (:lookup c)]
+      ;; false is non-nil, so it should be cached
+      (is (= false (lookup "flag")))
+      (is (= 1 @call-count))
+      ;; Second call uses cache
+      (is (= false (lookup "flag")))
+      (is (= 1 @call-count)))))
+
+;; ---------------------------------------------------------------------------
+;; ttl-cache tests
+;; ---------------------------------------------------------------------------
+
+(deftest ttl-cache-caches-result
+  (testing "The fetch function is called once and the result is cached"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [] (swap! call-count inc) "v1.0")
+          c          (cache/ttl-cache fetch-fn 60000)
+          lookup     (:lookup c)]
+      (is (= "v1.0" (lookup)))
+      (is (= 1 @call-count))
+      ;; Cached
+      (is (= "v1.0" (lookup)))
+      (is (= 1 @call-count)))))
+
+(deftest ttl-cache-caches-nil-result
+  (testing "A nil result is cached (nil is a valid value, not a missing entry)"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [] (swap! call-count inc) nil)
+          c          (cache/ttl-cache fetch-fn 60000)
+          lookup     (:lookup c)]
+      (is (nil? (lookup)))
+      (is (= 1 @call-count))
+      ;; nil is cached — no re-fetch
+      (is (nil? (lookup)))
+      (is (= 1 @call-count)))))
+
+(deftest ttl-cache-expires-after-ttl
+  (testing "The cached value expires after the TTL and is re-fetched"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [] (swap! call-count inc) (str "v" @call-count))
+          ;; Use a 50ms TTL for testing
+          c          (cache/ttl-cache fetch-fn 50)
+          lookup     (:lookup c)]
+      (is (= "v1" (lookup)))
+      (is (= 1 @call-count))
+      ;; Still cached immediately
+      (is (= "v1" (lookup)))
+      (is (= 1 @call-count))
+      ;; Wait for expiry
+      (Thread/sleep 60)
+      ;; Should re-fetch
+      (is (= "v2" (lookup)))
+      (is (= 2 @call-count)))))
+
+(deftest ttl-cache-invalidate-forces-refetch
+  (testing "Invalidation causes immediate re-fetch on next lookup"
+    (let [call-count (atom 0)
+          fetch-fn   (fn [] (swap! call-count inc) (str "v" @call-count))
+          c          (cache/ttl-cache fetch-fn 60000)
+          lookup     (:lookup c)
+          invalidate (:invalidate c)]
+      (is (= "v1" (lookup)))
+      (is (= 1 @call-count))
+      ;; Invalidate
+      (invalidate)
+      ;; Re-fetches immediately
+      (is (= "v2" (lookup)))
+      (is (= 2 @call-count)))))


### PR DESCRIPTION
(for immutable or rarely changed data that still gets looked up a lot)

Right now just used for get-workspace and get-active-hierarchy-version, both of which get called repeatedly in some places but are largely immutable. Found by way of looking for admin endpoint performance gains.