### PR TITLE
Update dependencies and gate on dependency conflicts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,27 +14,27 @@
             :url "https://cyverse.org/license"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "apps-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.12.4"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
                  [clj-http "3.13.1"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
                  [com.google.guava/guava "23.0"]
-                 [com.github.seancorfield/honeysql "2.7.1368"]
+                 [com.github.seancorfield/honeysql "2.7.1437"]
                  [dev.weavejester/medley "1.10.0"]
                  [metosin/compojure-api "1.1.14"]
-                 [org.cyverse/async-tasks-client "0.0.5"]
-                 [org.cyverse/authy "3.0.1"]
-                 [org.cyverse/clj-kondo-exports "0.1.0"]
-                 [org.cyverse/clojure-commons "3.0.12"]
-                 [org.cyverse/debug-utils "2.9.0"]
-                 [org.cyverse/kameleon "3.0.10"]
-                 [org.cyverse/mescal "4.1.0"]
-                 [org.cyverse/metadata-client "3.2.1"]
-                 [org.cyverse/common-cli "2.8.2"]
-                 [org.cyverse/common-cfg "2.8.3"]
-                 [org.cyverse/common-swagger-api "3.4.22"]
-                 [org.cyverse/cyverse-groups-client "0.1.9"]
-                 [org.cyverse/permissions-client "2.8.5"]
-                 [org.cyverse/service-logging "2.8.4"]
+                 [org.cyverse/async-tasks-client "0.0.6"]
+                 [org.cyverse/authy "3.0.2"]
+                 [org.cyverse/clj-kondo-exports "0.1.1"]
+                 [org.cyverse/clojure-commons "3.0.13"]
+                 [org.cyverse/debug-utils "2.9.1"]
+                 [org.cyverse/kameleon "3.0.11"]
+                 [org.cyverse/mescal "4.1.1"]
+                 [org.cyverse/metadata-client "3.2.2"]
+                 [org.cyverse/common-cli "2.8.3"]
+                 [org.cyverse/common-cfg "2.8.4"]
+                 [org.cyverse/common-swagger-api "3.4.23"]
+                 [org.cyverse/cyverse-groups-client "0.1.10"]
+                 [org.cyverse/permissions-client "2.8.6"]
+                 [org.cyverse/service-logging "2.8.6"]
                  [org.flatland/ordered "1.15.12"]
                  [io.github.clj-kondo/config-slingshot-slingshot "1.0.0"]
                  [me.raynes/fs "1.4.6"]
@@ -43,16 +43,30 @@
                  [ring/ring-jetty-adapter "1.12.2"]]
   :eastwood {:exclude-namespaces [apps.protocols :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
-  :plugins [[cider/cider-nrepl "0.59.0"]
-            [com.github.clj-kondo/lein-clj-kondo "2026.04.15"]
-            [jonase/eastwood "1.4.3"]
-            [lein-ancient "0.7.0"]
-            [dev.weavejester/lein-cljfmt "0.16.4"]
-            [refactor-nrepl/refactor-nrepl "3.11.0"]
+  :plugins [[jonase/eastwood "1.4.3"]
+            [lein-ancient "1.0.0"]
             [test2junit "1.4.4"]]
-  :profiles {:dev {:plugins        [[lein-ring "0.12.6"]]
-                   :resource-paths ["conf/test"]}
-             :repl {:source-paths ["repl"]}
+  ;; cider-nrepl and refactor-nrepl are editor tooling, not build tooling. In
+  ;; top-level :plugins they were on every invocation's classpath; they belong
+  ;; in :repl (or a personal ~/.lein/profiles.clj), which is where they now live.
+  ;;
+  ;; clj-kondo and cljfmt each sit in their own profile because their dependency
+  ;; trees are internally inconsistent -- clj-kondo pulls Clojure 1.11.4 while
+  ;; its sci dependency pulls 1.12.0, and cljfmt's tree disagrees with
+  ;; test2junit's. Both trip :pedantic? :abort on conflicts that live entirely
+  ;; inside third-party plugins and never reach the runtime classpath.
+  ;; Lint with `lein with-profile +kondo clj-kondo`, format with
+  ;; `lein with-profile +cljfmt cljfmt check`.
+  :profiles {:dev    {:plugins        [[lein-ring "0.12.6"]]
+                      :resource-paths ["conf/test"]}
+             :kondo  {:plugins [[com.github.clj-kondo/lein-clj-kondo "2026.08.04"]]
+                      :pedantic? :warn}
+             :cljfmt {:plugins [[dev.weavejester/lein-cljfmt "0.16.5"]]
+                      :pedantic? :warn}
+             :repl   {:source-paths ["repl"]
+                      :plugins [[cider/cider-nrepl "0.62.2"]
+                                [refactor-nrepl/refactor-nrepl "3.14.0"]]
+                      :pedantic? :warn}
              :uberjar {:aot :all}}
   :repl-options {:timeout 120000}
   :main ^:skip-aot apps.core

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,34 @@
             :url "https://cyverse.org/license"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "apps-standalone.jar"
+  ;; Fail the build on a new dependency conflict rather than printing a
+  ;; warning nobody reads.
+  :pedantic? :abort
+  ;; Records versions Leiningen already resolves, read off the resolved
+  ;; classpath rather than copied from lein's "Consider using these
+  ;; :managed-dependencies" hint -- that hint names the version that LOST the
+  ;; conflict, so pasting it would be a silent upgrade.
+  ;;
+  ;; The jackson-* group is pinned to the coherent 2.17.2 family that main
+  ;; resolves. It needs stating explicitly: compojure-api 1.1.14 is declared
+  ;; directly here and drags cheshire 5.9.0 -> jackson-core 2.9.9, which wins by
+  ;; nearest-wins over the newer jackson the org.cyverse libraries bring
+  ;; transitively. Left alone, that pairs jackson-core 2.9.9 with databind
+  ;; 2.18.3 -- an eight-minor spread that surfaces as a runtime
+  ;; NoSuchMethodError, not a resolution failure, and that :pedantic? cannot see
+  ;; because each artifact is individually unambiguous.
+  :managed-dependencies [[com.fasterxml.jackson.core/jackson-annotations "2.17.2"]
+                         [com.fasterxml.jackson.core/jackson-core "2.17.2"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.17.2"]
+                         [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.17.2"]
+                         [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.17.2"]
+                         [cheshire "5.9.0"]
+                         [com.google.code.findbugs/jsr305 "1.3.9"]
+                         [commons-codec "1.16.1"]
+                         [prismatic/schema "1.1.12"]
+                         [riddley "0.1.12"]
+                         [ring/ring-codec "1.1.0"]
+                         [tigris "0.1.1"]]
   :dependencies [[org.clojure/clojure "1.12.5"]
                  [clj-http "3.13.1"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]


### PR DESCRIPTION
Part of a fleet-wide pass over the DE Clojure repos to clear Leiningen's
"Possibly confusing dependencies" reports and bring dependencies current.
**20 warnings → 0.**

## Changes

- `build: normalize plugins and move editor tooling into profiles`
- `build: fail the build on confusing dependencies`

## The cider-nrepl leak is fixed at the source

Published `org.cyverse` poms used to declare `cider/cider-nrepl` at *compile*
scope, so a development REPL tool was landing on this service's runtime
classpath and inside its uberjar. Those libraries have since been re-released
with it removed, so bumping the pins was enough — **no exclusion workaround
needed**. Verified: 0 cider entries on the resolved classpath and 0 in the
built uberjar.

## The jackson pin is the important part of this PR

`apps` declares `metosin/compojure-api "1.1.14"` directly, and that drags
`cheshire 5.9.0 -> jackson-core 2.9.9`. By Maven's nearest-wins rule it beats
the much newer jackson the `org.cyverse` libraries bring transitively.

On `main` the family happens to resolve coherently at **2.17.2**. After the
dependency bumps it did not — it landed on `jackson-core 2.9.9` paired with
`databind 2.18.3`, an **eight-minor spread**. That surfaces as a runtime
`NoSuchMethodError`, not a resolution failure, and **`:pedantic?` cannot see it**
because each artifact is individually unambiguous. All 81 tests passed in that
state and the uberjar built fine, which is exactly why it is worth calling out.

The `:managed-dependencies` block pins the whole family back to `main`'s 2.17.2,
verified identical to `main` on the resolved classpath.

## Editor tooling moved out of top-level :plugins

`cider-nrepl` and `refactor-nrepl` were in shared top-level `:plugins`, putting
them on every invocation's classpath. They move to the `:repl` profile (and pick
up current versions). `clj-kondo` and `cljfmt` each get their own profile — both
have internally inconsistent trees that trip the gate on conflicts living
entirely inside third-party plugins.

Combined with the upstream releases, the uberjar no longer ships a development
REPL tool: **3 cider jars on the classpath -> 0, and 0 in the built jar**.

## Deliberately not changed

- `mvxcvi/clj-pgp` stays at **1.1.0** — the existing comment says 1.1.1 causes
  random decryption exceptions.
- `ring/ring-jetty-adapter` stays at **1.12.2**; 1.15.5 is a framework upgrade
  and belongs in its own PR.

## Extra verification

Largest test suite in the fleet, so the strongest signal available:

```
lein test     81 tests, 217 assertions, 0 failures
lein uberjar  builds; 0 cider entries
clj-kondo     clean
cljfmt        all source files formatted correctly
```

## Verification

```
confusing-dep warnings   20 -> 0
lein deps :tree          exit 0 (default, +dev,+test, +uberjar)
lein test                Ran 81 tests containing 217 assertions., 0 failures
lein uberjar             builds; 0 cider entries in the jar
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)