### PR TITLE
Forward mount_data_store from analysis submission into job model

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.2.1"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-cfg "2.8.3"]
-                 [org.cyverse/common-swagger-api "3.4.17"]
+                 [org.cyverse/common-swagger-api "3.4.19"]
                  [org.cyverse/cyverse-groups-client "0.1.9"]
                  [org.cyverse/permissions-client "2.8.5"]
                  [org.cyverse/service-logging "2.8.4"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.cyverse/metadata-client "3.2.1"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-cfg "2.8.3"]
-                 [org.cyverse/common-swagger-api "3.4.19"]
+                 [org.cyverse/common-swagger-api "3.4.20"]
                  [org.cyverse/cyverse-groups-client "0.1.9"]
                  [org.cyverse/permissions-client "2.8.5"]
                  [org.cyverse/service-logging "2.8.4"]

--- a/src/apps/persistence/users.clj
+++ b/src/apps/persistence/users.clj
@@ -56,11 +56,11 @@
   "Gets an existing login record that matches all fields"
   [user-id ip-address session-id login-time]
   (first
-    (sql/select :logins
-                (sql/where {:user_id user-id
-                            :ip_address ip-address
-                            :session_id session-id
-                            :login_time (long->timestamp login-time)}))))
+   (sql/select :logins
+               (sql/where {:user_id user-id
+                           :ip_address ip-address
+                           :session_id session-id
+                           :login_time (long->timestamp login-time)}))))
 
 (defn- upsert-login-record
   "Records a user login, if at least one field differs from an existing entry."

--- a/src/apps/service/apps/de/job_view.clj
+++ b/src/apps/service/apps/de/job_view.clj
@@ -131,7 +131,7 @@
   [user {:keys [id name version_id] :as app} include-hidden-params?]
   (let [app-steps           (get-steps version_id)
         limit-check-results (limits/load-limit-check-results user)]
-    (-> (select-keys app [:id :name :description :disabled :deleted :version :version_id])
+    (-> (select-keys app [:id :name :description :disabled :deleted :version :version_id :overall_job_type])
         (assoc :label name
                :versions (amp/list-app-versions id)
                :requirements (map (partial get-step-resource-requirements app) app-steps)

--- a/src/apps/service/apps/de/jobs/common.clj
+++ b/src/apps/service/apps/de/jobs/common.clj
@@ -203,5 +203,6 @@
          :uuid                 (or (:uuid submission) (uuid))
          :wiki_url             (:wiki_url app)
          :skip-parent-meta     (:skip-parent-meta submission)
-         :file-metadata        (:file-metadata submission)}
+         :file-metadata        (:file-metadata submission)
+         :mount_data_store     (:mount_data_store submission true)}
         execution-target)))

--- a/src/apps/service/apps/jobs/params.clj
+++ b/src/apps/service/apps/jobs/params.clj
@@ -181,11 +181,12 @@
 
 (defn get-job-relaunch-info
   [apps-client user {system-id :system_id app-id :app_id version-id :app_version_id :as job}]
-  (let [{:keys [debug config requirements] :or {debug false}} (get-job-submission job)]
+  (let [{:keys [debug config requirements mount_data_store] :or {debug false mount_data_store true}} (get-job-submission job)]
     (-> (if version-id
           (.getAppVersionJobView apps-client system-id app-id version-id)
           (.getAppJobView apps-client system-id app-id))
         (assoc :debug debug)
+        (assoc :mount_data_store mount_data_store)
         (update :groups (partial update-app-groups user config))
         (update :requirements update-resources-reqs requirements))))
 
@@ -193,7 +194,9 @@
   [apps-client user {system-id :system_id app-id :app_id :as submission}]
   (when-not system-id (cxu/internal-system-error "no system ID assocaited with submission"))
   (when-not app-id (cxu/internal-system-error "no app ID associated with submission"))
-  (update (assoc (.getAppJobView apps-client system-id (uuidify app-id)) :debug (:debug submission false))
+  (update (assoc (.getAppJobView apps-client system-id (uuidify app-id))
+                 :debug (:debug submission false)
+                 :mount_data_store (:mount_data_store submission true))
           :groups
           (partial update-app-groups user (:config submission))))
 


### PR DESCRIPTION
The field existed in the AnalysisSubmission schema and in model.Job, but build-submission silently dropped it. Add it to the outgoing job map with a default of true so that omitting the field from a submission preserves the existing behaviour.