### PR TITLE
Move apps to JDK 25 and put only the jar on the classpath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM clojure:temurin-22-lein-jammy AS builder
+FROM clojure:temurin-25-lein-trixie AS builder
 
 WORKDIR /usr/src/app
 
@@ -18,7 +18,7 @@ RUN lein do clean, uberjar && \
     mv target/apps-standalone.jar .
 
 # Runtime stage
-FROM eclipse-temurin:22-jre-jammy
+FROM eclipse-temurin:25-jre-noble
 
 WORKDIR /usr/src/app
 
@@ -38,7 +38,9 @@ ENV OTEL_TRACES_EXPORTER=none
 COPY --from=builder /usr/src/app/apps-standalone.jar /usr/src/app/
 COPY conf/main/logback.xml /usr/src/app/
 
-ENTRYPOINT ["apps", "-Dlogback.configurationFile=/usr/src/app/logback.xml", "-cp", ".:apps-standalone.jar:/", "apps.core"]
+# Only the jar belongs on the classpath. logback is configured by absolute path above, and apps.core
+# takes its config from --config, so neither the working directory nor / ever supplied anything.
+ENTRYPOINT ["apps", "-Dlogback.configurationFile=/usr/src/app/logback.xml", "-cp", "apps-standalone.jar", "apps.core"]
 
 ARG git_commit=unknown
 ARG version=unknown


### PR DESCRIPTION
The runtime image was Temurin 22.0.2, built 2024-07-16. JDK 22 is a non-LTS release that was superseded in September 2024, so apps has been running a JDK that no longer receives security updates. This moves both stages to the JDK 25 images terrain already uses.

The entrypoint classpath was ".:apps-standalone.jar:/". Neither the working directory nor / ever supplied anything: apps loads no classpath resources, logback is configured by absolute path, and apps.core takes its config from --config, which the deployment passes explicitly and which defaults to an absolute path. The classpath-file fallback in apps.core could in principle read apps.properties off the classpath, but that file is in neither the uberjar nor the image working directory, so the fallback was already unreachable in the container.

Removing them is also what makes a JDK 25 AOT cache possible later: the cache dumper refuses a non-empty directory on the classpath, and rejects a runtime classpath that differs from the dumped one.

Verified: the full test suite passes on JDK 25 (81 tests, 217 assertions); the jar loads and apps.core --help works with a jar-only classpath; and the runtime stage builds and runs, with logback still resolving its config.