### PR TITLE
Fix N+1 query pattern in list-app-publication-requests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/debug-utils "2.9.0"]
                  [org.cyverse/kameleon "3.0.10"]
                  [org.cyverse/mescal "4.1.0"]
-                 [org.cyverse/metadata-client "3.2.0"]
+                 [org.cyverse/metadata-client "3.2.1-SNAPSHOT"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-cfg "2.8.3"]
                  [org.cyverse/common-swagger-api "3.4.17"]

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/debug-utils "2.9.0"]
                  [org.cyverse/kameleon "3.0.10"]
                  [org.cyverse/mescal "4.1.0"]
-                 [org.cyverse/metadata-client "3.2.1-SNAPSHOT"]
+                 [org.cyverse/metadata-client "3.2.1"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-cfg "2.8.3"]
                  [org.cyverse/common-swagger-api "3.4.17"]

--- a/src/apps/clients/metadata.clj
+++ b/src/apps/clients/metadata.clj
@@ -67,7 +67,6 @@
   [username app-ids attrs]
   (let [ontology-version (get-active-hierarchy-version :validate false)]
     (if (and ontology-version (seq app-ids))
-      #_:clj-kondo/ignore
       (let [result (metadata-client/filter-hierarchies-batch
                     (config/metadata-client)
                     username

--- a/src/apps/clients/metadata.clj
+++ b/src/apps/clients/metadata.clj
@@ -67,6 +67,7 @@
   [username app-ids attrs]
   (let [ontology-version (get-active-hierarchy-version :validate false)]
     (if (and ontology-version (seq app-ids))
+      #_:clj-kondo/ignore
       (let [result (metadata-client/filter-hierarchies-batch
                     (config/metadata-client)
                     username

--- a/src/apps/clients/metadata.clj
+++ b/src/apps/clients/metadata.clj
@@ -1,6 +1,7 @@
 (ns apps.clients.metadata
   (:require [apps.persistence.categories :as db-categories]
             [apps.util.config :as config]
+            [kameleon.uuids :refer [uuidify]]
             [metadata-client.core :as metadata-client]
             [slingshot.slingshot :refer [throw+]]))
 
@@ -59,6 +60,25 @@
                                       attrs
                                       app-target-type
                                       app-id))
+
+(defn filter-hierarchies-batch
+  "Fetches ontology hierarchy classifications for multiple apps in one request.
+   Returns a map of app-id -> {:hierarchies [...]}."
+  [username app-ids attrs]
+  (let [ontology-version (get-active-hierarchy-version :validate false)]
+    (if (and ontology-version (seq app-ids))
+      (let [result (metadata-client/filter-hierarchies-batch
+                    (config/metadata-client)
+                    username
+                    ontology-version
+                    attrs
+                    [app-target-type]
+                    app-ids)]
+        ;; result is {:targets [{:id UUID :hierarchies [...]} ...]}
+        (into {} (map (fn [{:keys [id hierarchies]}]
+                        [(uuidify id) {:hierarchies hierarchies}]))
+              (:targets result)))
+      {})))
 
 (defn filter-targets-by-ontology-search
   [username category-attrs search-term app-ids & {:keys [validate] :or {validate true}}]

--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -204,7 +204,6 @@
 (defn- get-resource-users
   "Lists users with any level of access to a resource."
   [resource-type resource-name]
-  #_:clj-kondo/ignore
   (->> (pc/list-resource-permissions (client) resource-type resource-name true)
        :permissions
        (mapv (comp :subject_id :subject))))

--- a/src/apps/clients/permissions.clj
+++ b/src/apps/clients/permissions.clj
@@ -204,6 +204,7 @@
 (defn- get-resource-users
   "Lists users with any level of access to a resource."
   [resource-type resource-name]
+  #_:clj-kondo/ignore
   (->> (pc/list-resource-permissions (client) resource-type resource-name true)
        :permissions
        (mapv (comp :subject_id :subject))))

--- a/src/apps/persistence/app_documentation.clj
+++ b/src/apps/persistence/app_documentation.clj
@@ -1,5 +1,6 @@
 (ns apps.persistence.app-documentation
   (:require [apps.persistence.entities :refer [app_references]]
+            [apps.util.db :as db]
             [korma.core :as sql]))
 
 (defn get-app-references
@@ -13,7 +14,7 @@
   [version-ids]
   (when (seq version-ids)
     (group-by :app_version_id
-              (sql/select app_references (sql/where {:app_version_id [:in version-ids]})))))
+              (sql/select app_references (sql/where {:app_version_id (db/sqlfn-any-array "uuid" version-ids)})))))
 
 (defn get-documentation
   "Retrieves documentation details for the given app ID."
@@ -42,7 +43,7 @@
     (set (map :app_version_id
               (sql/select :app_documentation
                           (sql/fields :app_version_id)
-                          (sql/where {:app_version_id [:in version-ids]}))))))
+                          (sql/where {:app_version_id (db/sqlfn-any-array "uuid" version-ids)}))))))
 
 (defn add-documentation
   "Inserts an App's documentation into the database."

--- a/src/apps/persistence/app_documentation.clj
+++ b/src/apps/persistence/app_documentation.clj
@@ -3,9 +3,17 @@
             [korma.core :as sql]))
 
 (defn get-app-references
-  "Retrieves references for the given app ID."
+  "Retrieves references for the given app version ID."
   [app-version-id]
   (sql/select app_references (sql/where {:app_version_id app-version-id})))
+
+(defn get-app-references-for-versions
+  "Retrieves references for multiple app version IDs.
+   Returns a map of version-id -> [reference-row ...]."
+  [version-ids]
+  (when (seq version-ids)
+    (group-by :app_version_id
+              (sql/select app_references (sql/where {:app_version_id [:in version-ids]})))))
 
 (defn get-documentation
   "Retrieves documentation details for the given app ID."
@@ -26,6 +34,15 @@
                            [:creators.username :created_by]
                            [:editors.username :modified_by])
                (sql/where {:app_version_id app-version-id}))))
+
+(defn get-version-ids-with-docs
+  "Returns the set of version IDs (from the given collection) that have documentation."
+  [version-ids]
+  (when (seq version-ids)
+    (set (map :app_version_id
+              (sql/select :app_documentation
+                          (sql/fields :app_version_id)
+                          (sql/where {:app_version_id [:in version-ids]}))))))
 
 (defn add-documentation
   "Inserts an App's documentation into the database."

--- a/src/apps/persistence/app_groups.clj
+++ b/src/apps/persistence/app_groups.clj
@@ -156,6 +156,25 @@
               (sql/where {:app_category_app.app_id app-id
                           :is_public true})))
 
+(defn get-groups-for-apps
+  "Retrieves a listing of all groups each of the given apps is listed under.
+   Returns a map of app-id -> [{:id ... :name ...} ...]."
+  [app-ids]
+  (when (seq app-ids)
+    (let [rows (sql/select entities/app_category_listing
+                           (sql/fields :id
+                                       :name
+                                       [:app_category_app.app_id :app_id])
+                           (sql/join :app_category_app
+                                     (= :app_category_app.app_category_id
+                                        :app_category_listing.id))
+                           (sql/where {:app_category_app.app_id [:in app-ids]
+                                       :is_public true}))]
+      (into {}
+            (map (fn [[app-id groups]]
+                   [app-id (mapv #(select-keys % [:id :name]) groups)]))
+            (group-by :app_id rows)))))
+
 (defn get-suggested-groups-for-app
   "Retrieves a listing of all groups the integrator recommneds for the app."
   [app-id]
@@ -166,3 +185,21 @@
                         (= :app_categories.id
                            :suggested_groups.app_category_id))
               (sql/where {:suggested_groups.app_id app-id})))
+
+(defn get-suggested-groups-for-apps
+  "Retrieves a listing of all suggested groups for the given apps.
+   Returns a map of app-id -> [{:id ... :name ...} ...]."
+  [app-ids]
+  (when (seq app-ids)
+    (let [rows (sql/select :suggested_groups
+                           (sql/fields :app_categories.id
+                                       :app_categories.name
+                                       [:suggested_groups.app_id :app_id])
+                           (sql/join :app_categories
+                                     (= :app_categories.id
+                                        :suggested_groups.app_category_id))
+                           (sql/where {:suggested_groups.app_id [:in app-ids]}))]
+      (into {}
+            (map (fn [[app-id groups]]
+                   [app-id (mapv #(select-keys % [:id :name]) groups)]))
+            (group-by :app_id rows)))))

--- a/src/apps/persistence/app_groups.clj
+++ b/src/apps/persistence/app_groups.clj
@@ -156,6 +156,15 @@
               (sql/where {:app_category_app.app_id app-id
                           :is_public true})))
 
+(defn- group-categories-by-app-id
+  "Groups query rows by :app_id and extracts only :id and :name from each group entry.
+   Returns a map of app-id -> [{:id ... :name ...} ...]."
+  [rows]
+  (into {}
+        (map (fn [[app-id groups]]
+               [app-id (mapv #(select-keys % [:id :name]) groups)]))
+        (group-by :app_id rows)))
+
 (defn get-groups-for-apps
   "Retrieves a listing of all groups each of the given apps is listed under.
    Returns a map of app-id -> [{:id ... :name ...} ...]."
@@ -170,10 +179,7 @@
                                         :app_category_listing.id))
                            (sql/where {:app_category_app.app_id [:in app-ids]
                                        :is_public true}))]
-      (into {}
-            (map (fn [[app-id groups]]
-                   [app-id (mapv #(select-keys % [:id :name]) groups)]))
-            (group-by :app_id rows)))))
+      (group-categories-by-app-id rows))))
 
 (defn get-suggested-groups-for-app
   "Retrieves a listing of all groups the integrator recommneds for the app."
@@ -199,7 +205,4 @@
                                      (= :app_categories.id
                                         :suggested_groups.app_category_id))
                            (sql/where {:suggested_groups.app_id [:in app-ids]}))]
-      (into {}
-            (map (fn [[app-id groups]]
-                   [app-id (mapv #(select-keys % [:id :name]) groups)]))
-            (group-by :app_id rows)))))
+      (group-categories-by-app-id rows))))

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -3,7 +3,7 @@
             [apps.persistence.app-search :refer [count-matching-app-ids find-matching-app-ids]]
             [apps.persistence.entities :as entities]
             [apps.util.assertions :refer [assert-app-version]]
-            [apps.util.db :refer [add-date-limits-where-clause]]
+            [apps.util.db :refer [add-date-limits-where-clause sqlfn-any-array]]
             [clojure.java.jdbc]
             [clojure.string :as str]
             [kameleon.queries :as kq]
@@ -435,7 +435,7 @@
                     workspace-root-group-id
                     favorites-group-index)
                    (add-app-version-listing-ratings-fields user-id)
-                   (sql/where {:version_id [:in version-ids]})
+                   (sql/where {:version_id (sqlfn-any-array "uuid" version-ids)})
                    sql/select)]
       (into {} (map (juxt :version_id identity) rows)))))
 

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -414,6 +414,33 @@
          sql/select
          first))))
 
+(defn get-app-version-details-batch
+  "Retrieves details for multiple apps by version ID.
+   Returns a map of version-id -> details-row."
+  [user-id workspace-root-group-id favorites-group-index version-ids]
+  (when (seq version-ids)
+    (let [rating-avg-subselect (sql/subselect
+                                entities/ratings
+                                (sql/fields (sql/raw "CAST(COALESCE(AVG(rating), 0.0) AS DOUBLE PRECISION) AS average_rating"))
+                                (sql/where {:ratings.app_id
+                                            :app_versions_listing.id}))
+          rating-total-subselect (sql/subselect
+                                  entities/ratings
+                                  (sql/aggregate (count :ratings.rating) :total_ratings)
+                                  (sql/where {:ratings.app_id
+                                              :app_versions_listing.id}))
+          rows (-> (sql/select* :app_versions_listing)
+                   (sql/fields :*
+                               [rating-avg-subselect :average_rating]
+                               [rating-total-subselect :total_ratings])
+                   (add-app-versions-listing-is-favorite-field
+                    workspace-root-group-id
+                    favorites-group-index)
+                   (add-app-version-listing-ratings-fields user-id)
+                   (sql/where {:version_id [:in version-ids]})
+                   sql/select)]
+      (into {} (map (juxt :version_id identity) rows)))))
+
 (defn- add-deleted-and-orphaned-where-clause
   [query public-app-ids]
   (sql/where query

--- a/src/apps/persistence/app_listing.clj
+++ b/src/apps/persistence/app_listing.clj
@@ -386,53 +386,51 @@
     (query-spy "get-single-app::search-query:" q)
     (sql/select q)))
 
+(defn- rating-avg-subselect
+  "Subselect for computing the average rating of an app in the app_versions_listing view."
+  []
+  (sql/subselect
+   entities/ratings
+   (sql/fields (sql/raw "CAST(COALESCE(AVG(rating), 0.0) AS DOUBLE PRECISION) AS average_rating"))
+   (sql/where {:ratings.app_id
+               :app_versions_listing.id})))
+
+(defn- rating-total-subselect
+  "Subselect for computing the total number of ratings for an app in the app_versions_listing view."
+  []
+  (sql/subselect
+   entities/ratings
+   (sql/aggregate (count :ratings.rating) :total_ratings)
+   (sql/where {:ratings.app_id
+               :app_versions_listing.id})))
+
 (defn get-app-version-details
   "Retrieves the details for a single app."
   [user-id workspace-root-group-id favorites-group-index app-id version-id]
-  (let [rating-avg-subselect (sql/subselect
-                              entities/ratings
-                              (sql/fields (sql/raw "CAST(COALESCE(AVG(rating), 0.0) AS DOUBLE PRECISION) AS average_rating"))
-                              (sql/where {:ratings.app_id
-                                          :app_versions_listing.id}))
-        rating-total-subselect (sql/subselect
-                                entities/ratings
-                                (sql/aggregate (count :ratings.rating) :total_ratings)
-                                (sql/where {:ratings.app_id
-                                            :app_versions_listing.id}))]
-    (assert-app-version
-     [app-id version-id]
-     (-> (sql/select* :app_versions_listing)
-         (sql/fields :*
-                     [rating-avg-subselect :average_rating]
-                     [rating-total-subselect :total_ratings])
-         (add-app-versions-listing-is-favorite-field
-          workspace-root-group-id
-          favorites-group-index)
-         (add-app-version-listing-ratings-fields user-id)
-         (sql/where {:id         app-id
-                     :version_id version-id})
-         sql/select
-         first))))
+  (assert-app-version
+   [app-id version-id]
+   (-> (sql/select* :app_versions_listing)
+       (sql/fields :*
+                   [(rating-avg-subselect) :average_rating]
+                   [(rating-total-subselect) :total_ratings])
+       (add-app-versions-listing-is-favorite-field
+        workspace-root-group-id
+        favorites-group-index)
+       (add-app-version-listing-ratings-fields user-id)
+       (sql/where {:id         app-id
+                   :version_id version-id})
+       sql/select
+       first)))
 
 (defn get-app-version-details-batch
   "Retrieves details for multiple apps by version ID.
    Returns a map of version-id -> details-row."
   [user-id workspace-root-group-id favorites-group-index version-ids]
   (when (seq version-ids)
-    (let [rating-avg-subselect (sql/subselect
-                                entities/ratings
-                                (sql/fields (sql/raw "CAST(COALESCE(AVG(rating), 0.0) AS DOUBLE PRECISION) AS average_rating"))
-                                (sql/where {:ratings.app_id
-                                            :app_versions_listing.id}))
-          rating-total-subselect (sql/subselect
-                                  entities/ratings
-                                  (sql/aggregate (count :ratings.rating) :total_ratings)
-                                  (sql/where {:ratings.app_id
-                                              :app_versions_listing.id}))
-          rows (-> (sql/select* :app_versions_listing)
+    (let [rows (-> (sql/select* :app_versions_listing)
                    (sql/fields :*
-                               [rating-avg-subselect :average_rating]
-                               [rating-total-subselect :total_ratings])
+                               [(rating-avg-subselect) :average_rating]
+                               [(rating-total-subselect) :total_ratings])
                    (add-app-versions-listing-is-favorite-field
                     workspace-root-group-id
                     favorites-group-index)

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -1125,3 +1125,47 @@
                              :app_publication_request_status_code_id status-code-id
                              :updater_id                             user-id})
                           request-ids)))))
+
+;; --- Batch query functions for publication-request listing optimization ---
+
+(defn get-app-latest-versions
+  "Retrieves the latest version ID for each of the given app IDs.
+   Returns a map of app-id -> version-id."
+  [app-ids]
+  (when (seq app-ids)
+    (into {}
+          (map (juxt :id :version_id))
+          (select entities/app_listing
+                  (fields :id :version_id)
+                  (where {:id [:in app-ids]})))))
+
+(defn list-app-versions-for-apps
+  "Retrieves the list of available versions for multiple apps.
+   Returns a map of app-id -> [{:version ... :version_id ...} ...]."
+  ([app-ids]
+   (list-app-versions-for-apps app-ids false))
+  ([app-ids include-deleted?]
+   (when (seq app-ids)
+     (let [rows (-> (select* entities/app_versions)
+                    (fields :app_id :version [:id :version_id])
+                    (where {:app_id [:in app-ids]})
+                    ((fn [q] (if-not include-deleted? (where q {:deleted false}) q)))
+                    (order :version_order :DESC)
+                    select)]
+       (group-by :app_id rows)))))
+
+(defn get-app-version-tools-batch
+  "Loads information about the tools associated with specific app versions.
+   Returns a map of version-id -> [tool ...]."
+  [version-ids]
+  (when (seq version-ids)
+    (let [rows (-> (get-tool-listing-base-query)
+                   (join :container_images {:tool_listing.container_images_id :container_images.id})
+                   (fields [:container_images.name :image_name]
+                           [:container_images.tag :image_tag]
+                           [:container_images.url :image_url]
+                           [:container_images.deprecated :deprecated]
+                           :app_version_id)
+                   (where {:app_version_id [:in version-ids]})
+                   select)]
+      (group-by :app_version_id rows))))

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -326,22 +326,22 @@
               :version
               :attribution)))
 
-(defn- get-app-tools-base-query
-  "Returns a query for information about the tools associated with an app."
-  [app-id]
+(defn- get-tools-with-images-base-query
+  "Returns a base query for tool information including the container image join and fields."
+  []
   (-> (get-tool-listing-base-query)
       (join :container_images {:tool_listing.container_images_id :container_images.id})
       (fields [:container_images.name :image_name]
               [:container_images.tag :image_tag]
               [:container_images.url :image_url]
-              [:container_images.deprecated :deprecated])
-      (where {:app_id app-id})))
+              [:container_images.deprecated :deprecated])))
 
 (defn get-app-tools
   "Loads information about the tools associated with undeleted versions of an app."
   [app-id]
-  (-> (get-app-tools-base-query app-id)
-      (where {:app_version_id [:in (subselect entities/app_versions
+  (-> (get-tools-with-images-base-query)
+      (where {:app_id         app-id
+              :app_version_id [:in (subselect entities/app_versions
                                               (fields :id)
                                               (where {:app_id  app-id
                                                       :deleted false}))]})
@@ -350,8 +350,9 @@
 (defn get-all-app-tools
   "Loads information about the tools associated with all versions of an app."
   [app-id]
-  (-> (get-app-tools-base-query app-id)
-      (where {:app_version_id [:in (subselect entities/app_versions
+  (-> (get-tools-with-images-base-query)
+      (where {:app_id         app-id
+              :app_version_id [:in (subselect entities/app_versions
                                               (fields :id)
                                               (where {:app_id app-id}))]})
       select))
@@ -359,8 +360,9 @@
 (defn get-app-version-tools
   "Loads information about the tools associated with a specific app version."
   [app-id version-id]
-  (-> (get-app-tools-base-query app-id)
-      (where {:app_version_id version-id})
+  (-> (get-tools-with-images-base-query)
+      (where {:app_id         app-id
+              :app_version_id version-id})
       select))
 
 (defn task-ids-for-app-version
@@ -1159,13 +1161,8 @@
    Returns a map of version-id -> [tool ...]."
   [version-ids]
   (when (seq version-ids)
-    (let [rows (-> (get-tool-listing-base-query)
-                   (join :container_images {:tool_listing.container_images_id :container_images.id})
-                   (fields [:container_images.name :image_name]
-                           [:container_images.tag :image_tag]
-                           [:container_images.url :image_url]
-                           [:container_images.deprecated :deprecated]
-                           :app_version_id)
+    (let [rows (-> (get-tools-with-images-base-query)
+                   (fields :app_version_id)
                    (where {:app_version_id [:in version-ids]})
                    select)]
       (group-by :app_version_id rows))))

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -1146,12 +1146,12 @@
    (list-app-versions-for-apps app-ids false))
   ([app-ids include-deleted?]
    (when (seq app-ids)
-     (let [rows (-> (select* entities/app_versions)
-                    (fields :app_id :version [:id :version_id])
-                    (where {:app_id [:in app-ids]})
-                    ((fn [q] (if-not include-deleted? (where q {:deleted false}) q)))
-                    (order :version_order :DESC)
-                    select)]
+      (let [rows (-> (select* entities/app_versions)
+                     (fields :app_id :version [:id :version_id])
+                     (where {:app_id [:in app-ids]})
+                     (add-deleted-versions-clause include-deleted?)
+                     (order :version_order :DESC)
+                     select)]
        (group-by :app_id rows)))))
 
 (defn get-app-version-tools-batch

--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -1148,12 +1148,12 @@
    (list-app-versions-for-apps app-ids false))
   ([app-ids include-deleted?]
    (when (seq app-ids)
-      (let [rows (-> (select* entities/app_versions)
-                     (fields :app_id :version [:id :version_id])
-                     (where {:app_id [:in app-ids]})
-                     (add-deleted-versions-clause include-deleted?)
-                     (order :version_order :DESC)
-                     select)]
+     (let [rows (-> (select* entities/app_versions)
+                    (fields :app_id :version [:id :version_id])
+                    (where {:app_id [:in app-ids]})
+                    (add-deleted-versions-clause include-deleted?)
+                    (order :version_order :DESC)
+                    select)]
        (group-by :app_id rows)))))
 
 (defn get-app-version-tools-batch

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -921,9 +921,10 @@
   (when (seq app-ids)
     (let [rows (-> (sql/select* [:jobs :j])
                    (sql/fields :j.app_id
-                               [(sql/raw "COUNT(j.id) FILTER (WHERE j.status = 'Completed' AND NOT EXISTS (SELECT parent_id FROM jobs jp WHERE jp.parent_id = j.id))")
+                               [(sql/raw (str "COUNT(j.id) FILTER (WHERE j.status = '" completed-status "'"
+                                              " AND NOT EXISTS (SELECT parent_id FROM jobs jp WHERE jp.parent_id = j.id))"))
                                 :job_count_completed]
-                               [(sql/raw "MAX(j.end_date) FILTER (WHERE j.status = 'Completed')")
+                               [(sql/raw (str "MAX(j.end_date) FILTER (WHERE j.status = '" completed-status "')"))
                                 :job_last_completed])
                    (sql/where {:j.app_id [:in app-ids]})
                    (db/add-date-limits-where-clause params)

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -913,3 +913,24 @@
   "Sets a timeout for obtaining locks in the database."
   []
   (sql/exec-raw ["SET LOCAL lock_timeout='5s'" []]))
+
+(defn get-public-job-stats-batch
+  "Fetches public job stats (job_count_completed and job_last_completed) for multiple app IDs.
+   Returns a map of app-id-string -> {:job_count_completed N :job_last_completed timestamp-or-nil}."
+  [app-ids params]
+  (when (seq app-ids)
+    (let [rows (-> (sql/select* [:jobs :j])
+                   (sql/fields :j.app_id
+                               [(sql/raw "COUNT(j.id) FILTER (WHERE j.status = 'Completed' AND NOT EXISTS (SELECT parent_id FROM jobs jp WHERE jp.parent_id = j.id))")
+                                :job_count_completed]
+                               [(sql/raw "MAX(j.end_date) FILTER (WHERE j.status = 'Completed')")
+                                :job_last_completed])
+                   (sql/where {:j.app_id [:in app-ids]})
+                   (db/add-date-limits-where-clause params)
+                   (sql/group :j.app_id)
+                   sql/select)]
+      (into {}
+            (map (fn [{:keys [app_id] :as row}]
+                   [app_id (merge {:job_count_completed 0}
+                                  (dissoc row :app_id))]))
+            rows))))

--- a/src/apps/persistence/jobs.clj
+++ b/src/apps/persistence/jobs.clj
@@ -926,7 +926,7 @@
                                 :job_count_completed]
                                [(sql/raw (str "MAX(j.end_date) FILTER (WHERE j.status = '" completed-status "')"))
                                 :job_last_completed])
-                   (sql/where {:j.app_id [:in app-ids]})
+                   (sql/where {:j.app_id (db/sqlfn-any-array "varchar" app-ids)})
                    (db/add-date-limits-where-clause params)
                    (sql/group :j.app_id)
                    sql/select)]

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -611,52 +611,51 @@
   ([{username :shortUsername :as user} details tools app-references admin?
     {:keys [versions-map job-stats-map groups-map suggested-map hierarchies-map has-docs-set]}]
    (let [{app-id :id version-id :version_id} details]
-     (-> details
-         (select-keys [:id
-                       :wiki_url
-                       :version
-                       :version_id
-                       :deleted
-                       :disabled
-                       :edited_date
-                       :integration_date
-                       :integrator_name
-                       :integrator_email
-                       :step_count
-                       :tool_count
-                       :external_app_count
-                       :task_count
-                       :overall_job_type
-                       :average_rating
-                       :total_ratings
-                       :is_favorite])
-         (assoc :name                 (:name details "")
-                :description          (:description details "")
-                :versions             (if versions-map
-                                        (mapv #(select-keys % [:version :version_id])
-                                              (get versions-map app-id []))
-                                        (amp/list-app-versions app-id admin?))
-                :references           (map :reference_text app-references)
-                :tools                (map format-app-tool tools)
-                :job_stats            (if job-stats-map
-                                        (remove-nil-vals
-                                         (or (get job-stats-map (str app-id))
-                                             {:job_count_completed 0}))
-                                        (format-app-details-job-stats (str app-id) nil admin?))
-                :extra                (format-app-extra-info version-id admin?)
-                :documentation        (format-app-documentation app-id version-id user admin?)
-                :categories           (if groups-map
-                                        (get groups-map app-id [])
-                                        (get-groups-for-app app-id))
-                :suggested_categories (if suggested-map
-                                        (get suggested-map app-id [])
-                                        (get-suggested-groups-for-app app-id))
-                :system_id            c/system-id)
-         ((fn [app]
-            (if hierarchies-map
-              (merge app (get hierarchies-map app-id {:hierarchies []}))
-              (format-app-hierarchies app username))))
-         (format-wiki-url has-docs-set)))))
+     (as-> details app
+       (select-keys app [:id
+                         :wiki_url
+                         :version
+                         :version_id
+                         :deleted
+                         :disabled
+                         :edited_date
+                         :integration_date
+                         :integrator_name
+                         :integrator_email
+                         :step_count
+                         :tool_count
+                         :external_app_count
+                         :task_count
+                         :overall_job_type
+                         :average_rating
+                         :total_ratings
+                         :is_favorite])
+       (assoc app :name                 (:name details "")
+                  :description          (:description details "")
+                  :versions             (if versions-map
+                                          (mapv #(select-keys % [:version :version_id])
+                                                (get versions-map app-id []))
+                                          (amp/list-app-versions app-id admin?))
+                  :references           (map :reference_text app-references)
+                  :tools                (map format-app-tool tools)
+                  :job_stats            (if job-stats-map
+                                          (remove-nil-vals
+                                           (or (get job-stats-map (str app-id))
+                                               {:job_count_completed 0}))
+                                          (format-app-details-job-stats (str app-id) nil admin?))
+                  :extra                (format-app-extra-info version-id admin?)
+                  :documentation        (format-app-documentation app-id version-id user admin?)
+                  :categories           (if groups-map
+                                          (get groups-map app-id [])
+                                          (get-groups-for-app app-id))
+                  :suggested_categories (if suggested-map
+                                          (get suggested-map app-id [])
+                                          (get-suggested-groups-for-app app-id))
+                  :system_id            c/system-id)
+       (if hierarchies-map
+         (merge app (get hierarchies-map app-id {:hierarchies []}))
+         (format-app-hierarchies app username))
+       (format-wiki-url app has-docs-set)))))
 
 ;; This function was split from `get-app-details` to provide a way for administrative endpoints to skip permission
 ;; checks without including the app stat information.

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -859,7 +859,7 @@
             ;; Phase C: Deref all futures and assemble results.
             ;; Re-key details-map by app-id for easier lookup
             details-by-app  (into {}
-                                  (map (fn [[vid details]]
+                                  (map (fn [[_ details]]
                                          [(:id details) details]))
                                   (or @details-map {}))
 

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -808,10 +808,10 @@
    Delegates to format-app-details with pre-fetched maps to avoid duplicating formatting logic."
   [user format-app details-map tools-map refs-map prefetched
    {app-id :app_id :keys [id requestor]}]
-  (let [details (get details-map app-id)
+  (let [details    (get details-map app-id)
         version-id (:version_id details)
-        tools   (get tools-map version-id [])
-        refs    (get refs-map version-id [])]
+        tools      (get tools-map version-id [])
+        refs       (get refs-map version-id [])]
     {:id        id
      :app       (when details
                   (->> (format-app-details user details tools refs false prefetched)

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -630,28 +630,29 @@
                          :average_rating
                          :total_ratings
                          :is_favorite])
-       (assoc app :name                 (:name details "")
-                  :description          (:description details "")
-                  :versions             (if versions-map
-                                          (mapv #(select-keys % [:version :version_id])
-                                                (get versions-map app-id []))
-                                          (amp/list-app-versions app-id admin?))
-                  :references           (map :reference_text app-references)
-                  :tools                (map format-app-tool tools)
-                  :job_stats            (if job-stats-map
-                                          (remove-nil-vals
-                                           (or (get job-stats-map (str app-id))
-                                               {:job_count_completed 0}))
-                                          (format-app-details-job-stats (str app-id) nil admin?))
-                  :extra                (format-app-extra-info version-id admin?)
-                  :documentation        (format-app-documentation app-id version-id user admin?)
-                  :categories           (if groups-map
-                                          (get groups-map app-id [])
-                                          (get-groups-for-app app-id))
-                  :suggested_categories (if suggested-map
-                                          (get suggested-map app-id [])
-                                          (get-suggested-groups-for-app app-id))
-                  :system_id            c/system-id)
+       (assoc app
+              :name                 (:name details "")
+              :description          (:description details "")
+              :versions             (if versions-map
+                                      (mapv #(select-keys % [:version :version_id])
+                                            (get versions-map app-id []))
+                                      (amp/list-app-versions app-id admin?))
+              :references           (map :reference_text app-references)
+              :tools                (map format-app-tool tools)
+              :job_stats            (if job-stats-map
+                                      (remove-nil-vals
+                                       (or (get job-stats-map (str app-id))
+                                           {:job_count_completed 0}))
+                                      (format-app-details-job-stats (str app-id) nil admin?))
+              :extra                (format-app-extra-info version-id admin?)
+              :documentation        (format-app-documentation app-id version-id user admin?)
+              :categories           (if groups-map
+                                      (get groups-map app-id [])
+                                      (get-groups-for-app app-id))
+              :suggested_categories (if suggested-map
+                                      (get suggested-map app-id [])
+                                      (get-suggested-groups-for-app app-id))
+              :system_id            c/system-id)
        (if hierarchies-map
          (merge app (get hierarchies-map app-id {:hierarchies []}))
          (format-app-hierarchies app username))

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -827,7 +827,7 @@
     (if (empty? requests)
       []
       (let [{:keys [username shortUsername]} user
-            app-ids         (distinct (map :app_id requests))
+            app-ids         (vec (distinct (map :app_id requests)))
 
             ;; Phase A: Fire I/O that only depends on app-ids immediately.
             ;; These run in parallel with the version-ids-map query below.

--- a/src/apps/service/apps/de/listings.clj
+++ b/src/apps/service/apps/de/listings.clj
@@ -8,7 +8,9 @@
     :refer [get-app-category
             get-app-group-hierarchy
             get-groups-for-app
+            get-groups-for-apps
             get-suggested-groups-for-app
+            get-suggested-groups-for-apps
             get-visible-workspaces
             search-app-groups]]
    [apps.persistence.app-listing
@@ -22,6 +24,7 @@
             get-all-app-ids
             get-app-extra-info
             get-app-version-details
+            get-app-version-details-batch
             get-apps-for-admin
             get-apps-for-user
             get-apps-in-group-for-user
@@ -541,9 +544,16 @@
      :apps  apps}))
 
 (defn- format-wiki-url
-  "CORE-6510: Remove the wiki_url from app details responses if the App has documentation saved."
-  [{:keys [id wiki_url] :as app}]
-  (assoc app :wiki_url (if (docs/has-docs? id) nil wiki_url)))
+  "CORE-6510: Remove the wiki_url from app details responses if the App has documentation saved.
+   Accepts an optional has-docs-set for batched use; when provided, checks set membership
+   by version-id instead of querying the database."
+  ([app]
+   (format-wiki-url app nil))
+  ([{:keys [id version_id wiki_url] :as app} has-docs-set]
+   (let [has-docs? (if has-docs-set
+                     (contains? has-docs-set version_id)
+                     (docs/has-docs? id))]
+     (assoc app :wiki_url (if has-docs? nil wiki_url)))))
 
 (defn- format-app-hierarchies
   [{app-id :id :as app} username]
@@ -569,10 +579,10 @@
     nil))
 
 (defn- format-app-documentation
-  [app-id version-id username admin?]
+  [app-id version-id user admin?]
   (when admin?
     (try+
-     (docs/get-app-version-docs username app-id version-id admin?)
+     (docs/get-app-version-docs user app-id version-id admin?)
      (catch [:type :clojure-commons.exception/not-found] _ nil))))
 
 (defn- format-tool-image [{:keys [image_name image_tag image_url deprecated]}]
@@ -587,41 +597,66 @@
          :container {:image (format-tool-image tool)}))
 
 (defn- format-app-details
-  "Formats information for the get-app-details service."
-  [{username :shortUsername :as user} details tools app-references admin?]
-  (let [{app-id :id version-id :version_id} details]
-    (-> details
-        (select-keys [:id
-                      :wiki_url
-                      :version
-                      :version_id
-                      :deleted
-                      :disabled
-                      :edited_date
-                      :integration_date
-                      :integrator_name
-                      :integrator_email
-                      :step_count
-                      :tool_count
-                      :external_app_count
-                      :task_count
-                      :overall_job_type
-                      :average_rating
-                      :total_ratings
-                      :is_favorite])
-        (assoc :name                 (:name details "")
-               :description          (:description details "")
-               :versions             (amp/list-app-versions app-id admin?)
-               :references           (map :reference_text app-references)
-               :tools                (map format-app-tool tools)
-               :job_stats            (format-app-details-job-stats (str app-id) nil admin?)
-               :extra                (format-app-extra-info version-id admin?)
-               :documentation        (format-app-documentation app-id version-id user admin?)
-               :categories           (get-groups-for-app app-id)
-               :suggested_categories (get-suggested-groups-for-app app-id)
-               :system_id            c/system-id)
-        (format-app-hierarchies username)
-        format-wiki-url)))
+  "Formats information for the get-app-details service.
+   Accepts an optional `prefetched` map for batched use. When keys are present in the map,
+   they are used instead of performing per-app I/O. Supported keys:
+     :versions-map      - {app-id -> [{:version ... :version_id ...} ...]}
+     :job-stats-map     - {app-id-string -> {:job_count_completed N ...}}
+     :groups-map        - {app-id -> [{:id :name} ...]}
+     :suggested-map     - {app-id -> [{:id :name} ...]}
+     :hierarchies-map   - {app-id -> {:hierarchies [...]}}
+     :has-docs-set      - #{version-id ...}  (for format-wiki-url)"
+  ([user details tools app-references admin?]
+   (format-app-details user details tools app-references admin? nil))
+  ([{username :shortUsername :as user} details tools app-references admin?
+    {:keys [versions-map job-stats-map groups-map suggested-map hierarchies-map has-docs-set]}]
+   (let [{app-id :id version-id :version_id} details]
+     (-> details
+         (select-keys [:id
+                       :wiki_url
+                       :version
+                       :version_id
+                       :deleted
+                       :disabled
+                       :edited_date
+                       :integration_date
+                       :integrator_name
+                       :integrator_email
+                       :step_count
+                       :tool_count
+                       :external_app_count
+                       :task_count
+                       :overall_job_type
+                       :average_rating
+                       :total_ratings
+                       :is_favorite])
+         (assoc :name                 (:name details "")
+                :description          (:description details "")
+                :versions             (if versions-map
+                                        (mapv #(select-keys % [:version :version_id])
+                                              (get versions-map app-id []))
+                                        (amp/list-app-versions app-id admin?))
+                :references           (map :reference_text app-references)
+                :tools                (map format-app-tool tools)
+                :job_stats            (if job-stats-map
+                                        (remove-nil-vals
+                                         (or (get job-stats-map (str app-id))
+                                             {:job_count_completed 0}))
+                                        (format-app-details-job-stats (str app-id) nil admin?))
+                :extra                (format-app-extra-info version-id admin?)
+                :documentation        (format-app-documentation app-id version-id user admin?)
+                :categories           (if groups-map
+                                        (get groups-map app-id [])
+                                        (get-groups-for-app app-id))
+                :suggested_categories (if suggested-map
+                                        (get suggested-map app-id [])
+                                        (get-suggested-groups-for-app app-id))
+                :system_id            c/system-id)
+         ((fn [app]
+            (if hierarchies-map
+              (merge app (get hierarchies-map app-id {:hierarchies []}))
+              (format-app-hierarchies app username))))
+         (format-wiki-url has-docs-set)))))
 
 ;; This function was split from `get-app-details` to provide a way for administrative endpoints to skip permission
 ;; checks without including the app stat information.
@@ -768,17 +803,80 @@
        (filter (comp amp/param-ds-input-types :type))
        (mapv #(str (:step_id %) "_" (:id %)))))
 
-(defn- format-app-publication-request
-  [user {app-id :app_id :keys [id requestor]}]
-  {:id        id
-   :app       (get-app-details* user app-id false)
-   :requestor requestor})
+(defn- format-app-publication-request-batched
+  "Formats a single publication request using pre-fetched batch data.
+   Delegates to format-app-details with pre-fetched maps to avoid duplicating formatting logic."
+  [user format-app details-map tools-map refs-map prefetched
+   {app-id :app_id :keys [id requestor]}]
+  (let [details (get details-map app-id)
+        version-id (:version_id details)
+        tools   (get tools-map version-id [])
+        refs    (get refs-map version-id [])]
+    {:id        id
+     :app       (when details
+                  (->> (format-app-details user details tools refs false prefetched)
+                       format-app
+                       (remove-nil-vals)))
+     :requestor requestor}))
 
 (defn list-app-publication-requests
-  "Lists app publication requests, optionally filtering the listing by app ID or requestor."
+  "Lists app publication requests, optionally filtering the listing by app ID or requestor.
+   Uses batched queries to avoid the N+1 problem."
   [user {app-id :app_id include-completed :include_completed :keys [requestor]}]
-  (mapv (partial format-app-publication-request user)
-        (amp/list-app-publication-requests app-id requestor include-completed)))
+  (let [requests (amp/list-app-publication-requests app-id requestor include-completed)]
+    (if (empty? requests)
+      []
+      (let [{:keys [username shortUsername]} user
+            app-ids         (distinct (map :app_id requests))
+
+            ;; Phase A: Fire I/O that only depends on app-ids immediately.
+            ;; These run in parallel with the version-ids-map query below.
+            workspace       (get-workspace username)
+            public-app-ids  (future (perms-client/get-public-app-ids))
+            perms           (future (perms-client/load-app-permissions shortUsername app-ids))
+            hierarchies-map (future (metadata-client/filter-hierarchies-batch
+                                     shortUsername
+                                     app-ids
+                                     (workspace-metadata-category-attrs)))
+            versions-map    (future (amp/list-app-versions-for-apps app-ids))
+            groups-map      (future (get-groups-for-apps app-ids))
+            suggested-map   (future (get-suggested-groups-for-apps app-ids))
+            job-stats-map   (future (jobs-db/get-public-job-stats-batch (map str app-ids) nil))
+
+            ;; Phase B: Resolve version-ids (one DB query); then fire I/O that depends on them.
+            version-ids-map (amp/get-app-latest-versions app-ids)
+            version-ids     (into [] (comp (filter some?) (distinct)) (vals version-ids-map))
+
+            details-map     (future (get-app-version-details-batch
+                                     (:user_id workspace)
+                                     (:root_category_id workspace)
+                                     (workspace-favorites-app-category-index)
+                                     version-ids))
+            tools-map       (future (amp/get-app-version-tools-batch version-ids))
+            refs-map        (future (app-docs-db/get-app-references-for-versions version-ids))
+            has-docs-set    (future (app-docs-db/get-version-ids-with-docs version-ids))
+
+            ;; Phase C: Deref all futures and assemble results.
+            ;; Re-key details-map by app-id for easier lookup
+            details-by-app  (into {}
+                                  (map (fn [[vid details]]
+                                         [(:id details) details]))
+                                  (or @details-map {}))
+
+            ;; Build the listing formatter (batches beta/certified/limits internally)
+            format-app      (get-app-listing-formatter user false @perms app-ids @public-app-ids)
+
+            ;; Assemble the pre-fetched map for format-app-details
+            prefetched      {:versions-map    @versions-map
+                             :job-stats-map   @job-stats-map
+                             :groups-map      @groups-map
+                             :suggested-map   @suggested-map
+                             :hierarchies-map @hierarchies-map
+                             :has-docs-set    @has-docs-set}]
+
+        (mapv (partial format-app-publication-request-batched
+                       user format-app details-by-app @tools-map @refs-map prefetched)
+              requests)))))
 
 (defn list-tools-in-untrusted-registries
   "Lists tools in untrusted registries that are in use by an app."


### PR DESCRIPTION
Refactored the publication requests endpoint to batch all I/O instead of calling get-app-details* per request

- Added batch DB functions: get-app-latest-versions, get-app-version-details-batch, get-app-version-tools-batch, get-app-references-for-versions, get-version-ids-with-docs, get-groups-for-apps, get-suggested-groups-for-apps, get-public-job-stats-batch
- Refactored format-app-details to accept optional pre-fetched data maps, so batched and single-app paths share formatting logic
- Perform independent I/O concurrently via futures

Depends on https://github.com/cyverse-de/metadata-client/pull/8 and transitively https://github.com/cyverse-de/metadata/pull/30 and https://github.com/cyverse-de/common-swagger-api/pull/99