### PR TITLE
Read the notification type through its lookup table

### DIFF
--- a/src/apps/persistence/app_metadata.clj
+++ b/src/apps/persistence/app_metadata.clj
@@ -404,7 +404,8 @@
                (join [:tasks :task] {:step.task_id :task.id})
                (join [:tools :tool] {:task.tool_id :tool.id})
                (join [:tool_types :tt] {:tool.tool_type_id :tt.id})
-               (fields :tt.notification_type)
+               (join [:notification_types :nt] {:tt.notification_type_id :nt.id})
+               (fields [:nt.name :notification_type])
                (where {:step.app_version_id app-version-id}))
        (map :notification_type)))
 


### PR DESCRIPTION
Companion to [cyverse-de/de-database#45](https://github.com/cyverse-de/de-database/pull/45), which replaces the `notification_types` enum with a lookup table and turns `tool_types.notification_type` into a `notification_type_id` foreign key.

`get-app-notification-types` is the **only** reader of that column anywhere in the codebase — everything else touching `tool_types` (`persistence/tools.clj`, `metadata/element_listings.clj`, `persistence/jobs.clj`, the `/tool-types` endpoint) selects `id`/`name`/`label`/`description`/`hidden`.

```diff
                (join [:tool_types :tt] {:tool.tool_type_id :tt.id})
+               (join [:notification_types :nt] {:tt.notification_type_id :nt.id})
-               (fields :tt.notification_type)
+               (fields [:nt.name :notification_type])
                (where {:step.app_version_id app-version-id}))
        (map :notification_type)))
```

Aliased back to `:notification_type` so `get-notification-type` in `clients/notifications.clj` is untouched and the return stays a seq of strings.

The added join can neither drop nor duplicate a row: `notification_type_id` is `NOT NULL` with an FK to the lookup table's primary key, so it matches exactly one.

## Deploy alongside the migration

This PR and de-database#45 are a matched pair: the migration drops `tool_types.notification_type`, so the current code stops finding it, and this code selects through `notification_types`, which doesn't exist until the migration lands. Whichever goes first, `get-app-notification-types` raises until the other catches up. The ordering is symmetric — neither direction is safer — so just keep the gap small.

The window is benign. `format-job-status-update` is called inside the `try` in `send-job-status-update`, and every arity funnels through it:

```clojure
(try
  (send-notification (format-job-status-update username email-address job-info message))
  (catch Exception e
    (log/warn e "unable to send job status update notification for" (:id job-info))))
```

So the error is caught and logged with the job id, and the status update itself proceeds — no 500, no redelivery, no retry storm. The only cost is that job-status notifications raised during the window are dropped rather than retried. Over a same-day release that's a handful of messages, each one logged.

An expand/contract split of #45 would close the window entirely (rename the enum with `ALTER TYPE ... RENAME`, add the table beside it, drop the old column in a third migration — verified working on PG 18.4). It was considered and set aside: a third migration and an extra ordered deploy step isn't worth it when the window is minutes and the failure is already caught.

## Verification

- `clj-kondo`: 0 errors, 0 warnings
- `lein test`: 81 tests, 217 assertions, 0 failures, 0 errors — though note the suite has **no** coverage of this function, so that's a regression check, not a proof
- korma renders the intended SQL (`sql-only`):
  ```sql
  SELECT "nt"."name" AS "notification_type" FROM "app_steps" AS "step"
    LEFT JOIN "tasks" AS "task" ON ("step"."task_id" = "task"."id")
    LEFT JOIN "tools" AS "tool" ON ("task"."tool_id" = "tool"."id")
    LEFT JOIN "tool_types" AS "tt" ON ("tool"."tool_type_id" = "tt"."id")
    LEFT JOIN "notification_types" AS "nt" ON ("tt"."notification_type_id" = "nt"."id")
   WHERE ("step"."app_version_id" = ?)
  ```
- Against a restore of QA's `de`, the old query shape on the unconverted database and the new shape on the converted one return **identical results across all 10,144 app versions**. No version yields more than one distinct type, so the `first` call in `get-notification-type` — arbitrary by its own comment — can't change answer under the added join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
